### PR TITLE
feat: Support suffix byte range

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -387,6 +387,42 @@ func TestBasicBucketOperationsIntegration(t *testing.T) {
 			assert.Equal(t, body[1:], objectBytes)
 		})
 
+		t.Run("it should allow downloading the object with suffix byte range"+pathStyleSuffix, func(t *testing.T) {
+			s3Client, cleanup := setupTestServer(usePathStyle)
+			t.Cleanup(cleanup)
+			createBucketResult, err := s3Client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
+				Bucket: bucketName,
+			})
+			if err != nil {
+				assert.Fail(t, "CreateBucket failed", "err %v", err)
+			}
+			assert.NotNil(t, createBucketResult)
+
+			putObjectResult, err := s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Body:   bytes.NewReader(body),
+				Key:    key,
+			})
+			if err != nil {
+				assert.Fail(t, "PutObject failed", "err %v", err)
+			}
+			assert.NotNil(t, putObjectResult)
+
+			getObjectResult, err := s3Client.GetObject(context.TODO(), &s3.GetObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Range:  aws.String("bytes=-6"),
+			})
+			if err != nil {
+				assert.Fail(t, "GetObject failed", "err %v", err)
+			}
+			assert.NotNil(t, getObjectResult)
+			assert.NotNil(t, getObjectResult.Body)
+			objectBytes, err := io.ReadAll(getObjectResult.Body)
+			assert.Nil(t, err)
+			assert.Equal(t, body[7:], objectBytes)
+		})
+
 		t.Run("it should allow downloading the object with multi byte range"+pathStyleSuffix, func(t *testing.T) {
 			s3Client, cleanup := setupTestServer(usePathStyle)
 			t.Cleanup(cleanup)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -297,12 +297,20 @@ func parseAndValidateRangeHeader(rangeHeader string, object *storage.Object) ([]
 				if err == nil {
 					end = &endByte
 				}
+
+				// Translate suffix range to int range
+				if start == nil && end != nil {
+					startByte = object.Size - *end
+					start = &startByte
+					endByte = object.Size - 1
+					end = &endByte
+				}
 			}
 
 			if start != nil && *start < 0 {
 				return nil, errInvalidByteRange
 			}
-			if end != nil && *end > object.Size {
+			if end != nil && *end >= object.Size {
 				return nil, errInvalidByteRange
 			}
 
@@ -341,6 +349,7 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		for _, byteRange := range byteRanges {
 			var end int64 = object.Size
 			if byteRange.end != nil {
+				// convert to exclusive end indexing
 				end = *byteRange.end + 1
 			}
 			if byteRange.start != nil {


### PR DESCRIPTION
This allows range request to specify how many bytes you want to read relative to the end of the object