### PR TITLE
feat(tpm): add optional password protection for TPM keys

### DIFF
--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -108,6 +108,7 @@ Pithos supports multiple storage backends that can be configured in the storage 
   "tpmKeyAlgorithm": "ecc-p384",
   "tpmSymmetricAlgorithm": "aes-256",
   "tpmHMACAlgorithm": "sha256",
+  "tpmPassword": "",
   "innerPartStore": {
     "type": "FilesystemPartStore",
     "root": "./data/parts"
@@ -115,7 +116,7 @@ Pithos supports multiple storage backends that can be configured in the storage 
 }
 ```
 
-> **Note:** `tpmKeyAlgorithm` supports `rsa-2048`, `rsa-4096`, `ecc-p256` (default), `ecc-p384`, `ecc-p521`, and Brainpool curves (`ecc-brainpool-p256`, `p384`, `p512`). `tpmSymmetricAlgorithm` can be `aes-128` or `aes-256` (default).
+> **Note:** `tpmKeyAlgorithm` supports `rsa-2048`, `rsa-4096`, `ecc-p256` (default), `ecc-p384`, `ecc-p521`, and Brainpool curves (`ecc-brainpool-p256`, `p384`, `p512`). `tpmSymmetricAlgorithm` can be `aes-128` or `aes-256` (default). `tpmPassword` is optional; when set, it provides password-based authorization for TPM key access.
 
 ### Post-Quantum Encryption
 

--- a/internal/storage/metadatapart/partstore/config/config.go
+++ b/internal/storage/metadatapart/partstore/config/config.go
@@ -65,6 +65,8 @@ type TinkEncryptionPartStoreMiddlewareConfiguration struct {
 	TPMSymmetricAlgorithm internalConfig.StringProvider `json:"tpmSymmetricAlgorithm,omitempty"`
 	// HMAC algorithm ("sha256", "sha384", "sha512"). Default is "sha256".
 	TPMHMACAlgorithm internalConfig.StringProvider `json:"tpmHMACAlgorithm,omitempty"`
+	// TPM Password for key authorization (optional, empty string for no password)
+	TPMPassword internalConfig.StringProvider `json:"tpmPassword,omitempty"`
 	// PQ-safe specific
 	// PQSeed is the 64-byte hex-encoded seed for ML-KEM-1024.
 	// WARNING: This seed is used to derive the private key. If this seed is lost or changed,
@@ -218,7 +220,10 @@ func (t *TinkEncryptionPartStoreMiddlewareConfiguration) Instantiate(diProvider 
 			return nil, fmt.Errorf("invalid tpmSymmetricAlgorithm: %s", symmetricAlgorithm)
 		}
 
-		return tink.NewWithTPM(tpmPath, persistentHandle, keyFilePath, keyAlgorithm, symmetricAlgorithm, hmacAlgorithm, innerPartStore, mlkemKey)
+		// Get TPM password (optional, defaults to empty string for backwards compatibility)
+		tpmPassword := t.TPMPassword.Value()
+
+		return tink.NewWithTPM(tpmPath, persistentHandle, keyFilePath, keyAlgorithm, symmetricAlgorithm, hmacAlgorithm, tpmPassword, innerPartStore, mlkemKey)
 	default:
 		return nil, fmt.Errorf("unsupported KMS type: %s", kmsType)
 	}

--- a/internal/storage/metadatapart/partstore/middlewares/encryption/tink/tink.go
+++ b/internal/storage/metadatapart/partstore/middlewares/encryption/tink/tink.go
@@ -349,9 +349,10 @@ func NewWithAWSKMS(keyURI, region string, innerPartStore partstore.PartStore, ml
 // keyAlgorithm: the primary key algorithm, defaults to ECC P-256 if empty
 // symmetricAlgorithm: the symmetric key algorithm (e.g. "aes-128", "aes-256")
 // hmacAlgorithm: the HMAC algorithm ("sha256", "sha384", "sha512"), defaults to "sha256"
-func NewWithTPM(tpmPath string, persistentHandle uint32, keyFilePath string, keyAlgorithm string, symmetricAlgorithm string, hmacAlgorithm string, innerPartStore partstore.PartStore, mlkemKey *mlkem.DecapsulationKey1024) (partstore.PartStore, error) {
+// password: optional password for key authorization (empty string for no password)
+func NewWithTPM(tpmPath string, persistentHandle uint32, keyFilePath string, keyAlgorithm string, symmetricAlgorithm string, hmacAlgorithm string, password string, innerPartStore partstore.PartStore, mlkemKey *mlkem.DecapsulationKey1024) (partstore.PartStore, error) {
 	// Create TPM AEAD
-	tpmAEAD, err := tpm.NewAEAD(tpmPath, persistentHandle, keyFilePath, keyAlgorithm, symmetricAlgorithm, hmacAlgorithm)
+	tpmAEAD, err := tpm.NewAEAD(tpmPath, persistentHandle, keyFilePath, keyAlgorithm, symmetricAlgorithm, hmacAlgorithm, password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add support for password-based authorization when accessing TPM keys. This provides an additional layer of security for TPM-encrypted data.

Changes:
- Add password parameter to tpm.NewAEAD() and use it for key creation
- Update createAESKey/createHMACKey to set UserAuth with password
- Update Encrypt/Decrypt/computeHMAC to use password for TPM auth
- Add password parameter to tink.NewWithTPM()
- Add tpmPassword config option (optional, defaults to empty)
- Update docs with new configuration option

The feature is backwards compatible: omitting tpmPassword or setting it to empty string preserves existing behavior.