### PR TITLE
fix: clamp range end to object size instead of returning 416

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -2299,6 +2299,45 @@ func TestGetObject(t *testing.T) {
 			assert.Equal(t, body[7:], objectBytes)
 		})
 
+		t.Run("it should return 206 and clamp range end when it exceeds object size"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			createBucketResult, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+				Bucket: bucketName,
+			})
+			if err != nil {
+				assert.Fail(t, "CreateBucket failed", "err %v", err)
+			}
+			assert.NotNil(t, createBucketResult)
+
+			putObjectResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Body:   bytes.NewReader(body),
+				Key:    key,
+			})
+			if err != nil {
+				assert.Fail(t, "PutObject failed", "err %v", err)
+			}
+			assert.NotNil(t, putObjectResult)
+
+			// Request a range whose end far exceeds the object size.
+			// Per RFC 7233 §2.1 the server must return 206 with the available bytes,
+			// not 416 Range Not Satisfiable.
+			getObjectResult, err := s3Client.GetObject(context.Background(), &s3.GetObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Range:  aws.String("bytes=0-5242879"),
+			})
+			if err != nil {
+				assert.Fail(t, "GetObject failed", "err %v", err)
+			}
+			assert.NotNil(t, getObjectResult)
+			assert.NotNil(t, getObjectResult.Body)
+			objectBytes, err := io.ReadAll(getObjectResult.Body)
+			assert.Nil(t, err)
+			assert.Equal(t, body, objectBytes)
+		})
+
 		t.Run("it should allow downloading the object with multi byte range"+testSuffix, func(t *testing.T) {
 			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
 			t.Cleanup(cleanup)

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -1082,8 +1082,9 @@ func generateContentRangeValue(br storage.ByteRange, objectSize int64) string {
 
 	end := objectSize - 1
 	if br.Start != nil && br.End != nil {
-		// Normal range with explicit end (exclusive, so subtract 1 for inclusive)
-		end = *br.End - 1
+		// Normal range with explicit end (exclusive, so subtract 1 for inclusive).
+		// Clamp to objectSize to match the storage layer's normalizeAndValidateRanges behavior.
+		end = min(*br.End, objectSize) - 1
 	} else if br.Start == nil && br.End != nil {
 		// Suffix range
 		end = objectSize - 1
@@ -1294,9 +1295,10 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 				size = min(suffixLength, object.Size)
 			} else if byteRange.Start != nil {
 				// Normal range (End is exclusive)
+				// Clamp end to object size to match what normalizeAndValidateRanges does in the storage layer.
 				var end int64 = object.Size
 				if byteRange.End != nil {
-					end = *byteRange.End
+					end = min(*byteRange.End, object.Size)
 				}
 				size = end - *byteRange.Start
 			}

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -437,8 +437,10 @@ func normalizeAndValidateRanges(ranges []storage.ByteRange, objectSize int64) ([
 		if byteRange.Start != nil && *byteRange.Start < 0 {
 			return nil, storage.ErrInvalidRange
 		}
+		// Per RFC 7233: if the range end exceeds the object size, clamp it to the object size.
 		if byteRange.End != nil && *byteRange.End > objectSize {
-			return nil, storage.ErrInvalidRange
+			clamped := objectSize
+			byteRange.End = &clamped
 		}
 		if byteRange.Start != nil && byteRange.End != nil && *byteRange.Start >= *byteRange.End {
 			return nil, storage.ErrInvalidRange


### PR DESCRIPTION
Per RFC 7233 §2.1, when a range end exceeds the content length the server
must return the available bytes (206), not a 416 Range Not Satisfiable error.
Replace the rejection with a clamp to objectSize so requests like
Range: bytes=0-5242879 on a small file are served correctly.