### PR TITLE
feat: implement Post-Quantum Hybrid Encryption using ML-KEM-1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,24 @@ The following storage backends and middlewares are available:
   - Automated grounding every 1,000 entries using Merkle Trees for high-integrity checkpoints
 
 ###### Part Store Middleware
-- **TinkEncryptionPartStoreMiddleware**: Advanced encryption using Google Tink with support for AWS KMS, HashiCorp Vault, and local KMS. Features envelope encryption and key rotation capabilities
+- **TinkEncryptionPartStoreMiddleware**: Advanced encryption using Google Tink with support for AWS KMS, HashiCorp Vault, and local KMS. 
+  - Features envelope encryption and key rotation capabilities.
+  - Supports **Post-Quantum Hybrid Encryption** using **ML-KEM-1024** (FIPS 203). It enhances the envelope encryption by deriving the data encryption key from both a classical secret (protected by your chosen KMS) and a post-quantum shared secret via HKDF.
+
+  **Configuration Example (with PQ-Encryption):**
+  ```json
+  {
+    "type": "TinkEncryptionPartStoreMiddleware",
+    "kmsType": "local",
+    "password": "your-strong-password",
+    "pqSeed": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+    "innerPartStore": {
+      "type": "FilesystemPartStore",
+      "root": "./data/parts"
+    }
+  }
+  ```
+  *Note: `pqSeed` must be a 64-byte hex-encoded string. You can generate one using `openssl rand -hex 64`. Warning: If this seed is lost, encrypted data cannot be decrypted.*
 - **OutboxPartStore**: Implements outbox pattern for reliable part operations
 
 The default configuration (using SQLite) looks like this:

--- a/internal/storage/factory/factory.go
+++ b/internal/storage/factory/factory.go
@@ -77,7 +77,7 @@ func CreateStorage(storagePath string, db database.Database, useFilesystemPartSt
 			slog.Error("Encryption password is required for Tink encryption")
 			os.Exit(1)
 		}
-		partStore, err = tinkEncryptionPartStoreMiddleware.NewWithLocalKMS(partStoreEncryptionPassword, partStore)
+		partStore, err = tinkEncryptionPartStoreMiddleware.NewWithLocalKMS(partStoreEncryptionPassword, partStore, nil)
 		if err != nil {
 			slog.Error(fmt.Sprint("Error during NewTinkEncryptionPartStoreMiddleware: ", err))
 			os.Exit(1)

--- a/internal/storage/metadatapart/partstore/middlewares/encryption/tink/vault_test.go
+++ b/internal/storage/metadatapart/partstore/middlewares/encryption/tink/vault_test.go
@@ -81,7 +81,7 @@ func TestNewWithHCVault_AppRole(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 
 	// Test successful creation
-	mw, err := NewWithHCVault(ts.URL, "", "role-id", "secret-id", "transit/keys/my-key", innerStore, tlsConfig)
+	mw, err := NewWithHCVault(ts.URL, "", "role-id", "secret-id", "transit/keys/my-key", innerStore, tlsConfig, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, mw)
 
@@ -122,7 +122,7 @@ func TestNewWithHCVault_Token(t *testing.T) {
 	innerStore := &mockPartStore{}
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 
-	mw, err := NewWithHCVault(ts.URL, "my-token", "", "", "transit/keys/my-key", innerStore, tlsConfig)
+	mw, err := NewWithHCVault(ts.URL, "my-token", "", "", "transit/keys/my-key", innerStore, tlsConfig, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, mw)
 
@@ -137,11 +137,11 @@ func TestNewWithHCVault_InvalidArgs(t *testing.T) {
 	testutils.SkipIfIntegration(t)
 	innerStore := &mockPartStore{}
 	
-	_, err := NewWithHCVault("http://localhost:8200", "", "", "", "key", innerStore, nil)
+	_, err := NewWithHCVault("http://localhost:8200", "", "", "", "key", innerStore, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "must be provided")
 
-	_, err = NewWithHCVault("http://localhost:8200", "token", "role", "secret", "key", innerStore, nil)
+	_, err = NewWithHCVault("http://localhost:8200", "token", "role", "secret", "key", innerStore, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot use both")
 }
@@ -185,7 +185,7 @@ func TestTinkMiddleware_RefreshVaultToken(t *testing.T) {
 	innerStore := &mockPartStore{}
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 
-	mw, err := NewWithHCVault(ts.URL, "", "role", "secret", "transit/keys/my-key", innerStore, tlsConfig)
+	mw, err := NewWithHCVault(ts.URL, "", "role", "secret", "transit/keys/my-key", innerStore, tlsConfig, nil)
 	require.NoError(t, err)
 	
 	tinkMw, ok := mw.(*TinkEncryptionPartStoreMiddleware)


### PR DESCRIPTION
Enhance TinkEncryptionPartStoreMiddleware with Post-Quantum Hybrid Encryption support using ML-KEM-1024 (FIPS 203).

- Update PartHeader to version 3 to include PQEncapsulatedKey.
- Implement hybrid key derivation using HKDF to combine classical DEK and ML-KEM shared secret.
- Add PQSeed configuration option to enable PQ-safe encryption.
- Update KMS provider initializers (AWS, Vault, Local, TPM) to support ML-KEM.
- Add unit tests for ML-KEM hybrid encryption and JSON configuration.
- Update documentation in README.md.