### PR TITLE
feat(storage): implement conditional delete with If-Match ETag semantics

### DIFF
--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -353,6 +353,7 @@ type WebsiteConfigurationResponse struct {
 type DeleteObjectEntry struct {
 	Key       string  `xml:"Key"`
 	VersionId *string `xml:"VersionId"`
+	IfMatch   *string `xml:"IfMatch"`
 }
 
 type DeleteObjectsRequest struct {
@@ -1659,7 +1660,12 @@ func (s *Server) deleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("Deleting object", "bucket", bucketName.String(), "key", key.String())
-	err = s.storage.DeleteObject(ctx, bucketName, key)
+	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
+	var deleteOpts *storage.DeleteObjectOptions
+	if ifMatch != nil {
+		deleteOpts = &storage.DeleteObjectOptions{IfMatchETag: ifMatch}
+	}
+	err = s.storage.DeleteObject(ctx, bucketName, key, deleteOpts)
 	if err != nil {
 		handleError(err, w, r)
 		return
@@ -1732,8 +1738,9 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	// We track the original string key alongside the parsed ObjectKey so we can
 	// build the response even when validation fails.
 	type validEntry struct {
-		rawKey string
-		key    storage.ObjectKey
+		rawKey  string
+		key     storage.ObjectKey
+		ifMatch *string
 	}
 	validEntries := make([]validEntry, 0, len(req.Objects))
 
@@ -1757,18 +1764,18 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key})
+		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key, ifMatch: obj.IfMatch})
 	}
 
-	// Second pass: bulk delete all valid keys in one storage call.
+	// Second pass: bulk delete all valid entries in one storage call.
 	if len(validEntries) > 0 {
-		keys := make([]storage.ObjectKey, len(validEntries))
+		inputEntries := make([]storage.DeleteObjectsInputEntry, len(validEntries))
 		for i, ve := range validEntries {
-			keys[i] = ve.key
+			inputEntries[i] = storage.DeleteObjectsInputEntry{Key: ve.key, IfMatchETag: ve.ifMatch}
 		}
 
-		slog.Info("DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(keys))
-		deleteResult, err := s.storage.DeleteObjects(ctx, bucketName, keys)
+		slog.Info("DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(inputEntries))
+		deleteResult, err := s.storage.DeleteObjects(ctx, bucketName, inputEntries)
 		if err != nil {
 			if err == storage.ErrNoSuchBucket {
 				handleError(err, w, r)

--- a/internal/storage/benchmark/benchmark.go
+++ b/internal/storage/benchmark/benchmark.go
@@ -185,7 +185,7 @@ func cleanupObjectsInBucket(ctx context.Context, st storage.Storage, bucketName 
 	}
 
 	for _, obj := range objects {
-		err = st.DeleteObject(ctx, bucketName, obj.Key)
+		err = st.DeleteObject(ctx, bucketName, obj.Key, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -217,11 +217,11 @@ func (cs *CacheStorage) PutObject(ctx context.Context, bucketName storage.Bucket
 	return putObjectResult, nil
 }
 
-func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObject")
 	defer span.End()
 
-	err := cs.innerStorage.DeleteObject(ctx, bucketName, key)
+	err := cs.innerStorage.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
 		return err
 	}
@@ -234,11 +234,11 @@ func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.Buc
 	return nil
 }
 
-func (cs *CacheStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (cs *CacheStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObjects")
 	defer span.End()
 
-	result, err := cs.innerStorage.DeleteObjects(ctx, bucketName, keys)
+	result, err := cs.innerStorage.DeleteObjects(ctx, bucketName, entries)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/database/pgx/repository/object/pgx.go
+++ b/internal/storage/database/pgx/repository/object/pgx.go
@@ -217,9 +217,17 @@ func (or *pgxRepository) CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadI
 	return &keyCount, nil
 }
 
-func (or *pgxRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) error {
-	_, err := tx.ExecContext(ctx, deleteObjectByIdStmt, objectId.String())
-	return err
+func (or *pgxRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error) {
+	res, err := tx.ExecContext(ctx, deleteObjectByIdStmt, objectId.String())
+	if err != nil {
+		return nil, err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	deleted := rowsAffected > 0
+	return &deleted, nil
 }
 
 func (or *pgxRepository) DeleteObjectByIdAndETag(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, etag string) (*bool, error) {

--- a/internal/storage/database/repository/object/interface.go
+++ b/internal/storage/database/repository/object/interface.go
@@ -19,7 +19,7 @@ type Repository interface {
 	FindObjectByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) (*Entity, error)
 	CountObjectsByBucketNameAndPrefixAndStartAfter(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) (*int, error)
 	CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarker(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, uploadIdMarker string) (*int, error)
-	DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) error
+	DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error)
 	DeleteObjectByIdAndETag(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, etag string) (*bool, error)
 }
 

--- a/internal/storage/database/sqlite/repository/object/sqlite.go
+++ b/internal/storage/database/sqlite/repository/object/sqlite.go
@@ -217,9 +217,17 @@ func (or *sqliteRepository) CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUplo
 	return &keyCount, nil
 }
 
-func (or *sqliteRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) error {
-	_, err := tx.ExecContext(ctx, deleteObjectByIdStmt, objectId.String())
-	return err
+func (or *sqliteRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error) {
+	res, err := tx.ExecContext(ctx, deleteObjectByIdStmt, objectId.String())
+	if err != nil {
+		return nil, err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	deleted := rowsAffected > 0
+	return &deleted, nil
 }
 
 func (or *sqliteRepository) DeleteObjectByIdAndETag(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, etag string) (*bool, error) {

--- a/internal/storage/integrity/validator.go
+++ b/internal/storage/integrity/validator.go
@@ -18,10 +18,10 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage"
 	"github.com/jdillenkofer/pithos/internal/storage/database"
 	"github.com/jdillenkofer/pithos/internal/storage/database/repository"
-	"github.com/jdillenkofer/pithos/internal/storage/database/repository/part"
 	"github.com/jdillenkofer/pithos/internal/storage/database/repository/object"
-	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
+	"github.com/jdillenkofer/pithos/internal/storage/database/repository/part"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
+	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
 )
 
 type Validator struct {
@@ -111,7 +111,7 @@ func (v *Validator) ValidateAll(ctx context.Context) (*ValidationReport, error) 
 				report.FailedObjects++
 				if v.deleteCorrupted {
 					if v.confirmDeletion(result) {
-						err := v.storage.DeleteObject(ctx, bucket.Name, object.Key)
+						err := v.storage.DeleteObject(ctx, bucket.Name, object.Key, nil)
 						if err != nil {
 							result.ActionTaken = fmt.Sprintf("Failed to delete: %v", err)
 						} else {

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -594,7 +594,7 @@ func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storag
 	}, nil
 }
 
-func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.DeleteObject")
 	defer span.End()
 
@@ -607,6 +607,16 @@ func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName sto
 
 	object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
 	if err != nil {
+		if err == storage.ErrNoSuchKey {
+			tx.Rollback()
+			// Object does not exist.
+			if opts != nil && opts.IfMatchETag != nil {
+				// Conditional delete: object must exist.
+				return storage.ErrPreconditionFailed
+			}
+			// No condition: silently succeed per S3 semantics.
+			return nil
+		}
 		tx.Rollback()
 		return err
 	}
@@ -619,7 +629,13 @@ func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName sto
 		}
 	}
 
-	err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, key)
+	var metaOpts *metadatastore.DeleteObjectOptions
+	if opts != nil {
+		metaOpts = &metadatastore.DeleteObjectOptions{
+			IfMatchETag: opts.IfMatchETag,
+		}
+	}
+	err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, key, metaOpts)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -633,7 +649,7 @@ func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName sto
 	return nil
 }
 
-func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.DeleteObjects")
 	defer span.End()
 
@@ -645,35 +661,62 @@ func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName st
 	}
 
 	result := &storage.DeleteObjectsResult{
-		Entries: make([]storage.DeleteObjectsEntry, 0, len(keys)),
+		Entries: make([]storage.DeleteObjectsEntry, 0, len(entries)),
 	}
 
-	for _, key := range keys {
-		object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	for _, entry := range entries {
+		object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, entry.Key)
 		if err != nil {
 			if err == storage.ErrNoSuchKey {
-				result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: true})
+				if entry.IfMatchETag != nil {
+					// Object does not exist but ETag condition set → precondition failed for this entry.
+					result.Entries = append(result.Entries, storage.DeleteObjectsEntry{
+						Key:     entry.Key,
+						Deleted: false,
+						ErrCode: "PreconditionFailed",
+						ErrMsg:  "At least one of the pre-conditions you specified did not hold",
+					})
+				} else {
+					result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: entry.Key, Deleted: true})
+				}
 				continue
 			}
 			tx.Rollback()
 			return nil, err
 		}
 
-		for _, part := range object.Parts {
-			err = mbs.partStore.DeletePart(ctx, tx, part.Id)
-			if err != nil {
-				tx.Rollback()
-				return nil, err
+		// Object exists — check conditional ETag if specified.
+		if entry.IfMatchETag != nil && (object == nil || object.ETag != *entry.IfMatchETag) {
+			result.Entries = append(result.Entries, storage.DeleteObjectsEntry{
+				Key:     entry.Key,
+				Deleted: false,
+				ErrCode: "PreconditionFailed",
+				ErrMsg:  "At least one of the pre-conditions you specified did not hold",
+			})
+			continue
+		}
+
+		if object != nil {
+			for _, part := range object.Parts {
+				err = mbs.partStore.DeletePart(ctx, tx, part.Id)
+				if err != nil {
+					tx.Rollback()
+					return nil, err
+				}
 			}
 		}
 
-		err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, key)
+		var metaOpts *metadatastore.DeleteObjectOptions
+		if entry.IfMatchETag != nil {
+			metaOpts = &metadatastore.DeleteObjectOptions{IfMatchETag: entry.IfMatchETag}
+		}
+		err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, entry.Key, metaOpts)
 		if err != nil {
 			tx.Rollback()
 			return nil, err
 		}
 
-		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: true})
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: entry.Key, Deleted: true})
 	}
 
 	err = tx.Commit()

--- a/internal/storage/metadatapart/metadatapart_test.go
+++ b/internal/storage/metadatapart/metadatapart_test.go
@@ -1,20 +1,24 @@
 package metadatapart
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/jdillenkofer/pithos/internal/ptrutils"
 	"github.com/jdillenkofer/pithos/internal/storage"
 	repositoryFactory "github.com/jdillenkofer/pithos/internal/storage/database/repository"
 	"github.com/jdillenkofer/pithos/internal/storage/database/sqlite"
+	sqlMetadataStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/sql"
 	filesystemPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/filesystem"
 	sqlPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/sql"
-	sqlMetadataStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/sql"
 	testutils "github.com/jdillenkofer/pithos/internal/testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetadataPartStorageWithSql(t *testing.T) {
@@ -146,4 +150,206 @@ func TestMetadataPartStorageWithFilesystem(t *testing.T) {
 	content := []byte("MetadataPartStorage")
 	err = storage.Tester(metadataPartStorage, []storage.BucketName{storage.MustNewBucketName("bucket")}, content)
 	assert.Nil(t, err)
+}
+
+// newTestStorage creates a fresh MetadataPartStorage backed by a temporary SQLite DB and SQL part store.
+// Returns the raw *metadataPartStorage (for access to internal methods) and a cleanup function.
+func newTestStorage(t *testing.T) (*metadataPartStorage, func()) {
+	t.Helper()
+	storagePath, err := os.MkdirTemp("", "pithos-test-data-")
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(storagePath, "pithos.db")
+	db, err := sqlite.OpenDatabase(dbPath)
+	require.NoError(t, err)
+
+	partContentRepository, err := repositoryFactory.NewPartContentRepository(db)
+	require.NoError(t, err)
+	partStore, err := sqlPartStore.New(db, partContentRepository)
+	require.NoError(t, err)
+	bucketRepository, err := repositoryFactory.NewBucketRepository(db)
+	require.NoError(t, err)
+	objectRepository, err := repositoryFactory.NewObjectRepository(db)
+	require.NoError(t, err)
+	partRepository, err := repositoryFactory.NewPartRepository(db)
+	require.NoError(t, err)
+	metaStore, err := sqlMetadataStore.New(db, bucketRepository, objectRepository, partRepository)
+	require.NoError(t, err)
+	st, err := NewStorage(db, metaStore, partStore)
+	require.NoError(t, err)
+	mps := st.(*metadataPartStorage)
+
+	ctx := context.Background()
+	require.NoError(t, mps.Start(ctx))
+
+	cleanup := func() {
+		mps.Stop(ctx)
+		db.Close()
+		os.RemoveAll(storagePath)
+	}
+	return mps, cleanup
+}
+
+func TestConditionalDeleteObject_MatchingETag(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	result, err := st.PutObject(ctx, bucket, key, nil, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+	etag := *result.ETag
+
+	// Delete with correct ETag — should succeed.
+	err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(etag)})
+	require.NoError(t, err)
+
+	// Object should be gone.
+	_, err = st.HeadObject(ctx, bucket, key)
+	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
+}
+
+func TestConditionalDeleteObject_WrongETag(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	_, err := st.PutObject(ctx, bucket, key, nil, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	// Delete with wrong ETag — should return PreconditionFailed.
+	err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr("wrong-etag")})
+	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
+
+	// Object should still exist.
+	_, err = st.HeadObject(ctx, bucket, key)
+	require.NoError(t, err)
+}
+
+func TestConditionalDeleteObject_NoObjectWithCondition(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("nonexistent")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// Delete non-existent object with ETag condition — should return PreconditionFailed.
+	err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr("any-etag")})
+	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
+}
+
+func TestConditionalDeleteObject_NoObjectNoCondition(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("nonexistent")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// Delete non-existent object without condition — should silently succeed (S3 semantics).
+	err := st.DeleteObject(ctx, bucket, key, nil)
+	require.NoError(t, err)
+}
+
+func TestConditionalDeleteObjects_MixedConditions(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	key1 := storage.MustNewObjectKey("obj1")
+	key2 := storage.MustNewObjectKey("obj2")
+	key3 := storage.MustNewObjectKey("obj3")
+
+	res1, err := st.PutObject(ctx, bucket, key1, nil, bytes.NewReader([]byte("data1")), nil, nil)
+	require.NoError(t, err)
+	etag1 := *res1.ETag
+
+	_, err = st.PutObject(ctx, bucket, key2, nil, bytes.NewReader([]byte("data2")), nil, nil)
+	require.NoError(t, err)
+
+	_, err = st.PutObject(ctx, bucket, key3, nil, bytes.NewReader([]byte("data3")), nil, nil)
+	require.NoError(t, err)
+
+	entries := []storage.DeleteObjectsInputEntry{
+		{Key: key1, IfMatchETag: ptrutils.ToPtr(etag1)},        // correct etag → deleted
+		{Key: key2, IfMatchETag: ptrutils.ToPtr("wrong-etag")}, // wrong etag → error entry
+		{Key: key3}, // no condition → deleted
+	}
+	deleteResult, err := st.DeleteObjects(ctx, bucket, entries)
+	require.NoError(t, err)
+	require.Len(t, deleteResult.Entries, 3)
+
+	// Find entries by key.
+	byKey := make(map[string]storage.DeleteObjectsEntry)
+	for _, e := range deleteResult.Entries {
+		byKey[e.Key.String()] = e
+	}
+
+	assert.True(t, byKey["obj1"].Deleted, "obj1 should be deleted (correct etag)")
+	assert.False(t, byKey["obj2"].Deleted, "obj2 should NOT be deleted (wrong etag)")
+	assert.Equal(t, "PreconditionFailed", byKey["obj2"].ErrCode)
+	assert.True(t, byKey["obj3"].Deleted, "obj3 should be deleted (no condition)")
+
+	// Verify obj1 and obj3 are gone, obj2 still exists.
+	_, err = st.HeadObject(ctx, bucket, key1)
+	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
+	_, err = st.HeadObject(ctx, bucket, key2)
+	require.NoError(t, err)
+	_, err = st.HeadObject(ctx, bucket, key3)
+	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
+}
+
+func TestConditionalDeleteObject_WildcardMatchExistingObject(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	_, err := st.PutObject(ctx, bucket, key, nil, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	// Delete with If-Match: * on an existing object — should succeed.
+	err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
+	require.NoError(t, err)
+
+	// Object should be gone.
+	_, err = st.HeadObject(ctx, bucket, key)
+	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
+}
+
+func TestConditionalDeleteObject_WildcardMatchMissingObject(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("nonexistent")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// Delete with If-Match: * on a non-existent object — should return PreconditionFailed.
+	err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
+	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
 }

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -199,9 +199,21 @@ type ListPartsOptions struct {
 	MaxParts         int32
 }
 
+// ETagWildcard is the special If-Match / If-None-Match value that matches any
+// object, as defined by the HTTP spec and used by S3.
+const ETagWildcard = "*"
+
 type PutObjectOptions struct {
 	IfNoneMatchStar bool
 	IfMatchETag     *string
+}
+
+type DeleteObjectOptions struct {
+	// IfMatchETag, when non-nil, requires the stored object's ETag to equal this
+	// value before deleting; otherwise ErrPreconditionFailed is returned.
+	// The special value "*" matches any existing object (i.e. HTTP If-Match: *),
+	// returning ErrPreconditionFailed only when the object does not exist.
+	IfMatchETag *string
 }
 
 type MaintenanceStore interface {
@@ -230,7 +242,7 @@ type ObjectStore interface {
 	ListObjects(ctx context.Context, tx *sql.Tx, bucketName BucketName, opts ListObjectsOptions) (*ListBucketResult, error)
 	HeadObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey) (*Object, error)
 	PutObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object, opts *PutObjectOptions) error
-	DeleteObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey) error
+	DeleteObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
 }
 
 type MultipartStore interface {
@@ -365,7 +377,7 @@ func Tester(metadataStore MetadataStore, db database.Database) error {
 	if err != nil {
 		return err
 	}
-	err = metadataStore.DeleteObject(ctx, tx, bucketName, key)
+	err = metadataStore.DeleteObject(ctx, tx, bucketName, key, nil)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -418,7 +430,7 @@ func Tester(metadataStore MetadataStore, db database.Database) error {
 	if err != nil {
 		return err
 	}
-	err = metadataStore.DeleteObject(ctx, tx, bucketName, key)
+	err = metadataStore.DeleteObject(ctx, tx, bucketName, key, nil)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -431,7 +431,7 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 			if err != nil {
 				return err
 			}
-			err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
+			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 	return nil
 }
 
-func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey) error {
+func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, opts *metadatastore.DeleteObjectOptions) error {
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.DeleteObject")
 	defer span.End()
 
@@ -485,15 +485,42 @@ func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucke
 		return err
 	}
 
+	if opts != nil && opts.IfMatchETag != nil {
+		if *opts.IfMatchETag == metadatastore.ETagWildcard {
+			// If-Match: * — object must exist (any ETag); 412 if absent.
+			if objectEntity == nil {
+				return metadatastore.ErrPreconditionFailed
+			}
+		} else {
+			// Conditional delete: object must exist and ETag must match exactly.
+			if objectEntity == nil || objectEntity.ETag != *opts.IfMatchETag {
+				return metadatastore.ErrPreconditionFailed
+			}
+		}
+	}
+
 	if objectEntity != nil {
 		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
 		if err != nil {
 			return err
 		}
 
-		err = sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
-		if err != nil {
-			return err
+		if opts != nil && opts.IfMatchETag != nil && *opts.IfMatchETag != metadatastore.ETagWildcard {
+			deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *objectEntity.Id, *opts.IfMatchETag)
+			if err != nil {
+				return err
+			}
+			if !*deleted {
+				return metadatastore.ErrPreconditionFailed
+			}
+		} else {
+			deleted, err := sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
+			if err != nil {
+				return err
+			}
+			if !*deleted {
+				return metadatastore.ErrPreconditionFailed
+			}
 		}
 	}
 
@@ -668,7 +695,7 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 			}
 		}, oldPartEntities)
 
-		err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
+		_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
 		if err != nil {
 			return nil, err
 		}
@@ -744,7 +771,7 @@ func (sms *sqlMetadataStore) AbortMultipartUpload(ctx context.Context, tx *sql.T
 		}
 	}, partEntities)
 
-	err = sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
+	_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -222,16 +222,16 @@ func (m *AuditLogMiddleware) PutObject(ctx context.Context, bucketName storage.B
 	return res, err
 }
 
-func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
-	err := m.next.DeleteObject(ctx, bucketName, key)
+	err := m.next.DeleteObject(ctx, bucketName, key, opts)
 	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
 	return err
 }
 
-func (m *AuditLogMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (m *AuditLogMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
-	result, err := m.next.DeleteObjects(ctx, bucketName, keys)
+	result, err := m.next.DeleteObjects(ctx, bucketName, entries)
 	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
 	return result, err
 }

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -155,20 +155,20 @@ func (csm *conditionalStorageMiddleware) PutObject(ctx context.Context, bucketNa
 	return storage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
 }
 
-func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.DeleteObject")
 	defer span.End()
 
 	storage := csm.lookupStorage(bucketName)
-	return storage.DeleteObject(ctx, bucketName, key)
+	return storage.DeleteObject(ctx, bucketName, key, opts)
 }
 
-func (csm *conditionalStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (csm *conditionalStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.DeleteObjects")
 	defer span.End()
 
 	s := csm.lookupStorage(bucketName)
-	return s.DeleteObjects(ctx, bucketName, keys)
+	return s.DeleteObjects(ctx, bucketName, entries)
 }
 
 func (csm *conditionalStorageMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -371,11 +371,11 @@ func (psm *prometheusStorageMiddleware) PutObject(ctx context.Context, bucketNam
 	return putObjectResult, nil
 }
 
-func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObject")
 	defer span.End()
 
-	err := psm.innerStorage.DeleteObject(ctx, bucketName, key)
+	err := psm.innerStorage.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteObject"}).Inc()
 		return err
@@ -386,11 +386,11 @@ func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucket
 	return nil
 }
 
-func (psm *prometheusStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (psm *prometheusStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObjects")
 	defer span.End()
 
-	result, err := psm.innerStorage.DeleteObjects(ctx, bucketName, keys)
+	result, err := psm.innerStorage.DeleteObjects(ctx, bucketName, entries)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteObjects"}).Inc()
 		return nil, err

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -104,7 +104,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 				return
 			}
 		case storageOutboxEntry.DeleteObjectStorageOperation:
-			err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key))
+			err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
 			if err != nil {
 				tx.Rollback()
 				time.Sleep(5 * time.Second)
@@ -463,7 +463,7 @@ func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.Bucke
 	}, nil
 }
 
-func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObject")
 	defer span.End()
 
@@ -483,7 +483,7 @@ func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.Bu
 	return nil
 }
 
-func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObjects")
 	defer span.End()
 
@@ -492,8 +492,8 @@ func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.B
 		return nil, err
 	}
 
-	for _, key := range keys {
-		_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, key.String())
+	for _, entry := range entries {
+		_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, entry.Key.String())
 		if err != nil {
 			tx.Rollback()
 			return nil, err
@@ -506,10 +506,10 @@ func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.B
 	}
 
 	result := &storage.DeleteObjectsResult{
-		Entries: make([]storage.DeleteObjectsEntry, len(keys)),
+		Entries: make([]storage.DeleteObjectsEntry, len(entries)),
 	}
-	for i, key := range keys {
-		result.Entries[i] = storage.DeleteObjectsEntry{Key: key, Deleted: true}
+	for i, entry := range entries {
+		result.Entries[i] = storage.DeleteObjectsEntry{Key: entry.Key, Deleted: true}
 	}
 	return result, nil
 }

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -176,16 +176,16 @@ func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.
 	return putObjectResult, nil
 }
 
-func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObject")
 	defer span.End()
 
-	err := rs.primaryStorage.DeleteObject(ctx, bucketName, key)
+	err := rs.primaryStorage.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
 		return err
 	}
 	for _, secondaryStorage := range rs.secondaryStorages {
-		err = secondaryStorage.DeleteObject(ctx, bucketName, key)
+		err = secondaryStorage.DeleteObject(ctx, bucketName, key, opts)
 		if err != nil {
 			return err
 		}
@@ -193,16 +193,16 @@ func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName stora
 	return nil
 }
 
-func (rs *replicationStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (rs *replicationStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObjects")
 	defer span.End()
 
-	result, err := rs.primaryStorage.DeleteObjects(ctx, bucketName, keys)
+	result, err := rs.primaryStorage.DeleteObjects(ctx, bucketName, entries)
 	if err != nil {
 		return nil, err
 	}
 	for _, secondaryStorage := range rs.secondaryStorages {
-		_, err = secondaryStorage.DeleteObjects(ctx, bucketName, keys)
+		_, err = secondaryStorage.DeleteObjects(ctx, bucketName, entries)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -292,14 +292,18 @@ func (rs *s3ClientStorage) PutObject(ctx context.Context, bucketName storage.Buc
 	}, nil
 }
 
-func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.DeleteObject")
 	defer span.End()
 
-	_, err := rs.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+	input := &s3.DeleteObjectInput{
 		Bucket: aws.String(bucketName.String()),
 		Key:    aws.String(key.String()),
-	})
+	}
+	if opts != nil && opts.IfMatchETag != nil {
+		input.IfMatch = opts.IfMatchETag
+	}
+	_, err := rs.s3Client.DeleteObject(ctx, input)
 	var notFoundError *types.NotFound
 	if err != nil && errors.As(err, &notFoundError) {
 		return storage.ErrNoSuchBucket
@@ -310,13 +314,13 @@ func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.
 	return nil
 }
 
-func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, keys []storage.ObjectKey) (*storage.DeleteObjectsResult, error) {
+func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.DeleteObjects")
 	defer span.End()
 
-	identifiers := make([]types.ObjectIdentifier, len(keys))
-	for i, key := range keys {
-		k := key.String()
+	identifiers := make([]types.ObjectIdentifier, len(entries))
+	for i, entry := range entries {
+		k := entry.Key.String()
 		identifiers[i] = types.ObjectIdentifier{Key: &k}
 	}
 
@@ -340,7 +344,7 @@ func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage
 	}
 
 	result := &storage.DeleteObjectsResult{
-		Entries: make([]storage.DeleteObjectsEntry, 0, len(keys)),
+		Entries: make([]storage.DeleteObjectsEntry, 0, len(entries)),
 	}
 
 	for _, deleted := range deleteResult.Deleted {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -65,6 +65,14 @@ type PutObjectOptions struct {
 	IfMatchETag     *string
 }
 
+type DeleteObjectOptions struct {
+	// IfMatchETag, when non-nil, requires the stored object's ETag to equal this
+	// value before deleting; otherwise ErrPreconditionFailed is returned.
+	// The special value "*" matches any existing object (i.e. HTTP If-Match: *),
+	// returning ErrPreconditionFailed only when the object does not exist.
+	IfMatchETag *string
+}
+
 type InitiateMultipartUploadResult struct {
 	UploadId UploadId
 }
@@ -145,11 +153,19 @@ type DeleteObjectsResult struct {
 	Entries []DeleteObjectsEntry
 }
 
+// DeleteObjectsInputEntry represents a single entry in a bulk DeleteObjects request, optionally with a conditional ETag.
+type DeleteObjectsInputEntry struct {
+	Key         ObjectKey
+	IfMatchETag *string
+}
+
 type ChecksumInput = metadatastore.ChecksumInput
 type ChecksumValues = metadatastore.ChecksumValues
 type BucketName = metadatastore.BucketName
 type ObjectKey = metadatastore.ObjectKey
 type UploadId = metadatastore.UploadId
+
+const ETagWildcard = metadatastore.ETagWildcard
 
 var NewBucketName = metadatastore.NewBucketName
 var MustNewBucketName = metadatastore.MustNewBucketName
@@ -238,8 +254,8 @@ type ObjectManager interface {
 	// Returns the object metadata, a list of readers (one per range), and an error.
 	GetObject(ctx context.Context, bucketName BucketName, key ObjectKey, ranges []ByteRange) (*Object, []io.ReadCloser, error)
 	PutObject(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, data io.Reader, checksumInput *ChecksumInput, opts *PutObjectOptions) (*PutObjectResult, error)
-	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey) error
-	DeleteObjects(ctx context.Context, bucketName BucketName, keys []ObjectKey) (*DeleteObjectsResult, error)
+	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
+	DeleteObjects(ctx context.Context, bucketName BucketName, entries []DeleteObjectsInputEntry) (*DeleteObjectsResult, error)
 }
 
 // MultipartUploadManager manages multipart upload operations
@@ -349,7 +365,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return errors.New("invalid object key")
 		}
 
-		err = storage.DeleteObject(ctx, bucketName, key)
+		err = storage.DeleteObject(ctx, bucketName, key, nil)
 		if err != nil {
 			return err
 		}
@@ -374,7 +390,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return err
 		}
 
-		err = storage.DeleteObject(ctx, bucketName, key)
+		err = storage.DeleteObject(ctx, bucketName, key, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add ETag-based conditional delete support for DeleteObject and DeleteObjects, matching AWS S3 behavior: returns 412 PreconditionFailed when the provided If-Match ETag does not match the current object ETag or the object is absent.

closes #504 