### PR TITLE
feat(storage): implement If-Match/If-None-Match conditional requests for GetObject, HeadObject

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -2596,6 +2596,101 @@ func TestGetObject(t *testing.T) {
 			newContent = append(newContent, []byte("--\r\n")...)
 			assert.Equal(t, newContent, objectBytes)
 		})
+
+		t.Run("it should return 200 for GetObject with matching If-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			_, err = s3Client.GetObject(context.Background(), &s3.GetObjectInput{
+				Bucket:  bucketName,
+				Key:     key,
+				IfMatch: putResult.ETag,
+			})
+			assert.Nil(t, err)
+		})
+
+		t.Run("it should return 412 for GetObject with mismatched If-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.GetObject(context.Background(), &s3.GetObjectInput{
+				Bucket:  bucketName,
+				Key:     key,
+				IfMatch: aws.String("\"does-not-match\""),
+			})
+			assert.NotNil(t, err)
+			var apiErr smithy.APIError
+			if assert.ErrorAs(t, err, &apiErr) {
+				assert.Equal(t, "PreconditionFailed", apiErr.ErrorCode())
+			}
+		})
+
+		t.Run("it should return an error for GetObject with matching If-None-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			_, err = s3Client.GetObject(context.Background(), &s3.GetObjectInput{
+				Bucket:      bucketName,
+				Key:         key,
+				IfNoneMatch: putResult.ETag,
+			})
+			// 304 Not Modified surfaces as an error from the SDK (no body to deserialize).
+			assert.NotNil(t, err)
+			var httpErr *awshttp.ResponseError
+			if assert.ErrorAs(t, err, &httpErr) {
+				assert.Equal(t, 304, httpErr.Response.StatusCode)
+			}
+		})
+
+		t.Run("it should return 200 for GetObject with non-matching If-None-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.GetObject(context.Background(), &s3.GetObjectInput{
+				Bucket:      bucketName,
+				Key:         key,
+				IfNoneMatch: aws.String("\"does-not-match\""),
+			})
+			assert.Nil(t, err)
+		})
 	})
 }
 
@@ -2674,6 +2769,61 @@ func TestDeleteObject(t *testing.T) {
 			assert.NotNil(t, deleteObjectResult)
 			assert.Equal(t, 204, deleteObjectResult.StatusCode)
 		})
+
+		t.Run("it should return 204 for DeleteObject with matching If-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			_, err = s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+				Bucket:  bucketName,
+				Key:     key,
+				IfMatch: putResult.ETag,
+			})
+			assert.Nil(t, err)
+
+			// Verify the object is gone.
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.NotNil(t, err)
+		})
+
+		t.Run("it should return 412 for DeleteObject with mismatched If-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+				Bucket:  bucketName,
+				Key:     key,
+				IfMatch: aws.String("\"does-not-match\""),
+			})
+			assert.NotNil(t, err)
+			var apiErr smithy.APIError
+			if assert.ErrorAs(t, err, &apiErr) {
+				assert.Equal(t, "PreconditionFailed", apiErr.ErrorCode())
+			}
+
+			// Verify the object still exists.
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.Nil(t, err)
+		})
 	})
 }
 
@@ -2719,6 +2869,102 @@ func TestHeadObject(t *testing.T) {
 			assert.Equal(t, "lMCBYNtqPCnP3avKVUtqfrThqHo=", *headObjectResult.ChecksumSHA1)
 			assert.Equal(t, "sctyzI/H+7x/oVR7Gwt7NiQ7kop4Ua/7SrVraELVDpI=", *headObjectResult.ChecksumSHA256)
 			assert.Equal(t, types.ChecksumTypeFullObject, headObjectResult.ChecksumType)
+		})
+
+		t.Run("it should return 200 for HeadObject with matching If-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+				Bucket:  bucketName,
+				Key:     key,
+				IfMatch: putResult.ETag,
+			})
+			assert.Nil(t, err)
+		})
+
+		t.Run("it should return 412 for HeadObject with mismatched If-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+				Bucket:  bucketName,
+				Key:     key,
+				IfMatch: aws.String("\"does-not-match\""),
+			})
+			// HeadObject 412 has no XML body, so the SDK surfaces it as an HTTP response error only.
+			assert.NotNil(t, err)
+			var httpErr *awshttp.ResponseError
+			if assert.ErrorAs(t, err, &httpErr) {
+				assert.Equal(t, 412, httpErr.Response.StatusCode)
+			}
+		})
+
+		t.Run("it should return an error for HeadObject with matching If-None-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+				Bucket:      bucketName,
+				Key:         key,
+				IfNoneMatch: putResult.ETag,
+			})
+			// 304 Not Modified surfaces as an error from the SDK (no body to deserialize).
+			assert.NotNil(t, err)
+			var httpErr *awshttp.ResponseError
+			if assert.ErrorAs(t, err, &httpErr) {
+				assert.Equal(t, 304, httpErr.Response.StatusCode)
+			}
+		})
+
+		t.Run("it should return 200 for HeadObject with non-matching If-None-Match"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+				Bucket:      bucketName,
+				Key:         key,
+				IfNoneMatch: aws.String("\"does-not-match\""),
+			})
+			assert.Nil(t, err)
 		})
 	})
 }
@@ -4189,6 +4435,69 @@ func TestDeleteObjects(t *testing.T) {
 			// Existing object must be gone
 			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
 			assert.NotNil(t, err)
+		})
+
+		t.Run("it should delete object when ETag matches in DeleteObjects"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key, ETag: putResult.ETag},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 1)
+			assert.Len(t, result.Errors, 0)
+
+			// Object must be gone.
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.NotNil(t, err)
+		})
+
+		t.Run("it should return an error entry when ETag mismatches in DeleteObjects"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key, ETag: aws.String("\"does-not-match\"")},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 0)
+			assert.Len(t, result.Errors, 1)
+			assert.Equal(t, *key, *result.Errors[0].Key)
+			assert.Equal(t, "PreconditionFailed", *result.Errors[0].Code)
+
+			// Object must still exist.
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.Nil(t, err)
 		})
 	})
 }

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -353,7 +353,7 @@ type WebsiteConfigurationResponse struct {
 type DeleteObjectEntry struct {
 	Key       string  `xml:"Key"`
 	VersionId *string `xml:"VersionId"`
-	IfMatch   *string `xml:"IfMatch"`
+	ETag      *string `xml:"ETag"`
 }
 
 type DeleteObjectsRequest struct {
@@ -517,6 +517,8 @@ func handleError(err error, w http.ResponseWriter, r *http.Request) {
 		statusCode = 413
 	case storage.ErrPreconditionFailed:
 		statusCode = 412
+	case storage.ErrNotModified:
+		statusCode = 304
 	default:
 		slog.Error(fmt.Sprintf("Unhandled internal error: %v", err))
 		statusCode = 500
@@ -970,8 +972,30 @@ func (s *Server) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("Head object", "bucket", bucketName.String(), "key", key.String())
-	object, err := s.storage.HeadObject(ctx, bucketName, key)
+
+	var headOpts *storage.HeadObjectOptions
+	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
+	ifNoneMatch := getHeaderAsPtr(r.Header, ifNoneMatchHeader)
+	if ifMatch != nil || ifNoneMatch != nil {
+		headOpts = &storage.HeadObjectOptions{}
+		if ifMatch != nil {
+			headOpts.IfMatchETag = ifMatch
+		}
+		if ifNoneMatch != nil {
+			headOpts.IfNoneMatchETag = ifNoneMatch
+		}
+	}
+
+	object, err := s.storage.HeadObject(ctx, bucketName, key, headOpts)
 	if err != nil {
+		if err == storage.ErrNotModified {
+			w.WriteHeader(304)
+			return
+		}
+		if err == storage.ErrPreconditionFailed {
+			w.WriteHeader(412)
+			return
+		}
 		handleError(err, w, r)
 		return
 	}
@@ -1187,10 +1211,27 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var getOpts *storage.GetObjectOptions
+	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
+	ifNoneMatch := getHeaderAsPtr(r.Header, ifNoneMatchHeader)
+	if ifMatch != nil || ifNoneMatch != nil {
+		getOpts = &storage.GetObjectOptions{}
+		if ifMatch != nil {
+			getOpts.IfMatchETag = ifMatch
+		}
+		if ifNoneMatch != nil {
+			getOpts.IfNoneMatchETag = ifNoneMatch
+		}
+	}
+
 	// GetObject now returns metadata and readers in a single transaction
 	// It also validates the ranges and returns ErrInvalidRange if invalid
-	object, readers, err := s.storage.GetObject(ctx, bucketName, key, storageRanges)
+	object, readers, err := s.storage.GetObject(ctx, bucketName, key, storageRanges, getOpts)
 	if err != nil {
+		if err == storage.ErrNotModified {
+			w.WriteHeader(304)
+			return
+		}
 		handleError(err, w, r)
 		return
 	}
@@ -1738,9 +1779,9 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	// We track the original string key alongside the parsed ObjectKey so we can
 	// build the response even when validation fails.
 	type validEntry struct {
-		rawKey  string
-		key     storage.ObjectKey
-		ifMatch *string
+		rawKey string
+		key    storage.ObjectKey
+		etag   *string
 	}
 	validEntries := make([]validEntry, 0, len(req.Objects))
 
@@ -1764,14 +1805,14 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key, ifMatch: obj.IfMatch})
+		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key, etag: obj.ETag})
 	}
 
 	// Second pass: bulk delete all valid entries in one storage call.
 	if len(validEntries) > 0 {
 		inputEntries := make([]storage.DeleteObjectsInputEntry, len(validEntries))
 		for i, ve := range validEntries {
-			inputEntries[i] = storage.DeleteObjectsInputEntry{Key: ve.key, IfMatchETag: ve.ifMatch}
+			inputEntries[i] = storage.DeleteObjectsInputEntry{Key: ve.key, IfMatchETag: ve.etag}
 		}
 
 		slog.Info("DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(inputEntries))
@@ -2032,7 +2073,7 @@ func (s *Server) serveWebsiteGetObject(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("Website: getting object", "bucket", bucketName.String(), "key", resolvedKey)
 
-	object, readers, err := s.storage.GetObject(ctx, bucketName, objectKey, nil)
+	object, readers, err := s.storage.GetObject(ctx, bucketName, objectKey, nil, nil)
 	if err != nil {
 		if err == storage.ErrNoSuchKey {
 			s.serveErrorDocument(w, r, bucketName, websiteConfig, http.StatusNotFound, "NoSuchKey",
@@ -2082,7 +2123,7 @@ func (s *Server) serveWebsiteHeadObject(w http.ResponseWriter, r *http.Request) 
 
 	slog.Info("Website: head object", "bucket", bucketName.String(), "key", resolvedKey)
 
-	object, err := s.storage.HeadObject(ctx, bucketName, objectKey)
+	object, err := s.storage.HeadObject(ctx, bucketName, objectKey, nil)
 	if err != nil {
 		if err == storage.ErrNoSuchKey {
 			s.serveErrorDocument(w, r, bucketName, websiteConfig, http.StatusNotFound, "NoSuchKey",
@@ -2125,7 +2166,7 @@ func (s *Server) serveErrorDocument(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	object, readers, err := s.storage.GetObject(ctx, bucketName, errorKey, nil)
+	object, readers, err := s.storage.GetObject(ctx, bucketName, errorKey, nil, nil)
 	if err != nil {
 		// Error document not found — fall back to default HTML error
 		s.writeHTMLError(w, statusCode, code, message)

--- a/internal/storage/benchmark/benchmark.go
+++ b/internal/storage/benchmark/benchmark.go
@@ -148,7 +148,7 @@ func benchmarkDownloadSpeedForSize(ctx context.Context, st storage.Storage, buck
 			return 0, err
 		}
 
-		_, readers, err := st.GetObject(ctx, bucketName, key, nil)
+		_, readers, err := st.GetObject(ctx, bucketName, key, nil, nil)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -109,18 +109,18 @@ func (cs *CacheStorage) ListObjects(ctx context.Context, bucketName storage.Buck
 	return objects, nil
 }
 
-func (cs *CacheStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (cs *CacheStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.HeadObject")
 	defer span.End()
 
-	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key)
+	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key, opts)
 	if err != nil {
 		return nil, err
 	}
 	return object, nil
 }
 
-func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.GetObject")
 	defer span.End()
 
@@ -130,7 +130,7 @@ func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.Bucket
 	}
 
 	// Get object metadata
-	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key)
+	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -143,7 +143,7 @@ func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.Bucket
 
 	if err == ErrCacheMiss {
 		// @TODO: only cache byteRange that was requested
-		_, readers, err := cs.innerStorage.GetObject(ctx, bucketName, key, nil)
+		_, readers, err := cs.innerStorage.GetObject(ctx, bucketName, key, nil, opts)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -322,7 +322,7 @@ func (mbs *metadataPartStorage) ListObjects(ctx context.Context, bucketName stor
 	return &listBucketResult, nil
 }
 
-func (mbs *metadataPartStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (mbs *metadataPartStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.HeadObject")
 	defer span.End()
 
@@ -335,6 +335,21 @@ func (mbs *metadataPartStorage) HeadObject(ctx context.Context, bucketName stora
 	if err != nil {
 		tx.Rollback()
 		return nil, err
+	}
+
+	if opts != nil {
+		if opts.IfMatchETag != nil {
+			if *opts.IfMatchETag != storage.ETagWildcard && mObject.ETag != *opts.IfMatchETag {
+				tx.Rollback()
+				return nil, storage.ErrPreconditionFailed
+			}
+		}
+		if opts.IfNoneMatchETag != nil {
+			if *opts.IfNoneMatchETag == storage.ETagWildcard || mObject.ETag == *opts.IfNoneMatchETag {
+				tx.Rollback()
+				return nil, storage.ErrNotModified
+			}
+		}
 	}
 
 	err = tx.Commit()
@@ -442,7 +457,7 @@ func (mbs *metadataPartStorage) createRangeReader(ctx context.Context, tx *sql.T
 	return reader, nil
 }
 
-func (mbs *metadataPartStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (mbs *metadataPartStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.GetObject")
 	defer span.End()
 
@@ -455,6 +470,19 @@ func (mbs *metadataPartStorage) GetObject(ctx context.Context, bucketName storag
 	object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if opts != nil {
+		if opts.IfMatchETag != nil {
+			if *opts.IfMatchETag != storage.ETagWildcard && object.ETag != *opts.IfMatchETag {
+				return nil, nil, storage.ErrPreconditionFailed
+			}
+		}
+		if opts.IfNoneMatchETag != nil {
+			if *opts.IfNoneMatchETag == storage.ETagWildcard || object.ETag == *opts.IfNoneMatchETag {
+				return nil, nil, storage.ErrNotModified
+			}
+		}
 	}
 
 	// Default to full object if no ranges specified

--- a/internal/storage/metadatapart/metadatapart_test.go
+++ b/internal/storage/metadatapart/metadatapart_test.go
@@ -209,7 +209,7 @@ func TestConditionalDeleteObject_MatchingETag(t *testing.T) {
 	require.NoError(t, err)
 
 	// Object should be gone.
-	_, err = st.HeadObject(ctx, bucket, key)
+	_, err = st.HeadObject(ctx, bucket, key, nil)
 	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
 }
 
@@ -231,7 +231,7 @@ func TestConditionalDeleteObject_WrongETag(t *testing.T) {
 	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
 
 	// Object should still exist.
-	_, err = st.HeadObject(ctx, bucket, key)
+	_, err = st.HeadObject(ctx, bucket, key, nil)
 	require.NoError(t, err)
 }
 
@@ -309,11 +309,11 @@ func TestConditionalDeleteObjects_MixedConditions(t *testing.T) {
 	assert.True(t, byKey["obj3"].Deleted, "obj3 should be deleted (no condition)")
 
 	// Verify obj1 and obj3 are gone, obj2 still exists.
-	_, err = st.HeadObject(ctx, bucket, key1)
+	_, err = st.HeadObject(ctx, bucket, key1, nil)
 	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
-	_, err = st.HeadObject(ctx, bucket, key2)
+	_, err = st.HeadObject(ctx, bucket, key2, nil)
 	require.NoError(t, err)
-	_, err = st.HeadObject(ctx, bucket, key3)
+	_, err = st.HeadObject(ctx, bucket, key3, nil)
 	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
 }
 
@@ -335,7 +335,7 @@ func TestConditionalDeleteObject_WildcardMatchExistingObject(t *testing.T) {
 	require.NoError(t, err)
 
 	// Object should be gone.
-	_, err = st.HeadObject(ctx, bucket, key)
+	_, err = st.HeadObject(ctx, bucket, key, nil)
 	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
 }
 

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -176,6 +176,7 @@ var ErrUploadWithInvalidSequenceNumber error = errors.New("UploadWithInvalidSequ
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrEntityTooLarge error = errors.New("EntityTooLarge")
 var ErrPreconditionFailed error = errors.New("PreconditionFailed")
+var ErrNotModified error = errors.New("NotModified")
 var ErrNoSuchWebsiteConfiguration error = errors.New("NoSuchWebsiteConfiguration")
 
 type ListObjectsOptions struct {

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -201,16 +201,16 @@ func (m *AuditLogMiddleware) ListObjects(ctx context.Context, bucketName storage
 	return res, err
 }
 
-func (m *AuditLogMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (m *AuditLogMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
-	obj, err := m.next.HeadObject(ctx, bucketName, key)
+	obj, err := m.next.HeadObject(ctx, bucketName, key, opts)
 	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
 	return obj, err
 }
 
-func (m *AuditLogMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (m *AuditLogMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
-	obj, readers, err := m.next.GetObject(ctx, bucketName, key, ranges)
+	obj, readers, err := m.next.GetObject(ctx, bucketName, key, ranges, opts)
 	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
 	return obj, readers, err
 }

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -131,20 +131,20 @@ func (csm *conditionalStorageMiddleware) ListObjects(ctx context.Context, bucket
 	return storage.ListObjects(ctx, bucketName, opts)
 }
 
-func (csm *conditionalStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (csm *conditionalStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.HeadObject")
 	defer span.End()
 
 	storage := csm.lookupStorage(bucketName)
-	return storage.HeadObject(ctx, bucketName, key)
+	return storage.HeadObject(ctx, bucketName, key, opts)
 }
 
-func (csm *conditionalStorageMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (csm *conditionalStorageMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.GetObject")
 	defer span.End()
 
 	storage := csm.lookupStorage(bucketName)
-	return storage.GetObject(ctx, bucketName, key, ranges)
+	return storage.GetObject(ctx, bucketName, key, ranges, opts)
 }
 
 func (csm *conditionalStorageMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -315,11 +315,11 @@ func (psm *prometheusStorageMiddleware) ListObjects(ctx context.Context, bucketN
 	return mListBucketResult, nil
 }
 
-func (psm *prometheusStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (psm *prometheusStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.HeadObject")
 	defer span.End()
 
-	mObject, err := psm.innerStorage.HeadObject(ctx, bucketName, key)
+	mObject, err := psm.innerStorage.HeadObject(ctx, bucketName, key, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "HeadObject"}).Inc()
 		return nil, err
@@ -330,11 +330,11 @@ func (psm *prometheusStorageMiddleware) HeadObject(ctx context.Context, bucketNa
 	return mObject, nil
 }
 
-func (psm *prometheusStorageMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (psm *prometheusStorageMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.GetObject")
 	defer span.End()
 
-	object, readers, err := psm.innerStorage.GetObject(ctx, bucketName, key, ranges)
+	object, readers, err := psm.innerStorage.GetObject(ctx, bucketName, key, ranges, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "GetObject"}).Inc()
 		return nil, nil, err

--- a/internal/storage/migrator/migrator.go
+++ b/internal/storage/migrator/migrator.go
@@ -106,7 +106,7 @@ func migrateObjectsOfBucketFromSourceStorageToDestinationStorage(ctx context.Con
 }
 
 func migrateSingleObject(ctx context.Context, source, destination storage.Storage, bucketName storage.BucketName, sourceObject storage.Object) error {
-	_, readers, err := source.GetObject(ctx, bucketName, sourceObject.Key, nil)
+	_, readers, err := source.GetObject(ctx, bucketName, sourceObject.Key, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/migrator/migrator_test.go
+++ b/internal/storage/migrator/migrator_test.go
@@ -143,7 +143,7 @@ func TestStorageMigrator(t *testing.T) {
 	buckets, err := storage2.ListBuckets(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, bucketName, buckets[0].Name)
-	_, readers, err := storage2.GetObject(ctx, bucketName, objectKey, nil)
+	_, readers, err := storage2.GetObject(ctx, bucketName, objectKey, nil, nil)
 	assert.Nil(t, err)
 	assert.True(t, len(readers) > 0)
 	reader := readers[0]

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -362,7 +362,7 @@ func (os *outboxStorage) ListObjects(ctx context.Context, bucketName storage.Buc
 	return os.innerStorage.ListObjects(ctx, bucketName, opts)
 }
 
-func (os *outboxStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (os *outboxStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.HeadObject")
 	defer span.End()
 
@@ -371,10 +371,10 @@ func (os *outboxStorage) HeadObject(ctx context.Context, bucketName storage.Buck
 		return nil, err
 	}
 
-	return os.innerStorage.HeadObject(ctx, bucketName, key)
+	return os.innerStorage.HeadObject(ctx, bucketName, key, opts)
 }
 
-func (os *outboxStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (os *outboxStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.GetObject")
 	defer span.End()
 
@@ -383,7 +383,7 @@ func (os *outboxStorage) GetObject(ctx context.Context, bucketName storage.Bucke
 		return nil, nil, err
 	}
 
-	return os.innerStorage.GetObject(ctx, bucketName, key, ranges)
+	return os.innerStorage.GetObject(ctx, bucketName, key, ranges, opts)
 }
 
 const chunkSize = 256 * 1000 * 1000 // 256MB

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -131,18 +131,18 @@ func (rs *replicationStorage) ListObjects(ctx context.Context, bucketName storag
 	return rs.primaryStorage.ListObjects(ctx, bucketName, opts)
 }
 
-func (rs *replicationStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (rs *replicationStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.HeadObject")
 	defer span.End()
 
-	return rs.primaryStorage.HeadObject(ctx, bucketName, key)
+	return rs.primaryStorage.HeadObject(ctx, bucketName, key, opts)
 }
 
-func (rs *replicationStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (rs *replicationStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.GetObject")
 	defer span.End()
 
-	return rs.primaryStorage.GetObject(ctx, bucketName, key, ranges)
+	return rs.primaryStorage.GetObject(ctx, bucketName, key, ranges, opts)
 }
 
 func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -160,7 +160,7 @@ func (rs *s3ClientStorage) ListObjects(ctx context.Context, bucketName storage.B
 	}, nil
 }
 
-func (rs *s3ClientStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) (*storage.Object, error) {
+func (rs *s3ClientStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.HeadObject")
 	defer span.End()
 
@@ -189,7 +189,7 @@ func (rs *s3ClientStorage) HeadObject(ctx context.Context, bucketName storage.Bu
 	}, nil
 }
 
-func (rs *s3ClientStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange) (*storage.Object, []io.ReadCloser, error) {
+func (rs *s3ClientStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.GetObject")
 	defer span.End()
 
@@ -199,7 +199,7 @@ func (rs *s3ClientStorage) GetObject(ctx context.Context, bucketName storage.Buc
 	}
 
 	// First, get object metadata
-	object, err := rs.HeadObject(ctx, bucketName, key)
+	object, err := rs.HeadObject(ctx, bucketName, key, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -73,6 +73,32 @@ type DeleteObjectOptions struct {
 	IfMatchETag *string
 }
 
+// HeadObjectOptions holds conditional request options for HeadObject.
+// ETag values must be bare hex strings (without surrounding quotes).
+type HeadObjectOptions struct {
+	// IfMatchETag, when non-nil, requires the stored object's ETag to match;
+	// otherwise ErrPreconditionFailed is returned.
+	// The special value "*" matches any existing object.
+	IfMatchETag *string
+	// IfNoneMatchETag, when non-nil, requires the stored object's ETag to differ;
+	// otherwise ErrNotModified is returned.
+	// The special value "*" matches any existing object.
+	IfNoneMatchETag *string
+}
+
+// GetObjectOptions holds conditional request options for GetObject.
+// ETag values must be bare hex strings (without surrounding quotes).
+type GetObjectOptions struct {
+	// IfMatchETag, when non-nil, requires the stored object's ETag to match;
+	// otherwise ErrPreconditionFailed is returned.
+	// The special value "*" matches any existing object.
+	IfMatchETag *string
+	// IfNoneMatchETag, when non-nil, requires the stored object's ETag to differ;
+	// otherwise ErrNotModified is returned.
+	// The special value "*" matches any existing object.
+	IfNoneMatchETag *string
+}
+
 type InitiateMultipartUploadResult struct {
 	UploadId UploadId
 }
@@ -186,6 +212,7 @@ var ErrBadDigest error = metadatastore.ErrBadDigest
 var ErrNotImplemented error = metadatastore.ErrNotImplemented
 var ErrEntityTooLarge error = metadatastore.ErrEntityTooLarge
 var ErrPreconditionFailed error = metadatastore.ErrPreconditionFailed
+var ErrNotModified error = metadatastore.ErrNotModified
 var ErrInvalidBucketName error = metadatastore.ErrInvalidBucketName
 var ErrInvalidObjectKey error = metadatastore.ErrInvalidObjectKey
 var ErrInvalidUploadId error = metadatastore.ErrInvalidUploadId
@@ -247,12 +274,12 @@ type BucketWebsiteManager interface {
 // ObjectManager manages object operations
 type ObjectManager interface {
 	ListObjects(ctx context.Context, bucketName BucketName, opts ListObjectsOptions) (*ListBucketResult, error)
-	HeadObject(ctx context.Context, bucketName BucketName, key ObjectKey) (*Object, error)
+	HeadObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *HeadObjectOptions) (*Object, error)
 	// GetObject retrieves an object with optional byte ranges.
 	// If ranges is empty or nil, returns the entire object as a single reader.
 	// All operations are performed in a single transaction to ensure consistency.
 	// Returns the object metadata, a list of readers (one per range), and an error.
-	GetObject(ctx context.Context, bucketName BucketName, key ObjectKey, ranges []ByteRange) (*Object, []io.ReadCloser, error)
+	GetObject(ctx context.Context, bucketName BucketName, key ObjectKey, ranges []ByteRange, opts *GetObjectOptions) (*Object, []io.ReadCloser, error)
 	PutObject(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, data io.Reader, checksumInput *ChecksumInput, opts *PutObjectOptions) (*PutObjectResult, error)
 	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
 	DeleteObjects(ctx context.Context, bucketName BucketName, entries []DeleteObjectsInputEntry) (*DeleteObjectsResult, error)
@@ -341,7 +368,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return err
 		}
 
-		object, err := storage.HeadObject(ctx, bucketName, key)
+		object, err := storage.HeadObject(ctx, bucketName, key, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Add HeadObjectOptions and GetObjectOptions with IfMatchETag/IfNoneMatchETag fields to the ObjectManager interface
- Enforce ETag conditions inside the storage read transaction in metadatapart (optimistic locking)
- Return ErrPreconditionFailed (412) or ErrNotModified (304) from the storage layer; map in HTTP handlers
- Fix DeleteObjectEntry XML tag from <IfMatch> to <ETag> to match AWS SDK serialization; rename IfMatch/ifMatch fields to ETag/etag throughout
- Add integration tests for all 8 conditional cases across GetObject, HeadObject, DeleteObject and DeleteObjects

closes #501 