### PR TITLE
feat(config): add stdin support to StringProvider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0
 	golang.org/x/crypto v0.46.0
+	golang.org/x/term v0.38.0
 )
 
 require (


### PR DESCRIPTION
Add ability to read StringProvider values from stdin with:
- Custom prompt text
- Optional hidden input for passwords (using golang.org/x/term)