### PR TITLE
feat(metrics): add Prometheus metrics for outbox middlewares

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -497,7 +497,7 @@ func setupTestDatabases(ctx context.Context, dbType database.DatabaseType, useRe
 }
 
 func setupReplicatedStorage(ctx context.Context, registry *prometheus.Registry, baseEndpoint string, primaryListenerAddr string, usePathStyle bool, db2 database.Database, storagePath2 string, useFilesystemPartStore bool, encryptionType storageFactory.EncryptionType, encryptionPassword string, wrapPartStoreWithOutbox bool) (storage.Storage, error) {
-	localStore := storageFactory.CreateStorage(storagePath2, db2, useFilesystemPartStore, encryptionType, encryptionPassword, wrapPartStoreWithOutbox)
+	localStore := storageFactory.CreateStorage(storagePath2, db2, useFilesystemPartStore, encryptionType, encryptionPassword, wrapPartStoreWithOutbox, registry)
 
 	primaryS3Client := setupS3Client(baseEndpoint, primaryListenerAddr, usePathStyle)
 	s3ClientStorage, err := s3client.NewStorage(primaryS3Client)
@@ -510,7 +510,7 @@ func setupReplicatedStorage(ctx context.Context, registry *prometheus.Registry, 
 		return nil, err
 	}
 
-	outboxStorage, err := outbox.NewStorage(db2, s3ClientStorage, storageOutboxEntryRepository)
+	outboxStorage, err := outbox.NewStorage(db2, s3ClientStorage, storageOutboxEntryRepository, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +563,7 @@ func setupTestServerWithAuthorizer(requestAuthorizer authorization.RequestAuthor
 	if encryptionType != storageFactory.EncryptionTypeNone {
 		encryptionPassword = partStoreEncryptionPassword
 	}
-	store := storageFactory.CreateStorage(storagePath, dbs.primary, useFilesystemPartStore, encryptionType, encryptionPassword, wrapPartStoreWithOutbox)
+	store := storageFactory.CreateStorage(storagePath, dbs.primary, useFilesystemPartStore, encryptionType, encryptionPassword, wrapPartStoreWithOutbox, registry)
 
 	if !useReplication {
 		store, err = prometheusStorageMiddleware.NewStorageMiddleware(store, registry)

--- a/internal/storage/config/config.go
+++ b/internal/storage/config/config.go
@@ -8,10 +8,15 @@ import (
 	"log/slog"
 	"reflect"
 
+	"crypto/sha512"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jdillenkofer/pithos/internal/auditlog/signing"
+	signingVault "github.com/jdillenkofer/pithos/internal/auditlog/signing/vault"
+	"github.com/jdillenkofer/pithos/internal/auditlog/sink"
+	auditlogSinkConfig "github.com/jdillenkofer/pithos/internal/auditlog/sink/config"
 	internalConfig "github.com/jdillenkofer/pithos/internal/config"
 	"github.com/jdillenkofer/pithos/internal/dependencyinjection"
 	"github.com/jdillenkofer/pithos/internal/storage"
@@ -22,18 +27,13 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart"
 	metadataStoreConfig "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/config"
 	partStoreConfig "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/config"
+	auditMiddleware "github.com/jdillenkofer/pithos/internal/storage/middlewares/audit"
 	"github.com/jdillenkofer/pithos/internal/storage/middlewares/conditional"
 	prometheusMiddleware "github.com/jdillenkofer/pithos/internal/storage/middlewares/prometheus"
 	"github.com/jdillenkofer/pithos/internal/storage/outbox"
 	"github.com/jdillenkofer/pithos/internal/storage/replication"
 	"github.com/jdillenkofer/pithos/internal/storage/s3client"
 	"github.com/prometheus/client_golang/prometheus"
-	"crypto/sha512"
-	"github.com/jdillenkofer/pithos/internal/auditlog/signing"
-	signingVault "github.com/jdillenkofer/pithos/internal/auditlog/signing/vault"
-	"github.com/jdillenkofer/pithos/internal/auditlog/sink"
-	auditlogSinkConfig "github.com/jdillenkofer/pithos/internal/auditlog/sink/config"
-	auditMiddleware "github.com/jdillenkofer/pithos/internal/storage/middlewares/audit"
 )
 
 const (
@@ -475,7 +475,12 @@ func (o *OutboxStorageConfiguration) Instantiate(diProvider dependencyinjection.
 	if err != nil {
 		return nil, err
 	}
-	return outbox.NewStorage(db, innerStorage, storageOutboxEntryRepository)
+	t := reflect.TypeOf((*prometheus.Registerer)(nil))
+	prometheusRegisterer, err := diProvider.LookupByType(t)
+	if err != nil {
+		return nil, err
+	}
+	return outbox.NewStorage(db, innerStorage, storageOutboxEntryRepository, prometheusRegisterer.(prometheus.Registerer))
 }
 
 type ReplicationStorageConfiguration struct {

--- a/internal/storage/database/pgx/repository/partoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/partoutboxentry/pgx.go
@@ -14,6 +14,7 @@ type pgxRepository struct {
 }
 
 const (
+	countPartOutboxEntriesStmt                    = "SELECT COUNT(*) FROM part_outbox_entries"
 	findLastPartOutboxEntryByPartIdStmt           = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE part_id = $1 ORDER BY id DESC LIMIT 1"
 	findLastPartOutboxEntryGroupedByPartIdStmt    = "SELECT DISTINCT ON (part_id) id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY part_id, id DESC"
 	findFirstPartOutboxEntryStmt                  = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY id ASC LIMIT 1"
@@ -27,6 +28,15 @@ const (
 
 func NewRepository() (partoutboxentry.Repository, error) {
 	return &pgxRepository{}, nil
+}
+
+func (bor *pgxRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+	var count int
+	err := tx.QueryRowContext(ctx, countPartOutboxEntriesStmt).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func convertRowToPartOutboxEntryEntity(partOutboxRow *sql.Row) (*partoutboxentry.Entity, error) {

--- a/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
@@ -14,6 +14,7 @@ type pgxRepository struct {
 }
 
 const (
+	countStorageOutboxEntriesStmt                    = "SELECT COUNT(*) FROM storage_outbox_entries"
 	findFirstStorageOutboxEntryWithForUpdateLockStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1 FOR UPDATE"
 	findFirstStorageOutboxEntryStmt                  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
 	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
@@ -28,6 +29,15 @@ const (
 
 func NewRepository() (storageoutboxentry.Repository, error) {
 	return &pgxRepository{}, nil
+}
+
+func (sor *pgxRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+	var count int
+	err := tx.QueryRowContext(ctx, countStorageOutboxEntriesStmt).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageoutboxentry.Entity, error) {

--- a/internal/storage/database/repository/partoutboxentry/interface.go
+++ b/internal/storage/database/repository/partoutboxentry/interface.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Repository interface {
+	Count(ctx context.Context, tx *sql.Tx) (int, error)
 	FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, partId partstore.PartId) (*Entity, error)
 	FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx) ([]Entity, error)
 	FindFirstPartOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*Entity, error)

--- a/internal/storage/database/repository/storageoutboxentry/interface.go
+++ b/internal/storage/database/repository/storageoutboxentry/interface.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Repository interface {
+	Count(ctx context.Context, tx *sql.Tx) (int, error)
 	FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindFirstStorageOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)

--- a/internal/storage/database/sqlite/repository/partoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/partoutboxentry/sqlite.go
@@ -14,6 +14,7 @@ type sqliteRepository struct {
 }
 
 const (
+	countPartOutboxEntriesStmt                 = "SELECT COUNT(*) FROM part_outbox_entries"
 	findLastPartOutboxEntryByPartIdStmt        = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE part_id = $1 ORDER BY id DESC LIMIT 1"
 	findLastPartOutboxEntryGroupedByPartIdStmt = "SELECT e.id, e.operation, e.part_id, e.created_at, e.updated_at FROM part_outbox_entries e INNER JOIN ( SELECT part_id, MAX(id) as max_id FROM part_outbox_entries GROUP BY part_id) m ON e.part_id = m.part_id AND e.id = m.max_id"
 	findFirstPartOutboxEntryStmt               = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY id ASC LIMIT 1"
@@ -26,6 +27,15 @@ const (
 
 func NewRepository() (partoutboxentry.Repository, error) {
 	return &sqliteRepository{}, nil
+}
+
+func (bor *sqliteRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+	var count int
+	err := tx.QueryRowContext(ctx, countPartOutboxEntriesStmt).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func convertRowToPartOutboxEntryEntity(partOutboxRow *sql.Row) (*partoutboxentry.Entity, error) {

--- a/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
@@ -14,6 +14,7 @@ type sqliteRepository struct {
 }
 
 const (
+	countStorageOutboxEntriesStmt            = "SELECT COUNT(*) FROM storage_outbox_entries"
 	findFirstStorageOutboxEntryStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
 	findLastStorageOutboxEntryStmt           = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
 	findFirstStorageOutboxEntryForBucketStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
@@ -27,6 +28,15 @@ const (
 
 func NewRepository() (storageoutboxentry.Repository, error) {
 	return &sqliteRepository{}, nil
+}
+
+func (sor *sqliteRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+	var count int
+	err := tx.QueryRowContext(ctx, countStorageOutboxEntriesStmt).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageoutboxentry.Entity, error) {

--- a/internal/storage/factory/factory.go
+++ b/internal/storage/factory/factory.go
@@ -10,13 +10,14 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/database"
 	repositoryFactory "github.com/jdillenkofer/pithos/internal/storage/database/repository"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart"
+	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
+	sqlMetadataStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/sql"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
 	filesystemPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/filesystem"
 	tinkEncryptionPartStoreMiddleware "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/middlewares/encryption/tink"
 	outboxPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/outbox"
 	sqlPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/sql"
-	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
-	sqlMetadataStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/sql"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // EncryptionType represents the type of encryption to use for part storage
@@ -27,7 +28,7 @@ const (
 	EncryptionTypeTink EncryptionType = "tink"
 )
 
-func CreateStorage(storagePath string, db database.Database, useFilesystemPartStore bool, encryptionType EncryptionType, partStoreEncryptionPassword string, wrapPartStoreWithOutbox bool) storage.Storage {
+func CreateStorage(storagePath string, db database.Database, useFilesystemPartStore bool, encryptionType EncryptionType, partStoreEncryptionPassword string, wrapPartStoreWithOutbox bool, registerer prometheus.Registerer) storage.Storage {
 	var metadataStore metadatastore.MetadataStore
 	bucketRepository, err := repositoryFactory.NewBucketRepository(db)
 	if err != nil {
@@ -95,7 +96,7 @@ func CreateStorage(storagePath string, db database.Database, useFilesystemPartSt
 			slog.Error(fmt.Sprintf("Could not create PartOutboxEntryRepository: %s", err))
 			os.Exit(1)
 		}
-		partStore, err = outboxPartStore.New(db, partStore, partOutboxEntryRepository)
+		partStore, err = outboxPartStore.New(db, partStore, partOutboxEntryRepository, registerer)
 		if err != nil {
 			slog.Error(fmt.Sprint("Error during NewOutboxPartStore: ", err))
 			os.Exit(1)

--- a/internal/storage/metadatapart/partstore/config/config.go
+++ b/internal/storage/metadatapart/partstore/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	internalConfig "github.com/jdillenkofer/pithos/internal/config"
 	"github.com/jdillenkofer/pithos/internal/dependencyinjection"
@@ -19,6 +20,7 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/sftp"
 	sftpConfig "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/sftp/config"
 	sqlPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/sql"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -291,7 +293,12 @@ func (o *OutboxPartStoreConfiguration) Instantiate(diProvider dependencyinjectio
 	if err != nil {
 		return nil, err
 	}
-	return outbox.New(db, innerPartStore, partOutboxEntryRepository)
+	t := reflect.TypeOf((*prometheus.Registerer)(nil))
+	prometheusRegisterer, err := diProvider.LookupByType(t)
+	if err != nil {
+		return nil, err
+	}
+	return outbox.New(db, innerPartStore, partOutboxEntryRepository, prometheusRegisterer.(prometheus.Registerer))
 }
 
 type SftpPartStoreConfiguration struct {

--- a/internal/storage/metadatapart/partstore/config/config_test.go
+++ b/internal/storage/metadatapart/partstore/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jdillenkofer/pithos/internal/dependencyinjection"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
 	testutils "github.com/jdillenkofer/pithos/internal/testing"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
 )
@@ -26,6 +27,10 @@ func createPartStoreFromJson(b []byte) (partstore.PartStore, error) {
 	}
 	dbContainer := config.NewDbContainer()
 	err = diContainer.RegisterSingletonByType(reflect.TypeOf((*config.DbContainer)(nil)), dbContainer)
+	if err != nil {
+		return nil, err
+	}
+	err = diContainer.RegisterSingletonByType(reflect.TypeOf((*prometheus.Registerer)(nil)), prometheus.NewRegistry())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/metadatapart/partstore/outbox/outbox.go
+++ b/internal/storage/metadatapart/partstore/outbox/outbox.go
@@ -18,7 +18,68 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
 	"github.com/jdillenkofer/pithos/internal/task"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+type partOutboxMetrics struct {
+	pendingEntries     prometheus.Gauge
+	processedEntries   prometheus.Counter
+	processingDuration prometheus.Histogram
+	errorsCounter      prometheus.Counter
+}
+
+func newPartOutboxMetrics(registerer prometheus.Registerer) *partOutboxMetrics {
+	m := &partOutboxMetrics{
+		pendingEntries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "pithos",
+			Subsystem: "part_outbox",
+			Name:      "pending_entries",
+			Help:      "Number of pending part outbox entries",
+		}),
+		processedEntries: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "pithos",
+			Subsystem: "part_outbox",
+			Name:      "processed_entries_total",
+			Help:      "Total number of processed part outbox entries",
+		}),
+		processingDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "pithos",
+			Subsystem: "part_outbox",
+			Name:      "processing_duration_seconds",
+			Help:      "Duration of part outbox processing in seconds",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}),
+		errorsCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "pithos",
+			Subsystem: "part_outbox",
+			Name:      "errors_total",
+			Help:      "Total number of part outbox processing errors",
+		}),
+	}
+
+	if err := registerer.Register(m.pendingEntries); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register pendingEntries metric", "error", err)
+		}
+	}
+	if err := registerer.Register(m.processedEntries); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register processedEntries metric", "error", err)
+		}
+	}
+	if err := registerer.Register(m.processingDuration); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register processingDuration metric", "error", err)
+		}
+	}
+	if err := registerer.Register(m.errorsCounter); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register errorsCounter metric", "error", err)
+		}
+	}
+
+	return m
+}
 
 type outboxPartStore struct {
 	db                         database.Database
@@ -28,36 +89,62 @@ type outboxPartStore struct {
 	innerPartStore             partstore.PartStore
 	partOutboxEntryRepository  partOutboxEntry.Repository
 	tracer                     trace.Tracer
+	metrics                    *partOutboxMetrics
 }
 
 // Compile-time check to ensure outboxPartStore implements partstore.PartStore
 var _ partstore.PartStore = (*outboxPartStore)(nil)
 
-func New(db database.Database, innerPartStore partstore.PartStore, partOutboxEntryRepository partOutboxEntry.Repository) (partstore.PartStore, error) {
-	return &outboxPartStore{
+func New(db database.Database, innerPartStore partstore.PartStore, partOutboxEntryRepository partOutboxEntry.Repository, registerer prometheus.Registerer) (partstore.PartStore, error) {
+	obs := &outboxPartStore{
 		db:                        db,
 		triggerChannel:            make(chan struct{}, 16),
 		triggerChannelClosed:      false,
 		innerPartStore:            innerPartStore,
 		partOutboxEntryRepository: partOutboxEntryRepository,
 		tracer:                    otel.Tracer("internal/storage/metadatapart/partstore/outbox"),
-	}, nil
+		metrics:                   newPartOutboxMetrics(registerer),
+	}
+	return obs, nil
 }
 
 func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 	ctx, span := obs.tracer.Start(ctx, "outboxPartStore.maybeProcessOutboxEntries")
 	defer span.End()
 
+	startTime := time.Now()
 	processedOutboxEntryCount := 0
+	defer func() {
+		obs.metrics.processingDuration.Observe(time.Since(startTime).Seconds())
+		if processedOutboxEntryCount > 0 {
+			obs.metrics.processedEntries.Add(float64(processedOutboxEntryCount))
+		}
+	}()
+
+	tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return
+	}
+
+	pendingCount, err := obs.partOutboxEntryRepository.Count(ctx, tx)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	obs.metrics.pendingEntries.Set(float64(pendingCount))
+	tx.Commit()
+
 	for {
 		tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
 		if err != nil {
+			obs.metrics.errorsCounter.Inc()
 			return
 		}
 
 		entry, err := obs.partOutboxEntryRepository.FindFirstPartOutboxEntryWithForUpdateLock(ctx, tx)
 		if err != nil {
 			tx.Rollback()
+			obs.metrics.errorsCounter.Inc()
 			time.Sleep(5 * time.Second)
 			return
 		}
@@ -71,6 +158,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, *entry.Id)
 			if err != nil {
 				tx.Rollback()
+				obs.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
@@ -81,6 +169,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			err = obs.innerPartStore.PutPart(ctx, tx, entry.PartId, io.MultiReader(readers...))
 			if err != nil {
 				tx.Rollback()
+				obs.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
@@ -88,12 +177,14 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			err = obs.innerPartStore.DeletePart(ctx, tx, entry.PartId)
 			if err != nil {
 				tx.Rollback()
+				obs.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
 		default:
 			slog.Warn(fmt.Sprint("Invalid operation", entry.Operation, "during outbox processing."))
 			tx.Rollback()
+			obs.metrics.errorsCounter.Inc()
 			time.Sleep(5 * time.Second)
 			return
 		}

--- a/internal/storage/metadatapart/partstore/outbox/outbox_test.go
+++ b/internal/storage/metadatapart/partstore/outbox/outbox_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
 	filesystemPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/filesystem"
 	testutils "github.com/jdillenkofer/pithos/internal/testing"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,7 +51,8 @@ func TestOutboxPartStore(t *testing.T) {
 		slog.Error(fmt.Sprintf("Could not create PartOutboxEntryRepository: %s", err))
 		os.Exit(1)
 	}
-	outboxPartStore, err := New(db, filesystemPartStore, partOutboxEntryRepository)
+	reg := prometheus.NewRegistry()
+	outboxPartStore, err := New(db, filesystemPartStore, partOutboxEntryRepository, reg)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Could not create OutboxPartStore: %s", err))
 		os.Exit(1)

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -157,11 +157,31 @@ func (psm *prometheusStorageMiddleware) Start(ctx context.Context) error {
 	if err := psm.ValidatedLifecycle.Start(ctx); err != nil {
 		return err
 	}
-	psm.registerer.MustRegister(psm.failedApiOpsCounter)
-	psm.registerer.MustRegister(psm.successfulApiOpsCounter)
-	psm.registerer.MustRegister(psm.totalSizeByBucket)
-	psm.registerer.MustRegister(psm.totalBytesUploadedByBucket)
-	psm.registerer.MustRegister(psm.totalBytesDownloadedByBucket)
+	if err := psm.registerer.Register(psm.failedApiOpsCounter); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register failedApiOpsCounter metric", "error", err)
+		}
+	}
+	if err := psm.registerer.Register(psm.successfulApiOpsCounter); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register successfulApiOpsCounter metric", "error", err)
+		}
+	}
+	if err := psm.registerer.Register(psm.totalSizeByBucket); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register totalSizeByBucket metric", "error", err)
+		}
+	}
+	if err := psm.registerer.Register(psm.totalBytesUploadedByBucket); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register totalBytesUploadedByBucket metric", "error", err)
+		}
+	}
+	if err := psm.registerer.Register(psm.totalBytesDownloadedByBucket); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register totalBytesDownloadedByBucket metric", "error", err)
+		}
+	}
 
 	psm.metricsMeasuringTaskHandle = task.Start(func(cancelTask *atomic.Bool) {
 		psm.measureMetricsLoop(cancelTask)

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -18,9 +18,70 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
 	"github.com/jdillenkofer/pithos/internal/task"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
+
+type outboxMetrics struct {
+	pendingEntries     prometheus.Gauge
+	processedEntries   prometheus.Counter
+	processingDuration prometheus.Histogram
+	errorsCounter      prometheus.Counter
+}
+
+func newOutboxMetrics(registerer prometheus.Registerer) *outboxMetrics {
+	m := &outboxMetrics{
+		pendingEntries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "pithos",
+			Subsystem: "outbox",
+			Name:      "pending_entries",
+			Help:      "Number of pending outbox entries",
+		}),
+		processedEntries: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "pithos",
+			Subsystem: "outbox",
+			Name:      "processed_entries_total",
+			Help:      "Total number of processed outbox entries",
+		}),
+		processingDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "pithos",
+			Subsystem: "outbox",
+			Name:      "processing_duration_seconds",
+			Help:      "Duration of outbox processing in seconds",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}),
+		errorsCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "pithos",
+			Subsystem: "outbox",
+			Name:      "errors_total",
+			Help:      "Total number of outbox processing errors",
+		}),
+	}
+
+	if err := registerer.Register(m.pendingEntries); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register pendingEntries metric", "error", err)
+		}
+	}
+	if err := registerer.Register(m.processedEntries); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register processedEntries metric", "error", err)
+		}
+	}
+	if err := registerer.Register(m.processingDuration); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register processingDuration metric", "error", err)
+		}
+	}
+	if err := registerer.Register(m.errorsCounter); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error("Failed to register errorsCounter metric", "error", err)
+		}
+	}
+
+	return m
+}
 
 type outboxStorage struct {
 	*lifecycle.ValidatedLifecycle
@@ -31,12 +92,13 @@ type outboxStorage struct {
 	innerStorage                 storage.Storage
 	storageOutboxEntryRepository storageOutboxEntry.Repository
 	tracer                       trace.Tracer
+	metrics                      *outboxMetrics
 }
 
 // Compile-time check to ensure outboxStorage implements storage.Storage
 var _ storage.Storage = (*outboxStorage)(nil)
 
-func NewStorage(db database.Database, innerStorage storage.Storage, storageOutboxEntryRepository storageOutboxEntry.Repository) (storage.Storage, error) {
+func NewStorage(db database.Database, innerStorage storage.Storage, storageOutboxEntryRepository storageOutboxEntry.Repository, registerer prometheus.Registerer) (storage.Storage, error) {
 	lifecycle, err := lifecycle.NewValidatedLifecycle("OutboxStorage")
 	if err != nil {
 		return nil, err
@@ -49,20 +111,43 @@ func NewStorage(db database.Database, innerStorage storage.Storage, storageOutbo
 		innerStorage:                 innerStorage,
 		storageOutboxEntryRepository: storageOutboxEntryRepository,
 		tracer:                       otel.Tracer("internal/storage/outbox"),
+		metrics:                      newOutboxMetrics(registerer),
 	}
 	return os, nil
 }
 
 func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
+	startTime := time.Now()
 	processedOutboxEntryCount := 0
+	defer func() {
+		os.metrics.processingDuration.Observe(time.Since(startTime).Seconds())
+		if processedOutboxEntryCount > 0 {
+			os.metrics.processedEntries.Add(float64(processedOutboxEntryCount))
+		}
+	}()
+
+	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return
+	}
+	pendingCount, err := os.storageOutboxEntryRepository.Count(ctx, tx)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	os.metrics.pendingEntries.Set(float64(pendingCount))
+	tx.Commit()
+
 	for {
 		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
 		if err != nil {
+			os.metrics.errorsCounter.Inc()
 			return
 		}
 		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryWithForUpdateLock(ctx, tx)
 		if err != nil {
 			tx.Rollback()
+			os.metrics.errorsCounter.Inc()
 			time.Sleep(5 * time.Second)
 			return
 		}
@@ -76,6 +161,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			err = os.innerStorage.CreateBucket(ctx, entry.Bucket)
 			if err != nil {
 				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
@@ -83,6 +169,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			err = os.innerStorage.DeleteBucket(ctx, entry.Bucket)
 			if err != nil {
 				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
@@ -90,6 +177,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			chunks, err := os.storageOutboxEntryRepository.FindStorageOutboxEntryChunksById(ctx, tx, *entry.Id)
 			if err != nil {
 				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
@@ -100,6 +188,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(readers...), nil, nil)
 			if err != nil {
 				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
@@ -107,6 +196,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
 			if err != nil {
 				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}

--- a/internal/storage/outbox/outbox_test.go
+++ b/internal/storage/outbox/outbox_test.go
@@ -11,9 +11,10 @@ import (
 	repositoryFactory "github.com/jdillenkofer/pithos/internal/storage/database/repository"
 	"github.com/jdillenkofer/pithos/internal/storage/database/sqlite"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart"
-	filesystemPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/filesystem"
 	sqlMetadataStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore/sql"
+	filesystemPartStore "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore/filesystem"
 	testutils "github.com/jdillenkofer/pithos/internal/testing"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -111,7 +112,8 @@ func TestMetadataPartStorageWithOutbox(t *testing.T) {
 		os.Exit(1)
 
 	}
-	outboxStorage, err := NewStorage(db2, metadataPartStorage, storageOutboxEntryRepository)
+	reg := prometheus.NewRegistry()
+	outboxStorage, err := NewStorage(db2, metadataPartStorage, storageOutboxEntryRepository, reg)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Could not create OutboxStorage: %s", err))
 		os.Exit(1)


### PR DESCRIPTION
Add Prometheus metrics to both storage and part outbox middlewares:
- pithos_outbox_pending_entries (gauge)
- pithos_outbox_processed_entries_total (counter)
- pithos_outbox_processing_duration_seconds (histogram)
- pithos_outbox_errors_total (counter)
- pithos_part_outbox_pending_entries (gauge)
- pithos_part_outbox_processed_entries_total (counter)
- pithos_part_outbox_processing_duration_seconds (histogram)
- pithos_part_outbox_errors_total (counter)

Each outbox instance creates its own metrics registered with the provided
prometheus.Registerer, avoiding duplicate metric errors when multiple
outboxes are configured.

Also adds Count method to storageoutboxentry and partoutboxentry
repositories to support pending entry counting.

closes #658