### PR TITLE
feat(storage): support atomic PutObject If-None-Match create-if-absent

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -973,6 +973,147 @@ func TestPutObject(t *testing.T) {
 			assert.NotNil(t, putObjectResult)
 		})
 
+		t.Run("it should allow uploads with if-none-match when object is absent"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			createBucketResult, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+				Bucket: bucketName,
+			})
+			if err != nil {
+				assert.Fail(t, "CreateBucket failed", "err %v", err)
+			}
+			assert.NotNil(t, createBucketResult)
+
+			putObjectResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket:      bucketName,
+				Body:        bytes.NewReader([]byte("Hello, first object!")),
+				Key:         key,
+				IfNoneMatch: aws.String("*"),
+			})
+			if err != nil {
+				assert.Fail(t, "PutObject failed", "err %v", err)
+			}
+			assert.NotNil(t, putObjectResult)
+		})
+
+		t.Run("it should reject uploads with if-none-match when object already exists"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			createBucketResult, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+				Bucket: bucketName,
+			})
+			if err != nil {
+				assert.Fail(t, "CreateBucket failed", "err %v", err)
+			}
+			assert.NotNil(t, createBucketResult)
+
+			putObjectResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Body:   bytes.NewReader(body),
+				Key:    key,
+			})
+			if err != nil {
+				assert.Fail(t, "PutObject failed", "err %v", err)
+			}
+			assert.NotNil(t, putObjectResult)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket:      bucketName,
+				Body:        bytes.NewReader([]byte("Hello, first object!")),
+				Key:         key,
+				IfNoneMatch: aws.String("*"),
+			})
+
+			if err == nil {
+				assert.Fail(t, "PutObject should fail when If-None-Match is set and object exists")
+			}
+
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "PreconditionFailed" {
+				assert.Fail(t, "Expected aws error PreconditionFailed", "err %v", err)
+			}
+		})
+
+		t.Run("it should reject non-star if-none-match values"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			createBucketResult, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+				Bucket: bucketName,
+			})
+			if err != nil {
+				assert.Fail(t, "CreateBucket failed", "err %v", err)
+			}
+			assert.NotNil(t, createBucketResult)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket:      bucketName,
+				Body:        bytes.NewReader(body),
+				Key:         key,
+				IfNoneMatch: aws.String("\"invalid-etag\""),
+			})
+
+			if err == nil {
+				assert.Fail(t, "PutObject should fail when If-None-Match is not '*'")
+			}
+
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidRequest" {
+				assert.Fail(t, "Expected aws error InvalidRequest", "err %v", err)
+			}
+		})
+
+		t.Run("it should allow at most one concurrent create-if-absent upload"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			createBucketResult, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+				Bucket: bucketName,
+			})
+			if err != nil {
+				assert.Fail(t, "CreateBucket failed", "err %v", err)
+			}
+			assert.NotNil(t, createBucketResult)
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			results := make([]*s3.PutObjectOutput, 2)
+			errs := make([]error, 2)
+
+			for i := range 2 {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					<-start
+					results[i], errs[i] = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+						Bucket:      bucketName,
+						Body:        bytes.NewReader(body),
+						Key:         key,
+						IfNoneMatch: aws.String("*"),
+					})
+				}(i)
+			}
+
+			close(start)
+			wg.Wait()
+
+			successCount := 0
+			for i := range 2 {
+				if errs[i] == nil {
+					successCount++
+					assert.NotNil(t, results[i])
+					continue
+				}
+
+				var apiErr smithy.APIError
+				if !errors.As(errs[i], &apiErr) {
+					assert.Fail(t, "Expected smithy.APIError", "err %v", errs[i])
+					continue
+				}
+				assert.Equal(t, "PreconditionFailed", apiErr.ErrorCode())
+			}
+
+			assert.LessOrEqual(t, successCount, 1, "at most one concurrent create-if-absent upload may succeed")
+		})
+
 		t.Run("it should hit the upload limit when uploading an object that is too large"+testSuffix, func(t *testing.T) {
 			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
 			t.Cleanup(cleanup)

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -149,6 +149,7 @@ const expectHeader = "Expect"
 const contentRangeHeader = "Content-Range"
 const contentLengthHeader = "Content-Length"
 const rangeHeader = "Range"
+const ifNoneMatchHeader = "If-None-Match"
 const etagHeader = "ETag"
 const lastModifiedHeader = "Last-Modified"
 const contentTypeHeader = "Content-Type"
@@ -363,6 +364,7 @@ type bucketPolicyStatement struct {
 }
 
 var ErrMalformedPolicy = fmt.Errorf("MalformedPolicy")
+var ErrInvalidRequest = fmt.Errorf("InvalidRequest")
 
 // validateBucketPolicy validates that the policy matches the public-read pattern only.
 // The only supported policy is:
@@ -553,8 +555,12 @@ func handleError(err error, w http.ResponseWriter, r *http.Request) {
 		statusCode = 404
 	case ErrMalformedPolicy:
 		statusCode = 400
+	case ErrInvalidRequest:
+		statusCode = 400
 	case storage.ErrEntityTooLarge:
 		statusCode = 413
+	case storage.ErrPreconditionFailed:
+		statusCode = 412
 	default:
 		slog.Error(fmt.Sprintf("Unhandled internal error: %v", err))
 		statusCode = 500
@@ -1607,6 +1613,15 @@ func (s *Server) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	contentType := getHeaderAsPtr(r.Header, contentTypeHeader)
+	ifNoneMatch := getHeaderAsPtr(r.Header, ifNoneMatchHeader)
+	var putObjectOptions *storage.PutObjectOptions
+	if ifNoneMatch != nil {
+		if *ifNoneMatch != "*" {
+			handleError(ErrInvalidRequest, w, r)
+			return
+		}
+		putObjectOptions = &storage.PutObjectOptions{IfNoneMatchStar: true}
+	}
 
 	shouldReturn = validateMaxEntitySize(r, w)
 	if shouldReturn {
@@ -1623,7 +1638,7 @@ func (s *Server) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get(expectHeader) == "100-continue" {
 		w.WriteHeader(100)
 	}
-	putObjectResult, err := s.storage.PutObject(ctx, bucketName, key, contentType, r.Body, checksumInput)
+	putObjectResult, err := s.storage.PutObject(ctx, bucketName, key, contentType, r.Body, checksumInput, putObjectOptions)
 	if err != nil {
 		if _, ok := err.(*http.MaxBytesError); ok {
 			err = storage.ErrEntityTooLarge

--- a/internal/storage/benchmark/benchmark.go
+++ b/internal/storage/benchmark/benchmark.go
@@ -120,7 +120,7 @@ func benchmarkUploadSpeedForSize(ctx context.Context, st storage.Storage, bucket
 		}
 		reader := ioutils.NewByteReadSeekCloser(testData)
 
-		_, err = st.PutObject(ctx, bucketName, key, nil, reader, nil)
+		_, err = st.PutObject(ctx, bucketName, key, nil, reader, nil, nil)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -193,7 +193,7 @@ func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.Bucket
 	return object, readers, nil
 }
 
-func (cs *CacheStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (cs *CacheStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.PutObject")
 	defer span.End()
 
@@ -203,7 +203,7 @@ func (cs *CacheStorage) PutObject(ctx context.Context, bucketName storage.Bucket
 	}
 	byteReadSeekCloser := ioutils.NewByteReadSeekCloser(data)
 
-	putObjectResult, err := cs.innerStorage.PutObject(ctx, bucketName, key, contentType, byteReadSeekCloser, checksumInput)
+	putObjectResult, err := cs.innerStorage.PutObject(ctx, bucketName, key, contentType, byteReadSeekCloser, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/database/pgx/repository/object/pgx.go
+++ b/internal/storage/database/pgx/repository/object/pgx.go
@@ -16,6 +16,7 @@ type pgxRepository struct {
 
 const (
 	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"
+	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) ON CONFLICT DO NOTHING"
 	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, updated_at = $14 WHERE id = $15"
 	containsBucketObjectsByBucketNameStmt                                                        = "SELECT id FROM objects WHERE bucket_name = $1"
 	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
@@ -89,6 +90,32 @@ func (or *pgxRepository) SaveObject(ctx context.Context, tx *sql.Tx, object *obj
 	object.UpdatedAt = time.Now().UTC()
 	_, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
 	return err
+}
+
+func (or *pgxRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, object *object.Entity) (*bool, error) {
+	mapUploadIdToString := func(uploadId storage.UploadId) string {
+		return uploadId.String()
+	}
+	if object.Id == nil {
+		id := ulid.Make()
+		object.Id = &id
+	}
+	if object.CreatedAt.IsZero() {
+		object.CreatedAt = time.Now().UTC()
+	}
+	object.UpdatedAt = object.CreatedAt
+
+	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.CreatedAt, object.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	inserted := rowsAffected > 0
+	return &inserted, nil
 }
 
 func (or *pgxRepository) ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error) {

--- a/internal/storage/database/repository/object/interface.go
+++ b/internal/storage/database/repository/object/interface.go
@@ -11,6 +11,7 @@ import (
 
 type Repository interface {
 	SaveObject(ctx context.Context, tx *sql.Tx, object *Entity) error
+	InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, object *Entity) (*bool, error)
 	ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error)
 	FindObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAsc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) ([]Entity, error)
 	FindUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAsc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, uploadIdMarker string) ([]Entity, error)

--- a/internal/storage/database/sqlite/repository/object/sqlite.go
+++ b/internal/storage/database/sqlite/repository/object/sqlite.go
@@ -16,6 +16,7 @@ type sqliteRepository struct {
 
 const (
 	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"
+	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) ON CONFLICT DO NOTHING"
 	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, updated_at = $14 WHERE id = $15"
 	containsBucketObjectsByBucketNameStmt                                                        = "SELECT id FROM objects WHERE bucket_name = $1"
 	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
@@ -89,6 +90,32 @@ func (or *sqliteRepository) SaveObject(ctx context.Context, tx *sql.Tx, object *
 	object.UpdatedAt = time.Now().UTC()
 	_, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
 	return err
+}
+
+func (or *sqliteRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, object *object.Entity) (*bool, error) {
+	mapUploadIdToString := func(uploadId storage.UploadId) string {
+		return uploadId.String()
+	}
+	if object.Id == nil {
+		id := ulid.Make()
+		object.Id = &id
+	}
+	if object.CreatedAt.IsZero() {
+		object.CreatedAt = time.Now().UTC()
+	}
+	object.UpdatedAt = object.CreatedAt
+
+	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.CreatedAt, object.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	inserted := rowsAffected > 0
+	return &inserted, nil
 }
 
 func (or *sqliteRepository) ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error) {

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -559,7 +559,7 @@ func (mbs *metadataPartStorage) GetObject(ctx context.Context, bucketName storag
 	return &storageObject, readers, nil
 }
 
-func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.PutObject")
 	defer span.End()
 
@@ -569,20 +569,23 @@ func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storag
 	if err != nil {
 		return nil, err
 	}
+	ifNoneMatchStar := opts != nil && opts.IfNoneMatchStar
 
-	// if we already have such an object,
-	// remove all previous parts
-	previousObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
-	if err != nil && err != storage.ErrNoSuchKey {
-		tx.Rollback()
-		return nil, err
-	}
-	if previousObject != nil {
-		for _, part := range previousObject.Parts {
-			err = mbs.partStore.DeletePart(ctx, tx, part.Id)
-			if err != nil {
-				tx.Rollback()
-				return nil, err
+	if !ifNoneMatchStar {
+		// if we already have such an object,
+		// remove all previous parts
+		previousObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+		if err != nil && err != storage.ErrNoSuchKey {
+			tx.Rollback()
+			return nil, err
+		}
+		if previousObject != nil {
+			for _, part := range previousObject.Parts {
+				err = mbs.partStore.DeletePart(ctx, tx, part.Id)
+				if err != nil {
+					tx.Rollback()
+					return nil, err
+				}
 			}
 		}
 	}
@@ -633,7 +636,7 @@ func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storag
 		},
 	}
 
-	err = mbs.metadataStore.PutObject(ctx, tx, bucketName, &object)
+	err = mbs.metadataStore.PutObject(ctx, tx, bucketName, &object, &metadatastore.PutObjectOptions{IfNoneMatchStar: ifNoneMatchStar})
 	if err != nil {
 		tx.Rollback()
 		return nil, err

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -175,6 +175,7 @@ var ErrBadDigest error = errors.New("BadDigest")
 var ErrUploadWithInvalidSequenceNumber error = errors.New("UploadWithInvalidSequenceNumber")
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrEntityTooLarge error = errors.New("EntityTooLarge")
+var ErrPreconditionFailed error = errors.New("PreconditionFailed")
 var ErrNoSuchWebsiteConfiguration error = errors.New("NoSuchWebsiteConfiguration")
 var ErrNoSuchBucketPolicy error = errors.New("NoSuchBucketPolicy")
 
@@ -197,6 +198,10 @@ type ListMultipartUploadsOptions struct {
 type ListPartsOptions struct {
 	PartNumberMarker *string
 	MaxParts         int32
+}
+
+type PutObjectOptions struct {
+	IfNoneMatchStar bool
 }
 
 type MaintenanceStore interface {
@@ -230,7 +235,7 @@ type BucketPolicyStore interface {
 type ObjectStore interface {
 	ListObjects(ctx context.Context, tx *sql.Tx, bucketName BucketName, opts ListObjectsOptions) (*ListBucketResult, error)
 	HeadObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey) (*Object, error)
-	PutObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object) error
+	PutObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object, opts *PutObjectOptions) error
 	DeleteObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey) error
 }
 
@@ -319,7 +324,7 @@ func Tester(metadataStore MetadataStore, db database.Database) error {
 		ETag:         "",
 		Size:         0,
 		Parts:        []Part{},
-	})
+	}, nil)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -414,7 +414,7 @@ func (sms *sqlMetadataStore) HeadObject(ctx context.Context, tx *sql.Tx, bucketN
 	}, nil
 }
 
-func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, obj *metadatastore.Object) error {
+func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, obj *metadatastore.Object, opts *metadatastore.PutObjectOptions) error {
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.PutObject")
 	defer span.End()
 
@@ -426,21 +426,6 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		return metadatastore.ErrNoSuchBucket
 	}
 
-	oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
-	if err != nil {
-		return err
-	}
-	if oldObjectEntity != nil {
-		// object already exists
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
-		if err != nil {
-			return err
-		}
-		err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
-		if err != nil {
-			return err
-		}
-	}
 	objectEntity := object.Entity{
 		BucketName:        bucketName,
 		Key:               obj.Key,
@@ -455,11 +440,38 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		Size:              obj.Size,
 		UploadStatus:      object.UploadStatusCompleted,
 	}
-	err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
-	objectId := objectEntity.Id
-	if err != nil {
-		return err
+	if opts != nil && opts.IfNoneMatchStar {
+		inserted, err := sms.objectRepository.InsertObjectIfAbsent(ctx, tx, &objectEntity)
+		if err != nil {
+			return err
+		}
+		if !*inserted {
+			return metadatastore.ErrPreconditionFailed
+		}
+	} else {
+		oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
+		if err != nil {
+			return err
+		}
+		if oldObjectEntity != nil {
+			// object already exists
+			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
+			if err != nil {
+				return err
+			}
+			err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
+		if err != nil {
+			return err
+		}
 	}
+
+	objectId := objectEntity.Id
 	sequenceNumber := 0
 	for _, partStruc := range obj.Parts {
 		partEntity := part.Entity{

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -236,9 +236,9 @@ func (m *AuditLogMiddleware) GetObject(ctx context.Context, bucketName storage.B
 	return obj, readers, err
 }
 
-func (m *AuditLogMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (m *AuditLogMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
-	res, err := m.next.PutObject(ctx, bucketName, key, contentType, data, checksumInput)
+	res, err := m.next.PutObject(ctx, bucketName, key, contentType, data, checksumInput, opts)
 	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
 	return res, err
 }

--- a/internal/storage/middlewares/audit/audit_test.go
+++ b/internal/storage/middlewares/audit/audit_test.go
@@ -27,7 +27,7 @@ func (m *mockStorage) CreateBucket(ctx context.Context, bucketName storage.Bucke
 	return nil
 }
 
-func (m *mockStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (m *mockStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	return &storage.PutObjectResult{}, nil
 }
 

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -147,12 +147,12 @@ func (csm *conditionalStorageMiddleware) GetObject(ctx context.Context, bucketNa
 	return storage.GetObject(ctx, bucketName, key, ranges)
 }
 
-func (csm *conditionalStorageMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (csm *conditionalStorageMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.PutObject")
 	defer span.End()
 
 	storage := csm.lookupStorage(bucketName)
-	return storage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput)
+	return storage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
 }
 
 func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -397,7 +397,7 @@ func (psm *prometheusStorageMiddleware) GetObject(ctx context.Context, bucketNam
 	return object, readers, nil
 }
 
-func (psm *prometheusStorageMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (psm *prometheusStorageMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.PutObject")
 	defer span.End()
 
@@ -405,7 +405,7 @@ func (psm *prometheusStorageMiddleware) PutObject(ctx context.Context, bucketNam
 		psm.totalBytesUploadedByBucket.With(prometheus.Labels{"bucket": bucketName.String()}).Add(float64(n))
 	})
 
-	putObjectResult, err := psm.innerStorage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput)
+	putObjectResult, err := psm.innerStorage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "PutObject"}).Inc()
 		return nil, err

--- a/internal/storage/migrator/migrator.go
+++ b/internal/storage/migrator/migrator.go
@@ -217,7 +217,7 @@ func (a *StorageToS3UploadAPIClientAdapter) AbortMultipartUpload(ctx context.Con
 }
 
 func (a *StorageToS3UploadAPIClientAdapter) PutObject(ctx context.Context, input *s3.PutObjectInput, opts ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
-	result, err := a.storage.PutObject(ctx, storage.MustNewBucketName(*input.Bucket), storage.MustNewObjectKey(*input.Key), input.ContentType, input.Body, nil)
+	result, err := a.storage.PutObject(ctx, storage.MustNewBucketName(*input.Bucket), storage.MustNewObjectKey(*input.Key), input.ContentType, input.Body, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/migrator/migrator_test.go
+++ b/internal/storage/migrator/migrator_test.go
@@ -99,7 +99,7 @@ func TestStorageMigrator(t *testing.T) {
 	assert.Nil(t, err)
 
 	// @TODO: Use checksumInput
-	_, err = storage.PutObject(ctx, bucketName, objectKey, nil, bytes.NewReader(objectData), nil)
+	_, err = storage.PutObject(ctx, bucketName, objectKey, nil, bytes.NewReader(objectData), nil, nil)
 	assert.Nil(t, err)
 
 	storagePath2 := *tempDir2

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -97,7 +97,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			for i, chunk := range chunks {
 				readers[i] = bytes.NewReader(chunk.Content)
 			}
-			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(readers...), nil)
+			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(readers...), nil, nil)
 			if err != nil {
 				tx.Rollback()
 				time.Sleep(5 * time.Second)
@@ -388,9 +388,17 @@ func (os *outboxStorage) GetObject(ctx context.Context, bucketName storage.Bucke
 
 const chunkSize = 256 * 1000 * 1000 // 256MB
 
-func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.PutObject")
 	defer span.End()
+
+	if opts != nil && opts.IfNoneMatchStar {
+		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+		if err != nil {
+			return nil, err
+		}
+		return os.innerStorage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
+	}
 
 	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
 	if err != nil {

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -145,7 +145,7 @@ func (rs *replicationStorage) GetObject(ctx context.Context, bucketName storage.
 	return rs.primaryStorage.GetObject(ctx, bucketName, key, ranges)
 }
 
-func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.PutObject")
 	defer span.End()
 
@@ -156,7 +156,7 @@ func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.
 	}
 	defer readSeekCloser.Close()
 
-	putObjectResult, err := rs.primaryStorage.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput)
+	putObjectResult, err := rs.primaryStorage.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.
 		if err != nil {
 			return nil, err
 		}
-		_, err = secondaryStorage.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput)
+		_, err = secondaryStorage.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -247,7 +247,7 @@ func (rs *s3ClientStorage) GetObject(ctx context.Context, bucketName storage.Buc
 	return object, readers, nil
 }
 
-func (rs *s3ClientStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.PutObjectResult, error) {
+func (rs *s3ClientStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.PutObject")
 	defer span.End()
 
@@ -256,6 +256,12 @@ func (rs *s3ClientStorage) PutObject(ctx context.Context, bucketName storage.Buc
 		Key:         aws.String(key.String()),
 		ContentType: contentType,
 		Body:        reader,
+		IfNoneMatch: func() *string {
+			if opts != nil && opts.IfNoneMatchStar {
+				return aws.String("*")
+			}
+			return nil
+		}(),
 		// @TODO: Use checksumInput
 	})
 	var notFoundError *types.NotFound
@@ -263,6 +269,10 @@ func (rs *s3ClientStorage) PutObject(ctx context.Context, bucketName storage.Buc
 		return nil, storage.ErrNoSuchBucket
 	}
 	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "PreconditionFailed" {
+			return nil, storage.ErrPreconditionFailed
+		}
 		return nil, err
 	}
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -60,6 +60,10 @@ type PutObjectResult struct {
 	ChecksumSHA256    *string
 }
 
+type PutObjectOptions struct {
+	IfNoneMatchStar bool
+}
+
 type InitiateMultipartUploadResult struct {
 	UploadId UploadId
 }
@@ -151,6 +155,7 @@ var ErrNoSuchKey error = metadatastore.ErrNoSuchKey
 var ErrBadDigest error = metadatastore.ErrBadDigest
 var ErrNotImplemented error = metadatastore.ErrNotImplemented
 var ErrEntityTooLarge error = metadatastore.ErrEntityTooLarge
+var ErrPreconditionFailed error = metadatastore.ErrPreconditionFailed
 var ErrInvalidBucketName error = metadatastore.ErrInvalidBucketName
 var ErrInvalidObjectKey error = metadatastore.ErrInvalidObjectKey
 var ErrInvalidUploadId error = metadatastore.ErrInvalidUploadId
@@ -225,7 +230,7 @@ type ObjectManager interface {
 	// All operations are performed in a single transaction to ensure consistency.
 	// Returns the object metadata, a list of readers (one per range), and an error.
 	GetObject(ctx context.Context, bucketName BucketName, key ObjectKey, ranges []ByteRange) (*Object, []io.ReadCloser, error)
-	PutObject(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, data io.Reader, checksumInput *ChecksumInput) (*PutObjectResult, error)
+	PutObject(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, data io.Reader, checksumInput *ChecksumInput, opts *PutObjectOptions) (*PutObjectResult, error)
 	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey) error
 }
 
@@ -308,7 +313,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return errors.New("invalid bucketName")
 		}
 
-		_, err = storage.PutObject(ctx, bucketName, key, nil, data, nil)
+		_, err = storage.PutObject(ctx, bucketName, key, nil, data, nil, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add explicit PutObject options and propagate If-None-Match semantics through storage layers so create-if-absent checks are enforced atomically at write time. Cover absent/existing/non-star and concurrent write behavior with integration tests, and map invalid and precondition errors to S3-compatible responses.

closes #643