### PR TITLE
fix(auditlog): add O_APPEND flag for append-only file support

### DIFF
--- a/internal/auditlog/sink/writer.go
+++ b/internal/auditlog/sink/writer.go
@@ -37,7 +37,7 @@ func (s *WriterSink) InitialState() (*InitialState, error) {
 }
 
 func NewFileSink(path string, serializer serialization.Serializer) (*WriterSink, error) {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change adds the os.O_APPEND flag when opening the audit log file. This is required to support files with append-only attributes (chattr +a on Linux, chflags uappnd on macOS), preventing 'permission denied' errors during startup.