### PR TITLE
feat(storage): implement conditional CompleteMultipartUpload with atomic optimistic locking

### DIFF
--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -1405,6 +1405,33 @@ func (s *Server) completeMultipartUploadHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Conditional multipart upload: check If-Match and If-None-Match headers.
+	// AWS S3 compatible behaviour:
+	//   If-Match: <etag>  — the current object at the key must have this ETag, else 412.
+	//   If-Match: *       — any existing object satisfies the condition; fail (412) only when no object exists.
+	//   If-None-Match: *  — the operation must fail (412) when any object already exists at the key.
+	//   Both headers together are not allowed (400).
+	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
+	ifNoneMatch := getHeaderAsPtr(r.Header, ifNoneMatchHeader)
+	var completeOpts *storage.CompleteMultipartUploadOptions
+	if ifMatch != nil {
+		completeOpts = &storage.CompleteMultipartUploadOptions{IfMatchETag: ifMatch}
+	}
+	if ifNoneMatch != nil {
+		if *ifNoneMatch != "*" {
+			handleError(ErrInvalidRequest, w, r)
+			return
+		}
+		if completeOpts == nil {
+			completeOpts = &storage.CompleteMultipartUploadOptions{}
+		}
+		completeOpts.IfNoneMatchStar = true
+	}
+	if completeOpts != nil && completeOpts.IfMatchETag != nil && completeOpts.IfNoneMatchStar {
+		handleError(ErrInvalidRequest, w, r)
+		return
+	}
+
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		handleError(err, w, r)
@@ -1421,7 +1448,7 @@ func (s *Server) completeMultipartUploadHandler(w http.ResponseWriter, r *http.R
 	}
 
 	slog.Info("CompleteMultipartUpload", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String())
-	result, err := s.storage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	result, err := s.storage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, completeOpts)
 	if err != nil {
 		handleError(err, w, r)
 		return

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -275,11 +275,11 @@ func (cs *CacheStorage) UploadPart(ctx context.Context, bucketName storage.Bucke
 	return uploadPartResult, nil
 }
 
-func (cs *CacheStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (cs *CacheStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.CompleteMultipartUpload")
 	defer span.End()
 
-	completeMultipartUploadResult, err := cs.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	completeMultipartUploadResult, err := cs.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -857,7 +857,7 @@ func convertCompleteMultipartUploadResult(result metadatastore.CompleteMultipart
 	}
 }
 
-func (mbs *metadataPartStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (mbs *metadataPartStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.CompleteMultipartUpload")
 	defer span.End()
 
@@ -868,7 +868,7 @@ func (mbs *metadataPartStorage) CompleteMultipartUpload(ctx context.Context, buc
 		return nil, err
 	}
 
-	result, err := mbs.metadataStore.CompleteMultipartUpload(ctx, tx, bucketName, key, uploadId, checksumInput)
+	result, err := mbs.metadataStore.CompleteMultipartUpload(ctx, tx, bucketName, key, uploadId, checksumInput, opts)
 	if err != nil {
 		tx.Rollback()
 		return nil, err

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -217,6 +217,20 @@ type DeleteObjectOptions struct {
 	IfMatchETag *string
 }
 
+// CompleteMultipartUploadOptions holds conditional request options for CompleteMultipartUpload.
+// AWS S3 behaviour: If-Match is checked against the ETag of the *current* object at the key
+// (before it is replaced). If-None-Match "*" prevents the upload from completing when any
+// object already exists at the key.
+type CompleteMultipartUploadOptions struct {
+	// IfMatchETag, when non-nil, requires the currently stored object's ETag to equal
+	// this value; otherwise ErrPreconditionFailed is returned.
+	// The special value "*" matches any existing object.
+	IfMatchETag *string
+	// IfNoneMatchStar, when true, requires that no object currently exists at the key;
+	// otherwise ErrPreconditionFailed is returned (HTTP 412).
+	IfNoneMatchStar bool
+}
+
 type MaintenanceStore interface {
 	GetInUsePartIds(ctx context.Context, tx *sql.Tx) ([]partstore.PartId, error)
 }
@@ -249,7 +263,7 @@ type ObjectStore interface {
 type MultipartStore interface {
 	CreateMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, contentType *string, checksumType *string) (*InitiateMultipartUploadResult, error)
 	UploadPart(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, uploadId UploadId, partNumber int32, part Part) error
-	CompleteMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, uploadId UploadId, checksumInput *ChecksumInput) (*CompleteMultipartUploadResult, error)
+	CompleteMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, uploadId UploadId, checksumInput *ChecksumInput, opts *CompleteMultipartUploadOptions) (*CompleteMultipartUploadResult, error)
 	AbortMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, uploadId UploadId) (*AbortMultipartResult, error)
 	ListMultipartUploads(ctx context.Context, tx *sql.Tx, bucketName BucketName, opts ListMultipartUploadsOptions) (*ListMultipartUploadsResult, error)
 	ListParts(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, uploadId UploadId, opts ListPartsOptions) (*ListPartsResult, error)
@@ -420,7 +434,7 @@ func Tester(metadataStore MetadataStore, db database.Database) error {
 	if err != nil {
 		return err
 	}
-	_, err = metadataStore.CompleteMultipartUpload(ctx, tx, bucketName, key, initiateMultipartUploadResult.UploadId, nil)
+	_, err = metadataStore.CompleteMultipartUpload(ctx, tx, bucketName, key, initiateMultipartUploadResult.UploadId, nil, nil)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -3,10 +3,13 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jdillenkofer/pithos/internal/checksumutils"
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/ptrutils"
@@ -17,9 +20,25 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/database/repository/part"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// isUniqueConstraintViolation reports whether err is a unique-constraint
+// violation from either the PostgreSQL (pgconn.PgError / SQLSTATE 23505) or
+// SQLite (sqlite3.ErrConstraintUnique) driver.
+func isUniqueConstraintViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgerrcode.UniqueViolation
+	}
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique
+	}
+	return false
+}
 
 type sqlMetadataStore struct {
 	*lifecycle.ValidatedLifecycle
@@ -603,7 +622,7 @@ func (sms *sqlMetadataStore) UploadPart(ctx context.Context, tx *sql.Tx, bucketN
 	return nil
 }
 
-func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, uploadId metadatastore.UploadId, checksumInput *metadatastore.ChecksumInput) (*metadatastore.CompleteMultipartUploadResult, error) {
+func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, uploadId metadatastore.UploadId, checksumInput *metadatastore.ChecksumInput, opts *metadatastore.CompleteMultipartUploadOptions) (*metadatastore.CompleteMultipartUploadResult, error) {
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.CompleteMultipartUpload")
 	defer span.End()
 
@@ -671,6 +690,32 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 	if err != nil {
 		return nil, err
 	}
+
+	// Evaluate conditional headers (AWS S3 compatible behaviour):
+	//   If-Match:      the current object's ETag must match the supplied value.
+	//   If-None-Match: "*" means the operation must fail when any object exists.
+	if opts != nil {
+		if opts.IfMatchETag != nil {
+			// If-Match: * — any existing object satisfies the condition; fail when absent.
+			// If-Match: <etag> — existing ETag must match exactly; fail otherwise.
+			if *opts.IfMatchETag == metadatastore.ETagWildcard {
+				if oldObjectEntity == nil {
+					return nil, metadatastore.ErrPreconditionFailed
+				}
+			} else {
+				if oldObjectEntity == nil || oldObjectEntity.ETag != *opts.IfMatchETag {
+					return nil, metadatastore.ErrPreconditionFailed
+				}
+			}
+		}
+		if opts.IfNoneMatchStar {
+			// If-None-Match: * — fail when any object currently exists at the key.
+			if oldObjectEntity != nil {
+				return nil, metadatastore.ErrPreconditionFailed
+			}
+		}
+	}
+
 	if oldObjectEntity != nil {
 		oldPartEntities, err := sms.partRepository.FindPartsByObjectIdOrderBySequenceNumberAsc(ctx, tx, *oldObjectEntity.Id)
 		if err != nil {
@@ -695,9 +740,23 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 			}
 		}, oldPartEntities)
 
-		_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
-		if err != nil {
-			return nil, err
+		// Optimistic locking: when If-Match was supplied with an exact ETag,
+		// use an atomic DELETE WHERE id=$1 AND etag=$2 as the final guard.
+		// A zero rows-affected result means a concurrent writer already changed
+		// the object between our read and this delete, so we abort with 412.
+		if opts != nil && opts.IfMatchETag != nil && *opts.IfMatchETag != metadatastore.ETagWildcard {
+			deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *oldObjectEntity.Id, *opts.IfMatchETag)
+			if err != nil {
+				return nil, err
+			}
+			if !*deleted {
+				return nil, metadatastore.ErrPreconditionFailed
+			}
+		} else {
+			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -711,9 +770,27 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 	objectEntity.ChecksumSHA1 = calculatedChecksums.ChecksumSHA1
 	objectEntity.ChecksumSHA256 = calculatedChecksums.ChecksumSHA256
 	objectEntity.ChecksumType = ptrutils.ToPtr(checksumType)
-	err = sms.objectRepository.SaveObject(ctx, tx, objectEntity)
-	if err != nil {
-		return nil, err
+
+	if opts != nil && opts.IfNoneMatchStar {
+		// Optimistic locking: attempt to UPDATE the pending row to COMPLETED.
+		// If a concurrent transaction has already committed a completed object at
+		// this (bucket_name, key) the partial unique index
+		// objects_completed_unique will fire a unique-constraint violation, which
+		// we catch here and convert to ErrPreconditionFailed (412).
+		// This is atomic: the database enforces the constraint at write time
+		// regardless of the isolation level's snapshot visibility.
+		err = sms.objectRepository.SaveObject(ctx, tx, objectEntity)
+		if err != nil {
+			if isUniqueConstraintViolation(err) {
+				return nil, metadatastore.ErrPreconditionFailed
+			}
+			return nil, err
+		}
+	} else {
+		err = sms.objectRepository.SaveObject(ctx, tx, objectEntity)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &metadatastore.CompleteMultipartUploadResult{

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -254,9 +254,9 @@ func (m *AuditLogMiddleware) UploadPart(ctx context.Context, bucketName storage.
 	return res, err
 }
 
-func (m *AuditLogMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (m *AuditLogMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil)
-	res, err := m.next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	res, err := m.next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err)
 	return res, err
 }

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -187,12 +187,12 @@ func (csm *conditionalStorageMiddleware) UploadPart(ctx context.Context, bucketN
 	return storage.UploadPart(ctx, bucketName, key, uploadId, partNumber, reader, checksumInput)
 }
 
-func (csm *conditionalStorageMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (csm *conditionalStorageMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.CompleteMultipartUpload")
 	defer span.End()
 
 	storage := csm.lookupStorage(bucketName)
-	return storage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	return storage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 }
 
 func (csm *conditionalStorageMiddleware) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -437,11 +437,11 @@ func (psm *prometheusStorageMiddleware) UploadPart(ctx context.Context, bucketNa
 	return uploadPartResult, nil
 }
 
-func (psm *prometheusStorageMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (psm *prometheusStorageMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.CompleteMultipartUpload")
 	defer span.End()
 
-	completeMultipartUploadResult, err := psm.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	completeMultipartUploadResult, err := psm.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "CompleteMultipartUpload"}).Inc()
 		return nil, err

--- a/internal/storage/migrator/migrator.go
+++ b/internal/storage/migrator/migrator.go
@@ -190,7 +190,7 @@ func (a *StorageToS3UploadAPIClientAdapter) UploadPart(ctx context.Context, inpu
 }
 
 func (a *StorageToS3UploadAPIClientAdapter) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteMultipartUploadInput, opts ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error) {
-	result, err := a.storage.CompleteMultipartUpload(ctx, storage.MustNewBucketName(*input.Bucket), storage.MustNewObjectKey(*input.Key), storage.MustNewUploadId(*input.UploadId), nil)
+	result, err := a.storage.CompleteMultipartUpload(ctx, storage.MustNewBucketName(*input.Bucket), storage.MustNewObjectKey(*input.Key), storage.MustNewUploadId(*input.UploadId), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -537,7 +537,7 @@ func (os *outboxStorage) UploadPart(ctx context.Context, bucketName storage.Buck
 	return os.innerStorage.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
 }
 
-func (os *outboxStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (os *outboxStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.CompleteMultipartUpload")
 	defer span.End()
 
@@ -546,7 +546,7 @@ func (os *outboxStorage) CompleteMultipartUpload(ctx context.Context, bucketName
 		return nil, err
 	}
 
-	return os.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	return os.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 }
 
 func (os *outboxStorage) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -267,18 +267,18 @@ func (rs *replicationStorage) UploadPart(ctx context.Context, bucketName storage
 	return uploadPartResult, nil
 }
 
-func (rs *replicationStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (rs *replicationStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.CompleteMultipartUpload")
 	defer span.End()
 
-	completeMultipartUploadResult, err := rs.primaryStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput)
+	completeMultipartUploadResult, err := rs.primaryStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
 	rs.mapMutex.Lock()
 	secondaryUploadIds := rs.primaryUploadIdToSecondaryUploadIds[uploadId]
 	for i, secondaryStorage := range rs.secondaryStorages {
-		_, err := secondaryStorage.CompleteMultipartUpload(ctx, bucketName, key, secondaryUploadIds[i], checksumInput)
+		_, err := secondaryStorage.CompleteMultipartUpload(ctx, bucketName, key, secondaryUploadIds[i], checksumInput, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -422,7 +422,7 @@ func (rs *s3ClientStorage) UploadPart(ctx context.Context, bucketName storage.Bu
 	}, nil
 }
 
-func (rs *s3ClientStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput) (*storage.CompleteMultipartUploadResult, error) {
+func (rs *s3ClientStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.CompleteMultipartUpload")
 	defer span.End()
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -65,6 +65,8 @@ type PutObjectOptions struct {
 	IfMatchETag     *string
 }
 
+type CompleteMultipartUploadOptions = metadatastore.CompleteMultipartUploadOptions
+
 type DeleteObjectOptions struct {
 	// IfMatchETag, when non-nil, requires the stored object's ETag to equal this
 	// value before deleting; otherwise ErrPreconditionFailed is returned.
@@ -289,7 +291,7 @@ type ObjectManager interface {
 type MultipartUploadManager interface {
 	CreateMultipartUpload(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, checksumType *string) (*InitiateMultipartUploadResult, error)
 	UploadPart(ctx context.Context, bucketName BucketName, key ObjectKey, uploadId UploadId, partNumber int32, data io.Reader, checksumInput *ChecksumInput) (*UploadPartResult, error)
-	CompleteMultipartUpload(ctx context.Context, bucketName BucketName, key ObjectKey, uploadId UploadId, checksumInput *ChecksumInput) (*CompleteMultipartUploadResult, error)
+	CompleteMultipartUpload(ctx context.Context, bucketName BucketName, key ObjectKey, uploadId UploadId, checksumInput *ChecksumInput, opts *CompleteMultipartUploadOptions) (*CompleteMultipartUploadResult, error)
 	AbortMultipartUpload(ctx context.Context, bucketName BucketName, key ObjectKey, uploadId UploadId) error
 	ListMultipartUploads(ctx context.Context, bucketName BucketName, opts ListMultipartUploadsOptions) (*ListMultipartUploadsResult, error)
 	ListParts(ctx context.Context, bucketName BucketName, key ObjectKey, uploadId UploadId, opts ListPartsOptions) (*ListPartsResult, error)
@@ -412,7 +414,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return err
 		}
 
-		_, err = storage.CompleteMultipartUpload(ctx, bucketName, key, initiateMultipartUploadResult.UploadId, nil)
+		_, err = storage.CompleteMultipartUpload(ctx, bucketName, key, initiateMultipartUploadResult.UploadId, nil, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add If-Match and If-None-Match conditional header support to CompleteMultipartUpload, matching AWS S3 behaviour. If-Match with an exact ETag uses an atomic DELETE WHERE etag=$2 as the final guard. If-None-Match: * relies on the existing objects_completed_unique partial index to produce a unique constraint violation when a concurrent writer commits first, which is caught and converted to ErrPreconditionFailed (412).

Closes #645, closes #646 