### PR TITLE
feat(storage): implement DeleteObjects S3 API (POST /{bucket}?delete)

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -3994,3 +3994,201 @@ func TestWebsiteHosting(t *testing.T) {
 		})
 	})
 }
+
+func TestDeleteObjects(t *testing.T) {
+	testutils.SkipIfNotIntegration(t)
+
+	t.Parallel()
+
+	runIntegrationTest(t, func(t *testing.T, testSuffix string, dbType database.DatabaseType, usePathStyle bool, useReplication bool, useFilesystemPartStore bool, encryptionType storageFactory.EncryptionType, wrapPartStoreWithOutbox bool) {
+		t.Run("it should delete multiple existing objects"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key2, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key},
+						{Key: key2},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 2)
+			assert.Len(t, result.Errors, 0)
+
+			// Objects must no longer exist
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.NotNil(t, err)
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key2})
+			assert.NotNil(t, err)
+		})
+
+		t.Run("it should treat a missing key as successfully deleted"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			nonExistentKey := aws.String("does/not/exist.txt")
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: nonExistentKey},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 1)
+			assert.Len(t, result.Errors, 0)
+		})
+
+		t.Run("it should suppress deleted entries in quiet mode"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			quiet := true
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key},
+					},
+					Quiet: &quiet,
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 0)
+			assert.Len(t, result.Errors, 0)
+
+			// Object must still have been deleted
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.NotNil(t, err)
+		})
+
+		t.Run("it should return an error entry for objects with a VersionId"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key, VersionId: aws.String("some-version-id")},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 0)
+			assert.Len(t, result.Errors, 1)
+			assert.Equal(t, *key, *result.Errors[0].Key)
+			assert.Equal(t, "NotImplemented", *result.Errors[0].Code)
+		})
+
+		t.Run("it should return 404 when the bucket does not exist"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key},
+					},
+				},
+			})
+			assert.NotNil(t, err)
+			var apiErr smithy.APIError
+			assert.True(t, errors.As(err, &apiErr))
+			assert.Equal(t, "NoSuchBucket", apiErr.ErrorCode())
+		})
+
+		t.Run("it should handle an empty delete list"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 0)
+			assert.Len(t, result.Errors, 0)
+		})
+
+		t.Run("it should partially succeed when some keys exist and some do not"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			nonExistentKey := aws.String("does/not/exist.txt")
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key},
+						{Key: nonExistentKey},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 2)
+			assert.Len(t, result.Errors, 0)
+
+			// Existing object must be gone
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.NotNil(t, err)
+		})
+	})
+}

--- a/internal/auditlog/entry.go
+++ b/internal/auditlog/entry.go
@@ -24,6 +24,7 @@ const (
 	OpGetObject               Operation = "GetObject"
 	OpPutObject               Operation = "PutObject"
 	OpDeleteObject            Operation = "DeleteObject"
+	OpDeleteObjects           Operation = "DeleteObjects"
 	OpCreateMultipartUpload   Operation = "CreateMultipartUpload"
 	OpUploadPart              Operation = "UploadPart"
 	OpCompleteMultipartUpload Operation = "CompleteMultipartUpload"

--- a/internal/http/server/authorization/authorization.go
+++ b/internal/http/server/authorization/authorization.go
@@ -22,6 +22,7 @@ const (
 	OperationPutObject               = "PutObject"
 	OperationAbortMultipartUpload    = "AbortMultipartUpload"
 	OperationDeleteObject            = "DeleteObject"
+	OperationDeleteObjects           = "DeleteObjects"
 	OperationGetBucketWebsite        = "GetBucketWebsite"
 	OperationPutBucketWebsite        = "PutBucketWebsite"
 	OperationDeleteBucketWebsite     = "DeleteBucketWebsite"

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -51,6 +51,7 @@ func SetupServer(credentials []settings.Credentials, region string, apiEndpoint 
 	apiMux.HandleFunc("GET /{bucket}", server.listObjectsOrListMultipartUploadsOrGetBucketWebsiteHandler)
 	apiMux.HandleFunc("PUT /{bucket}", server.createBucketOrPutBucketWebsiteHandler)
 	apiMux.HandleFunc("DELETE /{bucket}", server.deleteBucketOrDeleteBucketWebsiteHandler)
+	apiMux.HandleFunc("POST /{bucket}", server.postBucketHandler)
 	apiMux.HandleFunc("HEAD /{bucket}/{key...}", server.headObjectHandler)
 	apiMux.HandleFunc("GET /{bucket}/{key...}", server.getObjectOrListPartsHandler)
 	apiMux.HandleFunc("POST /{bucket}/{key...}", server.createMultipartUploadOrCompleteMultipartUploadHandler)
@@ -347,6 +348,33 @@ type WebsiteConfigurationResponse struct {
 	Xmlns         string                             `xml:"xmlns,attr"`
 	IndexDocument *WebsiteConfigurationIndexDocument `xml:"IndexDocument"`
 	ErrorDocument *WebsiteConfigurationErrorDocument `xml:"ErrorDocument,omitempty"`
+}
+
+type DeleteObjectEntry struct {
+	Key       string  `xml:"Key"`
+	VersionId *string `xml:"VersionId"`
+}
+
+type DeleteObjectsRequest struct {
+	XMLName xml.Name             `xml:"Delete"`
+	Quiet   bool                 `xml:"Quiet"`
+	Objects []*DeleteObjectEntry `xml:"Object"`
+}
+
+type DeletedEntry struct {
+	Key string `xml:"Key"`
+}
+
+type DeleteErrorEntry struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+type DeleteObjectsResult struct {
+	XMLName xml.Name            `xml:"DeleteResult"`
+	Deleted []*DeletedEntry     `xml:"Deleted"`
+	Errors  []*DeleteErrorEntry `xml:"Error"`
 }
 
 var ErrInvalidRequest = fmt.Errorf("InvalidRequest")
@@ -1650,6 +1678,133 @@ func (s *Server) abortMultipartUploadOrDeleteObjectHandler(w http.ResponseWriter
 
 	// DeleteObject
 	s.deleteObjectHandler(w, r)
+}
+
+func (s *Server) postBucketHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	if query.Has("delete") {
+		s.deleteObjectsHandler(w, r)
+		return
+	}
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}
+
+const maxDeleteObjects = 1000
+
+func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "Server.deleteObjectsHandler")
+	defer span.End()
+
+	bucketName, err := storage.NewBucketName(r.PathValue(bucketPath))
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	shouldReturn := s.authorizeRequest(ctx, authorization.OperationDeleteObjects, ptrutils.ToPtr(bucketName.String()), nil, w, r)
+	if shouldReturn {
+		return
+	}
+
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	var req DeleteObjectsRequest
+	if err := xml.Unmarshal(data, &req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Objects) > maxDeleteObjects {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	result := DeleteObjectsResult{
+		Deleted: []*DeletedEntry{},
+		Errors:  []*DeleteErrorEntry{},
+	}
+
+	// First pass: validate entries and collect valid keys for bulk delete.
+	// We track the original string key alongside the parsed ObjectKey so we can
+	// build the response even when validation fails.
+	type validEntry struct {
+		rawKey string
+		key    storage.ObjectKey
+	}
+	validEntries := make([]validEntry, 0, len(req.Objects))
+
+	for _, obj := range req.Objects {
+		if obj.VersionId != nil {
+			result.Errors = append(result.Errors, &DeleteErrorEntry{
+				Key:     obj.Key,
+				Code:    "NotImplemented",
+				Message: "versioning is not supported",
+			})
+			continue
+		}
+
+		key, err := storage.NewObjectKey(obj.Key)
+		if err != nil {
+			result.Errors = append(result.Errors, &DeleteErrorEntry{
+				Key:     obj.Key,
+				Code:    "InvalidArgument",
+				Message: err.Error(),
+			})
+			continue
+		}
+
+		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key})
+	}
+
+	// Second pass: bulk delete all valid keys in one storage call.
+	if len(validEntries) > 0 {
+		keys := make([]storage.ObjectKey, len(validEntries))
+		for i, ve := range validEntries {
+			keys[i] = ve.key
+		}
+
+		slog.Info("DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(keys))
+		deleteResult, err := s.storage.DeleteObjects(ctx, bucketName, keys)
+		if err != nil {
+			if err == storage.ErrNoSuchBucket {
+				handleError(err, w, r)
+				return
+			}
+			handleError(err, w, r)
+			return
+		}
+
+		// Build a map from key string → entry for result lookup.
+		resultByKey := make(map[string]storage.DeleteObjectsEntry, len(deleteResult.Entries))
+		for _, entry := range deleteResult.Entries {
+			resultByKey[entry.Key.String()] = entry
+		}
+
+		for _, ve := range validEntries {
+			entry, ok := resultByKey[ve.key.String()]
+			if !ok || entry.Deleted {
+				if !req.Quiet {
+					result.Deleted = append(result.Deleted, &DeletedEntry{Key: ve.rawKey})
+				}
+			} else {
+				result.Errors = append(result.Errors, &DeleteErrorEntry{
+					Key:     ve.rawKey,
+					Code:    entry.ErrCode,
+					Message: entry.ErrMsg,
+				})
+			}
+		}
+	}
+
+	responseHeaders := w.Header()
+	responseHeaders.Set(contentTypeHeader, applicationXmlContentType)
+	w.WriteHeader(http.StatusOK)
+	out, _ := xmlMarshalWithDocType(result)
+	w.Write(out)
 }
 
 func (s *Server) getBucketWebsiteHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -234,6 +234,25 @@ func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.Buc
 	return nil
 }
 
+func (cs *CacheStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObjects")
+	defer span.End()
+
+	result, err := cs.innerStorage.DeleteObjects(ctx, bucketName, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range result.Entries {
+		if entry.Deleted {
+			cacheKey := getObjectCacheKeyForBucketAndKey(bucketName, entry.Key)
+			_ = cs.cache.Remove(cacheKey) // best-effort cache eviction
+		}
+	}
+
+	return result, nil
+}
+
 func (cs *CacheStorage) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.CreateMultipartUpload")
 	defer span.End()

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -633,6 +633,57 @@ func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName sto
 	return nil
 }
 
+func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.DeleteObjects")
+	defer span.End()
+
+	unblockGC := mbs.partGC.PreventGCFromRunning(ctx)
+	defer unblockGC()
+	tx, err := mbs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &storage.DeleteObjectsResult{
+		Entries: make([]storage.DeleteObjectsEntry, 0, len(keys)),
+	}
+
+	for _, key := range keys {
+		object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+		if err != nil {
+			if err == storage.ErrNoSuchKey {
+				result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: true})
+				continue
+			}
+			tx.Rollback()
+			return nil, err
+		}
+
+		for _, part := range object.Parts {
+			err = mbs.partStore.DeletePart(ctx, tx, part.Id)
+			if err != nil {
+				tx.Rollback()
+				return nil, err
+			}
+		}
+
+		err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, key)
+		if err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: true})
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func convertInitiateMultipartUploadResult(result metadatastore.InitiateMultipartUploadResult) storage.InitiateMultipartUploadResult {
 	return storage.InitiateMultipartUploadResult{
 		UploadId: result.UploadId,

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -229,6 +229,13 @@ func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storag
 	return err
 }
 
+func (m *AuditLogMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	result, err := m.next.DeleteObjects(ctx, bucketName, keys)
+	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	return result, err
+}
+
 func (m *AuditLogMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	m.log(ctx, auditlog.OpCreateMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
 	res, err := m.next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -163,6 +163,14 @@ func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucke
 	return storage.DeleteObject(ctx, bucketName, key)
 }
 
+func (csm *conditionalStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.DeleteObjects")
+	defer span.End()
+
+	s := csm.lookupStorage(bucketName)
+	return s.DeleteObjects(ctx, bucketName, keys)
+}
+
 func (csm *conditionalStorageMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.CreateMultipartUpload")
 	defer span.End()

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -386,6 +386,21 @@ func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucket
 	return nil
 }
 
+func (psm *prometheusStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObjects")
+	defer span.End()
+
+	result, err := psm.innerStorage.DeleteObjects(ctx, bucketName, keys)
+	if err != nil {
+		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteObjects"}).Inc()
+		return nil, err
+	}
+
+	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "DeleteObjects"}).Inc()
+
+	return result, nil
+}
+
 func (psm *prometheusStorageMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.CreateMultipartUpload")
 	defer span.End()

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -483,6 +483,37 @@ func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.Bu
 	return nil
 }
 
+func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObjects")
+	defer span.End()
+
+	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range keys {
+		_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, key.String())
+		if err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &storage.DeleteObjectsResult{
+		Entries: make([]storage.DeleteObjectsEntry, len(keys)),
+	}
+	for i, key := range keys {
+		result.Entries[i] = storage.DeleteObjectsEntry{Key: key, Deleted: true}
+	}
+	return result, nil
+}
+
 func (os *outboxStorage) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.CreateMultipartUpload")
 	defer span.End()

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -193,6 +193,23 @@ func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName stora
 	return nil
 }
 
+func (rs *replicationStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObjects")
+	defer span.End()
+
+	result, err := rs.primaryStorage.DeleteObjects(ctx, bucketName, keys)
+	if err != nil {
+		return nil, err
+	}
+	for _, secondaryStorage := range rs.secondaryStorages {
+		_, err = secondaryStorage.DeleteObjects(ctx, bucketName, keys)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
 func (rs *replicationStorage) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.CreateMultipartUpload")
 	defer span.End()

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -310,6 +310,59 @@ func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.
 	return nil
 }
 
+func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.DeleteObjects")
+	defer span.End()
+
+	identifiers := make([]types.ObjectIdentifier, len(keys))
+	for i, key := range keys {
+		k := key.String()
+		identifiers[i] = types.ObjectIdentifier{Key: &k}
+	}
+
+	deleteResult, err := rs.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(bucketName.String()),
+		Delete: &types.Delete{
+			Objects: identifiers,
+			Quiet:   aws.Bool(false),
+		},
+	})
+	var notFoundError *types.NotFound
+	if err != nil && errors.As(err, &notFoundError) {
+		return nil, storage.ErrNoSuchBucket
+	}
+	var ae smithy.APIError
+	if err != nil && errors.As(err, &ae) && ae.ErrorCode() == "NoSuchBucket" {
+		return nil, storage.ErrNoSuchBucket
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	result := &storage.DeleteObjectsResult{
+		Entries: make([]storage.DeleteObjectsEntry, 0, len(keys)),
+	}
+
+	for _, deleted := range deleteResult.Deleted {
+		key := storage.MustNewObjectKey(*deleted.Key)
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: true})
+	}
+	for _, errEntry := range deleteResult.Errors {
+		key := storage.MustNewObjectKey(*errEntry.Key)
+		code := ""
+		msg := ""
+		if errEntry.Code != nil {
+			code = *errEntry.Code
+		}
+		if errEntry.Message != nil {
+			msg = *errEntry.Message
+		}
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: false, ErrCode: code, ErrMsg: msg})
+	}
+
+	return result, nil
+}
+
 func (rs *s3ClientStorage) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.CreateMultipartUpload")
 	defer span.End()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -132,6 +132,19 @@ type ListPartsResult struct {
 	Parts                []*MultipartPart
 }
 
+// DeleteObjectsEntry represents the result for a single key in a DeleteObjects operation.
+type DeleteObjectsEntry struct {
+	Key     ObjectKey
+	Deleted bool
+	ErrCode string
+	ErrMsg  string
+}
+
+// DeleteObjectsResult is the per-key result of a bulk DeleteObjects operation.
+type DeleteObjectsResult struct {
+	Entries []DeleteObjectsEntry
+}
+
 type ChecksumInput = metadatastore.ChecksumInput
 type ChecksumValues = metadatastore.ChecksumValues
 type BucketName = metadatastore.BucketName
@@ -226,6 +239,7 @@ type ObjectManager interface {
 	GetObject(ctx context.Context, bucketName BucketName, key ObjectKey, ranges []ByteRange) (*Object, []io.ReadCloser, error)
 	PutObject(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, data io.Reader, checksumInput *ChecksumInput, opts *PutObjectOptions) (*PutObjectResult, error)
 	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey) error
+	DeleteObjects(ctx context.Context, bucketName BucketName, keys []ObjectKey) (*DeleteObjectsResult, error)
 }
 
 // MultipartUploadManager manages multipart upload operations


### PR DESCRIPTION
Add batch delete support across all storage layers in a single transaction. Includes XML handler, authorization, audit logging, and integration tests.

closes #505 