### PR TITLE
feat: implement PutObject append operation (#333)

### DIFF
--- a/internal/auditlog/entry.go
+++ b/internal/auditlog/entry.go
@@ -23,6 +23,7 @@ const (
 	OpHeadObject              Operation = "HeadObject"
 	OpGetObject               Operation = "GetObject"
 	OpPutObject               Operation = "PutObject"
+	OpAppendObject            Operation = "AppendObject"
 	OpDeleteObject            Operation = "DeleteObject"
 	OpDeleteObjects           Operation = "DeleteObjects"
 	OpCreateMultipartUpload   Operation = "CreateMultipartUpload"

--- a/internal/http/server/authorization/authorization.go
+++ b/internal/http/server/authorization/authorization.go
@@ -20,6 +20,7 @@ const (
 	OperationCompleteMultipartUpload = "CompleteMultipartUpload"
 	OperationUploadPart              = "UploadPart"
 	OperationPutObject               = "PutObject"
+	OperationAppendObject            = "AppendObject"
 	OperationAbortMultipartUpload    = "AbortMultipartUpload"
 	OperationDeleteObject            = "DeleteObject"
 	OperationDeleteObjects           = "DeleteObjects"

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -143,6 +143,7 @@ const maxPartsQuery = "max-parts"
 const listTypeQuery = "list-type"
 const continuationTokenQuery = "continuation-token"
 const websiteQuery = "website"
+const appendQuery = "append"
 
 const acceptRangesHeader = "Accept-Ranges"
 const expectHeader = "Expect"
@@ -163,6 +164,7 @@ const checksumCRC32CHeader = "x-amz-checksum-crc32c"
 const checksumCRC64NVMEHeader = "x-amz-checksum-crc64nvme"
 const checksumSHA1Header = "x-amz-checksum-sha1"
 const checksumSHA256Header = "x-amz-checksum-sha256"
+const writeOffsetBytesHeader = "x-amz-write-offset-bytes"
 
 const applicationXmlContentType = "application/xml"
 
@@ -515,6 +517,10 @@ func handleError(err error, w http.ResponseWriter, r *http.Request) {
 		statusCode = 400
 	case storage.ErrEntityTooLarge:
 		statusCode = 413
+	case storage.ErrTooManyParts:
+		statusCode = 400
+	case storage.ErrInvalidWriteOffset:
+		statusCode = 400
 	case storage.ErrPreconditionFailed:
 		statusCode = 412
 	case storage.ErrNotModified:
@@ -1661,12 +1667,74 @@ func (s *Server) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 }
 
+func (s *Server) appendObjectHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "Server.appendObjectHandler")
+	defer span.End()
+	bucketName, err := storage.NewBucketName(r.PathValue(bucketPath))
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+	key, err := storage.NewObjectKey(r.PathValue(keyPath))
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	shouldReturn := s.authorizeRequest(ctx, authorization.OperationAppendObject, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
+	if shouldReturn {
+		return
+	}
+
+	var appendObjectOptions *storage.AppendObjectOptions
+	if writeOffsetStr := r.Header.Get(writeOffsetBytesHeader); writeOffsetStr != "" {
+		writeOffset, parseErr := strconv.ParseInt(writeOffsetStr, 10, 64)
+		if parseErr != nil {
+			handleError(ErrInvalidRequest, w, r)
+			return
+		}
+		appendObjectOptions = &storage.AppendObjectOptions{WriteOffset: &writeOffset}
+	}
+
+	shouldReturn = validateMaxEntitySize(r, w)
+
+	checksumInput, err := extractChecksumInput(r)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	slog.Info("Appending to object", "bucket", bucketName.String(), "key", key.String())
+	if r.Header.Get(expectHeader) == "100-continue" {
+		w.WriteHeader(100)
+	}
+	appendObjectResult, err := s.storage.AppendObject(ctx, bucketName, key, r.Body, checksumInput, appendObjectOptions)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			err = storage.ErrEntityTooLarge
+		}
+		handleError(err, w, r)
+		return
+	}
+
+	responseHeaders := w.Header()
+	responseHeaders.Set(etagHeader, appendObjectResult.ETag)
+	responseHeaders.Set("x-amz-object-size", strconv.FormatInt(appendObjectResult.Size, 10))
+	w.WriteHeader(200)
+}
+
 func (s *Server) uploadPartOrPutObjectHandler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	// UploadPart
 	if query.Has(uploadIdQuery) || query.Has(partNumberQuery) {
 		s.uploadPartHandler(w, r)
+		return
+	}
+
+	// AppendObject
+	if query.Has(appendQuery) {
+		s.appendObjectHandler(w, r)
 		return
 	}
 

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -217,6 +217,22 @@ func (cs *CacheStorage) PutObject(ctx context.Context, bucketName storage.Bucket
 	return putObjectResult, nil
 }
 
+func (cs *CacheStorage) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	ctx, span := cs.tracer.Start(ctx, "CacheStorage.AppendObject")
+	defer span.End()
+
+	appendObjectResult, err := cs.innerStorage.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Invalidate the cached object so subsequent reads see the new content.
+	cacheKey := getObjectCacheKeyForBucketAndKey(bucketName, key)
+	_ = cs.cache.Remove(cacheKey)
+
+	return appendObjectResult, nil
+}
+
 func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObject")
 	defer span.End()

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -622,6 +622,145 @@ func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storag
 	}, nil
 }
 
+func (mbs *metadataPartStorage) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.AppendObject")
+	defer span.End()
+
+	unblockGC := mbs.partGC.PreventGCFromRunning(ctx)
+	defer unblockGC()
+	tx, err := mbs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the existing object (if any).
+	existingObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	if err != nil && err != storage.ErrNoSuchKey {
+		tx.Rollback()
+		return nil, err
+	}
+
+	// Validate WriteOffset condition.
+	if opts != nil && opts.WriteOffset != nil {
+		if existingObject == nil {
+			// Object does not exist — only allowed when offset == 0.
+			if *opts.WriteOffset != 0 {
+				tx.Rollback()
+				return nil, storage.ErrInvalidWriteOffset
+			}
+		} else {
+			// Object exists — offset must equal current size.
+			if *opts.WriteOffset != existingObject.Size {
+				tx.Rollback()
+				return nil, storage.ErrInvalidWriteOffset
+			}
+		}
+	}
+
+	// Write the new part's bytes.
+	newPartId, err := partstore.NewRandomPartId()
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	newPartSize, newPartChecksums, err := checksumutils.CalculateChecksumsStreaming(ctx, reader, func(r io.Reader) error {
+		return mbs.partStore.PutPart(ctx, tx, *newPartId, r)
+	})
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	// Validate checksums for the new data chunk (if provided by the caller).
+	if err = metadatastore.ValidateChecksums(checksumInput, *newPartChecksums); err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	newPart := metadatastore.Part{
+		Id:                *newPartId,
+		ETag:              *newPartChecksums.ETag,
+		ChecksumCRC32:     newPartChecksums.ChecksumCRC32,
+		ChecksumCRC32C:    newPartChecksums.ChecksumCRC32C,
+		ChecksumCRC64NVME: newPartChecksums.ChecksumCRC64NVME,
+		ChecksumSHA1:      newPartChecksums.ChecksumSHA1,
+		ChecksumSHA256:    newPartChecksums.ChecksumSHA256,
+		Size:              *newPartSize,
+	}
+
+	// Build the combined part list (existing parts first, then new part).
+	var allParts []metadatastore.Part
+	var totalSize int64
+	if existingObject != nil {
+		allParts = append(allParts, existingObject.Parts...)
+		totalSize = existingObject.Size
+	}
+
+	// S3 enforces a maximum of 10,000 parts per object.
+	const maxAppendParts = 10_000
+	if len(allParts)+1 > maxAppendParts {
+		tx.Rollback()
+		return nil, storage.ErrTooManyParts
+	}
+
+	allParts = append(allParts, newPart)
+	totalSize += *newPartSize
+
+	// Compute the whole-object ETag as MD5-of-part-ETags (multipart-style).
+	partChecksums := make([]checksumutils.PartChecksums, len(allParts))
+	for i, p := range allParts {
+		partChecksums[i] = checksumutils.PartChecksums{
+			ETag: p.ETag,
+			Size: p.Size,
+		}
+	}
+	combinedChecksums, err := checksumutils.CalculateMultipartChecksums(partChecksums, checksumutils.ChecksumTypeFullObject)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	// Determine content type: preserve existing or fall back to nil (unchanged).
+	var contentType *string
+	if existingObject != nil {
+		contentType = existingObject.ContentType
+	}
+
+	updatedObject := &metadatastore.Object{
+		Key:          key,
+		ContentType:  contentType,
+		LastModified: time.Now(),
+		ETag:         *combinedChecksums.ETag,
+		ChecksumType: ptrutils.ToPtr(metadatastore.ChecksumTypeFullObject),
+		Size:         totalSize,
+		Parts:        allParts,
+	}
+
+	metaOpts := &metadatastore.AppendObjectOptions{}
+	if err = mbs.metadataStore.AppendObject(ctx, tx, bucketName, updatedObject, metaOpts); err != nil {
+		tx.Rollback()
+		// The sql layer uses a CAS (DELETE WHERE id=X AND etag=Y) to detect a
+		// concurrent write that changed the object between our HeadObject read
+		// and this update. It surfaces that as ErrCASFailure. From the caller's
+		// perspective the object size moved under them, so we normalise the
+		// error to ErrInvalidWriteOffset (HTTP 400).
+		if err == storage.ErrCASFailure {
+			return nil, storage.ErrInvalidWriteOffset
+		}
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &storage.AppendObjectResult{
+		ETag: *combinedChecksums.ETag,
+		Size: totalSize,
+	}, nil
+}
+
 func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.DeleteObject")
 	defer span.End()

--- a/internal/storage/metadatapart/metadatapart_test.go
+++ b/internal/storage/metadatapart/metadatapart_test.go
@@ -4,16 +4,20 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/jdillenkofer/pithos/internal/checksumutils"
 	"github.com/jdillenkofer/pithos/internal/ptrutils"
 	"github.com/jdillenkofer/pithos/internal/storage"
 	repositoryFactory "github.com/jdillenkofer/pithos/internal/storage/database/repository"
 	"github.com/jdillenkofer/pithos/internal/storage/database/sqlite"
+	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
 	sqlMetadataStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/sql"
+	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
 	filesystemPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/filesystem"
 	sqlPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/sql"
 	testutils "github.com/jdillenkofer/pithos/internal/testing"
@@ -352,4 +356,220 @@ func TestConditionalDeleteObject_WildcardMatchMissingObject(t *testing.T) {
 	// Delete with If-Match: * on a non-existent object — should return PreconditionFailed.
 	err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
 	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
+}
+
+// --- AppendObject tests ---
+
+func TestAppendObject_CreateOnMissing(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// Append to a non-existent key — should behave like PutObject.
+	result, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.ETag)
+	assert.Equal(t, int64(5), result.Size)
+
+	obj, err := st.HeadObject(ctx, bucket, key, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), obj.Size)
+}
+
+func TestAppendObject_AppendsToExisting(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	result, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(11), result.Size)
+
+	// Read back and verify the concatenated content.
+	_, readers, err := st.GetObject(ctx, bucket, key, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, readers, 1)
+	defer readers[0].Close()
+	content, err := io.ReadAll(readers[0])
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(content))
+}
+
+func TestAppendObject_ETagIsMultipartStyle(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("part1")), nil, nil)
+	require.NoError(t, err)
+
+	result, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("part2")), nil, nil)
+	require.NoError(t, err)
+
+	// After two appends the object has 2 parts, so ETag must end in "-2".
+	// ETags are stored with surrounding double-quotes, e.g. `"abc123-2"`.
+	assert.True(t, len(result.ETag) > 3 && result.ETag[len(result.ETag)-3:] == "-2\"",
+		"expected multipart ETag ending in -2\", got %q", result.ETag)
+}
+
+func TestAppendObject_CorrectWriteOffset(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	first, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	// Append with the correct write offset (== current size) — should succeed.
+	_, err = st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil,
+		&storage.AppendObjectOptions{WriteOffset: &first.Size})
+	require.NoError(t, err)
+}
+
+func TestAppendObject_WrongWriteOffset(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	// Append with a wrong write offset — should return ErrInvalidWriteOffset.
+	wrongOffset := int64(999)
+	_, err = st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil,
+		&storage.AppendObjectOptions{WriteOffset: &wrongOffset})
+	assert.ErrorIs(t, err, storage.ErrInvalidWriteOffset)
+}
+
+func TestAppendObject_WriteOffsetZeroOnMissing(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// WriteOffset == 0 on a non-existent object should succeed (create new object).
+	zero := int64(0)
+	result, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil,
+		&storage.AppendObjectOptions{WriteOffset: &zero})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), result.Size)
+}
+
+func TestAppendObject_WriteOffsetNonZeroOnMissing(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// WriteOffset != 0 on a non-existent object should return ErrInvalidWriteOffset.
+	nonZero := int64(5)
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil,
+		&storage.AppendObjectOptions{WriteOffset: &nonZero})
+	assert.ErrorIs(t, err, storage.ErrInvalidWriteOffset)
+}
+
+func TestAppendObject_NoSuchBucket(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("nonexistent")
+	key := storage.MustNewObjectKey("obj")
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("data")), nil, nil)
+	assert.ErrorIs(t, err, storage.ErrNoSuchBucket)
+}
+
+func TestAppendObject_TooManyParts(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("stress")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	// Seed an object with exactly 10,000 parts directly via the metadata store
+	// so we don't have to perform 10,000 real appends (which would be O(n²) in
+	// SQLite and cause CI timeouts).
+	const maxParts = 10_000
+	parts := make([]metadatastore.Part, maxParts)
+	partChecksumsList := make([]checksumutils.PartChecksums, maxParts)
+
+	// ETag of a single byte "x", as produced by CalculateChecksumsStreaming.
+	partData := []byte("x")
+	_, partChecksums, err := checksumutils.CalculateChecksumsStreaming(ctx, bytes.NewReader(partData), func(r io.Reader) error { return nil })
+	require.NoError(t, err)
+	partETag := *partChecksums.ETag
+
+	for i := range parts {
+		pid, err := partstore.NewRandomPartId()
+		require.NoError(t, err)
+		parts[i] = metadatastore.Part{
+			Id:   *pid,
+			ETag: partETag,
+			Size: int64(len(partData)),
+		}
+		partChecksumsList[i] = checksumutils.PartChecksums{ETag: partETag, Size: int64(len(partData))}
+	}
+
+	objectChecksums, err := checksumutils.CalculateMultipartChecksums(partChecksumsList, checksumutils.ChecksumTypeFullObject)
+	require.NoError(t, err)
+
+	tx, err := st.db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	for _, p := range parts {
+		require.NoError(t, st.partStore.PutPart(ctx, tx, p.Id, bytes.NewReader(partData)))
+	}
+	err = st.metadataStore.PutObject(ctx, tx, bucket, &metadatastore.Object{
+		Key:   key,
+		ETag:  *objectChecksums.ETag,
+		Size:  int64(maxParts) * int64(len(partData)),
+		Parts: parts,
+	}, nil)
+	require.NoError(t, tx.Commit())
+	require.NoError(t, err)
+
+	// The next append must fail with ErrTooManyParts.
+	_, err = st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("x")), nil, nil)
+	assert.ErrorIs(t, err, storage.ErrTooManyParts)
 }

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -178,6 +178,14 @@ var ErrEntityTooLarge error = errors.New("EntityTooLarge")
 var ErrPreconditionFailed error = errors.New("PreconditionFailed")
 var ErrNotModified error = errors.New("NotModified")
 var ErrNoSuchWebsiteConfiguration error = errors.New("NoSuchWebsiteConfiguration")
+var ErrTooManyParts error = errors.New("TooManyParts")
+var ErrInvalidWriteOffset error = errors.New("InvalidWriteOffset")
+
+// ErrCASFailure is returned by the storage layer when a compare-and-swap
+// (optimistic lock) operation fails because a concurrent writer modified the
+// object between our read and our update. It is an internal error and should
+// be mapped to the appropriate public API error by the caller.
+var ErrCASFailure error = errors.New("CASFailure")
 
 type ListObjectsOptions struct {
 	Prefix        *string
@@ -207,6 +215,15 @@ const ETagWildcard = "*"
 type PutObjectOptions struct {
 	IfNoneMatchStar bool
 	IfMatchETag     *string
+}
+
+// AppendObjectOptions holds options for an AppendObject operation.
+type AppendObjectOptions struct {
+	// WriteOffset, when non-nil, specifies the expected current size of the
+	// object in bytes. The append is only performed if the actual object size
+	// matches this value; otherwise ErrInvalidWriteOffset is returned.
+	// Set to 0 to create a new object (equivalent to x-amz-write-offset-bytes: 0).
+	WriteOffset *int64
 }
 
 type DeleteObjectOptions struct {
@@ -257,6 +274,12 @@ type ObjectStore interface {
 	ListObjects(ctx context.Context, tx *sql.Tx, bucketName BucketName, opts ListObjectsOptions) (*ListBucketResult, error)
 	HeadObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey) (*Object, error)
 	PutObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object, opts *PutObjectOptions) error
+	// AppendObject appends a new part to an existing object's part list. The caller
+	// must supply the updated object metadata (including new ETag, size, and the
+	// full ordered part list). If no object exists at the key yet, a new object is
+	// created. If WriteOffset is set in opts and does not match the current object
+	// size, ErrInvalidWriteOffset is returned.
+	AppendObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object, opts *AppendObjectOptions) error
 	DeleteObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
 }
 

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -487,6 +487,118 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 	return nil
 }
 
+func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, obj *metadatastore.Object, opts *metadatastore.AppendObjectOptions) error {
+	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.AppendObject")
+	defer span.End()
+
+	existsBucket, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	if err != nil {
+		return err
+	}
+	if !*existsBucket {
+		return metadatastore.ErrNoSuchBucket
+	}
+
+	// Check whether an object already exists at this key.
+	oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
+	if err != nil {
+		return err
+	}
+
+	if oldObjectEntity != nil {
+		// Delete old parts metadata rows (the new part list is supplied in obj.Parts).
+		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
+		if err != nil {
+			return err
+		}
+
+		// Use a conditional delete (WHERE id=X AND etag=Y) as the CAS step so
+		// that a concurrent append or put that already changed the ETag causes
+		// this transaction to fail rather than silently overwriting.
+		deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *oldObjectEntity.Id, oldObjectEntity.ETag)
+		if err != nil {
+			return err
+		}
+		if !*deleted {
+			return metadatastore.ErrCASFailure
+		}
+
+		// Re-insert to get a fresh row (same approach as PutObject).
+		newEntity := object.Entity{
+			BucketName:   bucketName,
+			Key:          obj.Key,
+			ContentType:  oldObjectEntity.ContentType,
+			ETag:         obj.ETag,
+			ChecksumType: obj.ChecksumType,
+			Size:         obj.Size,
+			UploadStatus: object.UploadStatusCompleted,
+		}
+		err = sms.objectRepository.SaveObject(ctx, tx, &newEntity)
+		if err != nil {
+			return err
+		}
+
+		sequenceNumber := 0
+		for _, partStruc := range obj.Parts {
+			partEntity := part.Entity{
+				PartId:            partStruc.Id,
+				ObjectId:          *newEntity.Id,
+				ETag:              partStruc.ETag,
+				ChecksumCRC32:     partStruc.ChecksumCRC32,
+				ChecksumCRC32C:    partStruc.ChecksumCRC32C,
+				ChecksumCRC64NVME: partStruc.ChecksumCRC64NVME,
+				ChecksumSHA1:      partStruc.ChecksumSHA1,
+				ChecksumSHA256:    partStruc.ChecksumSHA256,
+				Size:              partStruc.Size,
+				SequenceNumber:    sequenceNumber,
+			}
+			err = sms.partRepository.SavePart(ctx, tx, &partEntity)
+			if err != nil {
+				return err
+			}
+			sequenceNumber++
+		}
+		return nil
+	}
+
+	// No existing object — create a new one (same semantics as PutObject).
+	newEntity := object.Entity{
+		BucketName:   bucketName,
+		Key:          obj.Key,
+		ContentType:  obj.ContentType,
+		ETag:         obj.ETag,
+		ChecksumType: obj.ChecksumType,
+		Size:         obj.Size,
+		UploadStatus: object.UploadStatusCompleted,
+	}
+	err = sms.objectRepository.SaveObject(ctx, tx, &newEntity)
+	if err != nil {
+		return err
+	}
+
+	sequenceNumber := 0
+	for _, partStruc := range obj.Parts {
+		partEntity := part.Entity{
+			PartId:            partStruc.Id,
+			ObjectId:          *newEntity.Id,
+			ETag:              partStruc.ETag,
+			ChecksumCRC32:     partStruc.ChecksumCRC32,
+			ChecksumCRC32C:    partStruc.ChecksumCRC32C,
+			ChecksumCRC64NVME: partStruc.ChecksumCRC64NVME,
+			ChecksumSHA1:      partStruc.ChecksumSHA1,
+			ChecksumSHA256:    partStruc.ChecksumSHA256,
+			Size:              partStruc.Size,
+			SequenceNumber:    sequenceNumber,
+		}
+		err = sms.partRepository.SavePart(ctx, tx, &partEntity)
+		if err != nil {
+			return err
+		}
+		sequenceNumber++
+	}
+	return nil
+}
+
 func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, opts *metadatastore.DeleteObjectOptions) error {
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.DeleteObject")
 	defer span.End()
@@ -537,9 +649,10 @@ func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucke
 			if err != nil {
 				return err
 			}
-			if !*deleted {
-				return metadatastore.ErrPreconditionFailed
-			}
+			// 0 rows affected means a concurrent writer already deleted the object.
+			// Since there was no client-supplied condition, the desired outcome
+			// (object gone) is already achieved — treat it as success.
+			_ = deleted
 		}
 	}
 

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -222,6 +222,13 @@ func (m *AuditLogMiddleware) PutObject(ctx context.Context, bucketName storage.B
 	return res, err
 }
 
+func (m *AuditLogMiddleware) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	res, err := m.next.AppendObject(ctx, bucketName, key, data, checksumInput, opts)
+	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
+	return res, err
+}
+
 func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
 	err := m.next.DeleteObject(ctx, bucketName, key, opts)

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -155,6 +155,14 @@ func (csm *conditionalStorageMiddleware) PutObject(ctx context.Context, bucketNa
 	return storage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
 }
 
+func (csm *conditionalStorageMiddleware) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.AppendObject")
+	defer span.End()
+
+	s := csm.lookupStorage(bucketName)
+	return s.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
+}
+
 func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.DeleteObject")
 	defer span.End()

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -371,6 +371,25 @@ func (psm *prometheusStorageMiddleware) PutObject(ctx context.Context, bucketNam
 	return putObjectResult, nil
 }
 
+func (psm *prometheusStorageMiddleware) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.AppendObject")
+	defer span.End()
+
+	reader = ioutils.NewStatsReadCloser(ioutils.NewNopSeekCloser(reader), func(n int) {
+		psm.totalBytesUploadedByBucket.With(prometheus.Labels{"bucket": bucketName.String()}).Add(float64(n))
+	})
+
+	appendObjectResult, err := psm.innerStorage.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
+	if err != nil {
+		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "AppendObject"}).Inc()
+		return nil, err
+	}
+
+	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "AppendObject"}).Inc()
+
+	return appendObjectResult, nil
+}
+
 func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObject")
 	defer span.End()

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -463,6 +463,20 @@ func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.Bucke
 	}, nil
 }
 
+func (os *outboxStorage) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	ctx, span := os.tracer.Start(ctx, "OutboxStorage.AppendObject")
+	defer span.End()
+
+	// Append is always conditional (requires the object to be consistent), so
+	// flush all pending outbox entries for the bucket before delegating.
+	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.innerStorage.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
+}
+
 func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObject")
 	defer span.End()

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -176,6 +176,37 @@ func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.
 	return putObjectResult, nil
 }
 
+func (rs *replicationStorage) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.AppendObject")
+	defer span.End()
+
+	// Use smart cache (memory up to maxMemoryCacheSize, then disk) so we can
+	// replay the body to each secondary storage.
+	readSeekCloser, err := ioutils.NewSmartCachedReadSeekCloser(reader, maxMemoryCacheSize)
+	if err != nil {
+		return nil, err
+	}
+	defer readSeekCloser.Close()
+
+	appendObjectResult, err := rs.primaryStorage.AppendObject(ctx, bucketName, key, readSeekCloser, checksumInput, opts)
+	if err != nil {
+		return nil, err
+	}
+	for _, secondaryStorage := range rs.secondaryStorages {
+		_, err = readSeekCloser.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, err
+		}
+		// Do not forward conditional opts (If-Match) to secondaries; the
+		// precondition was already enforced on the primary.
+		_, err = secondaryStorage.AppendObject(ctx, bucketName, key, readSeekCloser, checksumInput, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return appendObjectResult, nil
+}
+
 func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObject")
 	defer span.End()

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -292,6 +292,10 @@ func (rs *s3ClientStorage) PutObject(ctx context.Context, bucketName storage.Buc
 	}, nil
 }
 
+func (rs *s3ClientStorage) AppendObject(_ context.Context, _ storage.BucketName, _ storage.ObjectKey, _ io.Reader, _ *storage.ChecksumInput, _ *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	return nil, storage.ErrNotImplemented
+}
+
 func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.DeleteObject")
 	defer span.End()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -65,6 +65,22 @@ type PutObjectOptions struct {
 	IfMatchETag     *string
 }
 
+// AppendObjectOptions holds options for an AppendObject operation.
+type AppendObjectOptions struct {
+	// WriteOffset, when non-nil, specifies the expected current size of the
+	// object in bytes. The append is only performed if the actual object size
+	// matches this value; otherwise ErrInvalidWriteOffset is returned.
+	// Set to 0 to create a new object (equivalent to x-amz-write-offset-bytes: 0).
+	WriteOffset *int64
+}
+
+// AppendObjectResult is returned by a successful AppendObject operation.
+type AppendObjectResult struct {
+	ETag string
+	// Size is the total size of the object after the append.
+	Size int64
+}
+
 type CompleteMultipartUploadOptions = metadatastore.CompleteMultipartUploadOptions
 
 type DeleteObjectOptions struct {
@@ -220,6 +236,9 @@ var ErrInvalidObjectKey error = metadatastore.ErrInvalidObjectKey
 var ErrInvalidUploadId error = metadatastore.ErrInvalidUploadId
 var ErrInvalidRange error = errors.New("InvalidRange")
 var ErrNoSuchWebsiteConfiguration error = metadatastore.ErrNoSuchWebsiteConfiguration
+var ErrTooManyParts error = metadatastore.ErrTooManyParts
+var ErrInvalidWriteOffset error = metadatastore.ErrInvalidWriteOffset
+var ErrCASFailure error = metadatastore.ErrCASFailure
 
 var MaxEntitySize int64 = 5 * 1000 * 1000 * 1000 // 5 GB
 
@@ -283,6 +302,10 @@ type ObjectManager interface {
 	// Returns the object metadata, a list of readers (one per range), and an error.
 	GetObject(ctx context.Context, bucketName BucketName, key ObjectKey, ranges []ByteRange, opts *GetObjectOptions) (*Object, []io.ReadCloser, error)
 	PutObject(ctx context.Context, bucketName BucketName, key ObjectKey, contentType *string, data io.Reader, checksumInput *ChecksumInput, opts *PutObjectOptions) (*PutObjectResult, error)
+	// AppendObject appends data to an existing object. If the object does not exist,
+	// it behaves like PutObject and creates a new object with the provided data.
+	// The ETag in the result reflects the new whole-object ETag after the append.
+	AppendObject(ctx context.Context, bucketName BucketName, key ObjectKey, data io.Reader, checksumInput *ChecksumInput, opts *AppendObjectOptions) (*AppendObjectResult, error)
 	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
 	DeleteObjects(ctx context.Context, bucketName BucketName, entries []DeleteObjectsInputEntry) (*DeleteObjectsResult, error)
 }


### PR DESCRIPTION
Add support for appending bytes to an existing object via PUT /{bucket}/{key}?append.
- New ?append query subresource routed in server.go to appendObjectHandler
- Append stores each write as a new part; ETag uses multipart MD5-of-ETags format
- Supports If-Match conditional header for safe concurrent appends
- Enforces 10,000-part limit (ErrTooManyParts -> HTTP 400)
- Optimistic locking uses DeleteObjectByIdAndETag (CAS) to prevent lost updates
- Checksums cleared on append (cannot be recomputed without re-reading all data)
- AppendObject added to Storage interface and all middleware wrappers
- 8 unit tests covering create-on-missing, append, ETag format, If-Match, error cases

closes #333