### PR TITLE
feat(audit): adopt v2 nested log schema

### DIFF
--- a/internal/auditlog/entry.go
+++ b/internal/auditlog/entry.go
@@ -44,7 +44,7 @@ const (
 	PhaseComplete Phase = "COMPLETE"
 )
 
-const CurrentVersion uint16 = 1
+const CurrentVersion uint16 = 2
 
 type EntryType string
 
@@ -58,15 +58,56 @@ const GroundingBlockSize = 1000
 
 type GenesisDetails struct{}
 
-type LogDetails struct {
-	Operation  Operation
-	Phase      Phase
+type AuthType string
+
+const (
+	AuthTypeAnonymous    AuthType = "anonymous"
+	AuthTypeSigV4Header  AuthType = "sigv4-header"
+	AuthTypeSigV4Presign AuthType = "sigv4-presign"
+)
+
+type OutcomeType string
+
+const (
+	OutcomePending OutcomeType = "pending"
+	OutcomeSuccess OutcomeType = "success"
+	OutcomeError   OutcomeType = "error"
+	OutcomeDenied  OutcomeType = "denied"
+)
+
+type ResourceDetails struct {
 	Bucket     string
 	Key        string
 	UploadID   string
 	PartNumber int32
-	Actor      string
+}
+
+type ActorDetails struct {
+	CredentialID string
+	AuthType     AuthType
+}
+
+type RequestDetails struct {
+	RequestID string
+	TraceID   string
+	ClientIP  string
+}
+
+type OutcomeDetails struct {
+	StatusCode int32
+	Outcome    OutcomeType
+	ErrorCode  string
 	Error      string
+	DurationMs int64
+}
+
+type LogDetails struct {
+	Operation Operation
+	Phase     Phase
+	Resource  ResourceDetails
+	Actor     ActorDetails
+	Request   RequestDetails
+	Outcome   OutcomeDetails
 }
 
 type GroundingDetails struct {
@@ -102,12 +143,27 @@ func (e *Entry) CalculateHash() []byte {
 	case *LogDetails:
 		writeString(buf, string(d.Operation))
 		writeString(buf, string(d.Phase))
-		writeString(buf, d.Bucket)
-		writeString(buf, d.Key)
-		writeString(buf, d.UploadID)
-		binary.Write(buf, binary.BigEndian, d.PartNumber)
-		writeString(buf, d.Actor)
-		writeString(buf, d.Error)
+		writeString(buf, d.Resource.Bucket)
+		writeString(buf, d.Resource.Key)
+		writeString(buf, d.Resource.UploadID)
+		binary.Write(buf, binary.BigEndian, d.Resource.PartNumber)
+
+		if e.Version <= 1 {
+			writeString(buf, d.Actor.CredentialID)
+			writeString(buf, d.Outcome.Error)
+			break
+		}
+
+		writeString(buf, d.Actor.CredentialID)
+		writeString(buf, string(d.Actor.AuthType))
+		writeString(buf, d.Request.RequestID)
+		writeString(buf, d.Request.TraceID)
+		writeString(buf, d.Request.ClientIP)
+		binary.Write(buf, binary.BigEndian, d.Outcome.StatusCode)
+		writeString(buf, string(d.Outcome.Outcome))
+		writeString(buf, d.Outcome.ErrorCode)
+		writeString(buf, d.Outcome.Error)
+		binary.Write(buf, binary.BigEndian, d.Outcome.DurationMs)
 	case *GroundingDetails:
 		writeBytes(buf, d.MerkleRootHash)
 		if len(d.SignatureEd25519) != ed25519.SignatureSize {

--- a/internal/auditlog/serialization/binary.go
+++ b/internal/auditlog/serialization/binary.go
@@ -35,22 +35,57 @@ func (s *BinarySerializer) Encode(w io.Writer, e *auditlog.Entry) error {
 		if err := writeString(w, string(d.Phase)); err != nil {
 			return err
 		}
-		if err := writeString(w, d.Bucket); err != nil {
+		if err := writeString(w, d.Resource.Bucket); err != nil {
 			return err
 		}
-		if err := writeString(w, d.Key); err != nil {
+		if err := writeString(w, d.Resource.Key); err != nil {
 			return err
 		}
-		if err := writeString(w, d.UploadID); err != nil {
+		if err := writeString(w, d.Resource.UploadID); err != nil {
 			return err
 		}
-		if err := binary.Write(w, binary.BigEndian, d.PartNumber); err != nil {
+		if err := binary.Write(w, binary.BigEndian, d.Resource.PartNumber); err != nil {
 			return err
 		}
-		if err := writeString(w, d.Actor); err != nil {
+
+		if e.Version <= 1 {
+			if err := writeString(w, d.Actor.CredentialID); err != nil {
+				return err
+			}
+			if err := writeString(w, d.Outcome.Error); err != nil {
+				return err
+			}
+			break
+		}
+
+		if err := writeString(w, d.Actor.CredentialID); err != nil {
 			return err
 		}
-		if err := writeString(w, d.Error); err != nil {
+		if err := writeString(w, string(d.Actor.AuthType)); err != nil {
+			return err
+		}
+		if err := writeString(w, d.Request.RequestID); err != nil {
+			return err
+		}
+		if err := writeString(w, d.Request.TraceID); err != nil {
+			return err
+		}
+		if err := writeString(w, d.Request.ClientIP); err != nil {
+			return err
+		}
+		if err := binary.Write(w, binary.BigEndian, d.Outcome.StatusCode); err != nil {
+			return err
+		}
+		if err := writeString(w, string(d.Outcome.Outcome)); err != nil {
+			return err
+		}
+		if err := writeString(w, d.Outcome.ErrorCode); err != nil {
+			return err
+		}
+		if err := writeString(w, d.Outcome.Error); err != nil {
+			return err
+		}
+		if err := binary.Write(w, binary.BigEndian, d.Outcome.DurationMs); err != nil {
 			return err
 		}
 	case *auditlog.GroundingDetails:
@@ -70,7 +105,7 @@ func (s *BinarySerializer) Encode(w io.Writer, e *auditlog.Entry) error {
 			return err
 		}
 	}
-	
+
 	// Hashes and signatures are fixed length
 	if len(e.PreviousHash) != sha512.Size {
 		return errors.New("invalid previous hash length")
@@ -78,21 +113,21 @@ func (s *BinarySerializer) Encode(w io.Writer, e *auditlog.Entry) error {
 	if _, err := w.Write(e.PreviousHash); err != nil {
 		return err
 	}
-	
+
 	if len(e.Hash) != sha512.Size {
 		return errors.New("invalid hash length")
 	}
 	if _, err := w.Write(e.Hash); err != nil {
 		return err
 	}
-	
+
 	if len(e.SignatureEd25519) != ed25519.SignatureSize {
 		return errors.New("invalid entry signature length")
 	}
 	if _, err := w.Write(e.SignatureEd25519); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 
@@ -106,7 +141,7 @@ type BinaryDecoder struct {
 
 func (d *BinaryDecoder) Decode() (*auditlog.Entry, error) {
 	e := &auditlog.Entry{}
-	
+
 	if err := binary.Read(d.r, binary.BigEndian, &e.Version); err != nil {
 		return nil, err
 	}
@@ -116,7 +151,7 @@ func (d *BinaryDecoder) Decode() (*auditlog.Entry, error) {
 		return nil, err
 	}
 	e.Timestamp = time.Unix(0, ts)
-	
+
 	typeStr, err := readString(d.r)
 	if err != nil {
 		return nil, err
@@ -133,30 +168,76 @@ func (d *BinaryDecoder) Decode() (*auditlog.Entry, error) {
 			return nil, err
 		}
 		dls.Operation = auditlog.Operation(op)
-		
+
 		phaseStr, err := readString(d.r)
 		if err != nil {
 			return nil, err
 		}
 		dls.Phase = auditlog.Phase(phaseStr)
-		
-		if dls.Bucket, err = readString(d.r); err != nil {
+
+		if dls.Resource.Bucket, err = readString(d.r); err != nil {
 			return nil, err
 		}
-		if dls.Key, err = readString(d.r); err != nil {
+		if dls.Resource.Key, err = readString(d.r); err != nil {
 			return nil, err
 		}
-		if dls.UploadID, err = readString(d.r); err != nil {
+		if dls.Resource.UploadID, err = readString(d.r); err != nil {
 			return nil, err
 		}
-		if err := binary.Read(d.r, binary.BigEndian, &dls.PartNumber); err != nil {
+		if err := binary.Read(d.r, binary.BigEndian, &dls.Resource.PartNumber); err != nil {
 			return nil, err
 		}
-		if dls.Actor, err = readString(d.r); err != nil {
-			return nil, err
-		}
-		if dls.Error, err = readString(d.r); err != nil {
-			return nil, err
+
+		if e.Version <= 1 {
+			if dls.Actor.CredentialID, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			if dls.Outcome.Error, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			dls.Outcome.Outcome = auditlog.OutcomeSuccess
+			dls.Actor.AuthType = auditlog.AuthTypeAnonymous
+			if dls.Outcome.Error != "" {
+				dls.Outcome.Outcome = auditlog.OutcomeError
+				dls.Outcome.StatusCode = 500
+			} else {
+				dls.Outcome.StatusCode = 200
+			}
+		} else {
+			if dls.Actor.CredentialID, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			authType, err := readString(d.r)
+			if err != nil {
+				return nil, err
+			}
+			dls.Actor.AuthType = auditlog.AuthType(authType)
+			if dls.Request.RequestID, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			if dls.Request.TraceID, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			if dls.Request.ClientIP, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			if err := binary.Read(d.r, binary.BigEndian, &dls.Outcome.StatusCode); err != nil {
+				return nil, err
+			}
+			outcome, err := readString(d.r)
+			if err != nil {
+				return nil, err
+			}
+			dls.Outcome.Outcome = auditlog.OutcomeType(outcome)
+			if dls.Outcome.ErrorCode, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			if dls.Outcome.Error, err = readString(d.r); err != nil {
+				return nil, err
+			}
+			if err := binary.Read(d.r, binary.BigEndian, &dls.Outcome.DurationMs); err != nil {
+				return nil, err
+			}
 		}
 		e.Details = dls
 	case auditlog.EntryTypeGrounding:
@@ -174,22 +255,22 @@ func (d *BinaryDecoder) Decode() (*auditlog.Entry, error) {
 		}
 		e.Details = dls
 	}
-	
+
 	e.PreviousHash = make([]byte, sha512.Size)
 	if _, err := io.ReadFull(d.r, e.PreviousHash); err != nil {
 		return nil, err
 	}
-	
+
 	e.Hash = make([]byte, sha512.Size)
 	if _, err := io.ReadFull(d.r, e.Hash); err != nil {
 		return nil, err
 	}
-	
+
 	e.SignatureEd25519 = make([]byte, ed25519.SignatureSize)
 	if _, err := io.ReadFull(d.r, e.SignatureEd25519); err != nil {
 		return nil, err
 	}
-	
+
 	return e, nil
 }
 

--- a/internal/auditlog/serialization/json.go
+++ b/internal/auditlog/serialization/json.go
@@ -25,6 +25,33 @@ type jsonEntry struct {
 }
 
 type jsonLogDetails struct {
+	Operation string `json:"operation"`
+	Phase     string `json:"phase"`
+	Resource  struct {
+		Bucket     string `json:"bucket"`
+		Key        string `json:"key,omitempty"`
+		UploadID   string `json:"upload_id,omitempty"`
+		PartNumber int32  `json:"part_number,omitempty"`
+	} `json:"resource"`
+	Actor struct {
+		CredentialID string `json:"credential_id,omitempty"`
+		AuthType     string `json:"auth_type,omitempty"`
+	} `json:"actor"`
+	Request struct {
+		RequestID string `json:"request_id,omitempty"`
+		TraceID   string `json:"trace_id,omitempty"`
+		ClientIP  string `json:"client_ip,omitempty"`
+	} `json:"request"`
+	Outcome struct {
+		StatusCode int32  `json:"status_code"`
+		Outcome    string `json:"outcome,omitempty"`
+		ErrorCode  string `json:"error_code,omitempty"`
+		Error      string `json:"error,omitempty"`
+		DurationMs int64  `json:"duration_ms"`
+	} `json:"outcome"`
+}
+
+type jsonLogDetailsV1 struct {
 	Operation  string `json:"operation"`
 	Phase      string `json:"phase"`
 	Bucket     string `json:"bucket"`
@@ -49,16 +76,38 @@ func (s *JsonSerializer) Encode(w io.Writer, e *auditlog.Entry) error {
 	case *auditlog.GenesisDetails:
 		details, _ = json.Marshal(struct{}{})
 	case *auditlog.LogDetails:
-		details, err = json.Marshal(jsonLogDetails{
-			Operation:  string(d.Operation),
-			Phase:      string(d.Phase),
-			Bucket:     d.Bucket,
-			Key:        d.Key,
-			UploadID:   d.UploadID,
-			PartNumber: d.PartNumber,
-			Actor:      d.Actor,
-			Error:      d.Error,
-		})
+		if e.Version <= 1 {
+			details, err = json.Marshal(jsonLogDetailsV1{
+				Operation:  string(d.Operation),
+				Phase:      string(d.Phase),
+				Bucket:     d.Resource.Bucket,
+				Key:        d.Resource.Key,
+				UploadID:   d.Resource.UploadID,
+				PartNumber: d.Resource.PartNumber,
+				Actor:      d.Actor.CredentialID,
+				Error:      d.Outcome.Error,
+			})
+		} else {
+			payload := jsonLogDetails{
+				Operation: string(d.Operation),
+				Phase:     string(d.Phase),
+			}
+			payload.Resource.Bucket = d.Resource.Bucket
+			payload.Resource.Key = d.Resource.Key
+			payload.Resource.UploadID = d.Resource.UploadID
+			payload.Resource.PartNumber = d.Resource.PartNumber
+			payload.Actor.CredentialID = d.Actor.CredentialID
+			payload.Actor.AuthType = string(d.Actor.AuthType)
+			payload.Request.RequestID = d.Request.RequestID
+			payload.Request.TraceID = d.Request.TraceID
+			payload.Request.ClientIP = d.Request.ClientIP
+			payload.Outcome.StatusCode = d.Outcome.StatusCode
+			payload.Outcome.Outcome = string(d.Outcome.Outcome)
+			payload.Outcome.ErrorCode = d.Outcome.ErrorCode
+			payload.Outcome.Error = d.Outcome.Error
+			payload.Outcome.DurationMs = d.Outcome.DurationMs
+			details, err = json.Marshal(payload)
+		}
 	case *auditlog.GroundingDetails:
 		details, err = json.Marshal(jsonGroundingDetails{
 			MerkleRootHash:   hex.EncodeToString(d.MerkleRootHash),
@@ -135,19 +184,68 @@ func (d *JsonDecoder) Decode() (*auditlog.Entry, error) {
 	case auditlog.EntryTypeGenesis:
 		e.Details = &auditlog.GenesisDetails{}
 	case auditlog.EntryTypeLog:
+		if e.Version <= 1 {
+			var jd jsonLogDetailsV1
+			if err := json.Unmarshal(je.Details, &jd); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal legacy log details: %w", err)
+			}
+			outcomeType := auditlog.OutcomeSuccess
+			statusCode := int32(200)
+			if jd.Error != "" {
+				outcomeType = auditlog.OutcomeError
+				statusCode = 500
+			}
+			e.Details = &auditlog.LogDetails{
+				Operation: auditlog.Operation(jd.Operation),
+				Phase:     auditlog.Phase(jd.Phase),
+				Resource: auditlog.ResourceDetails{
+					Bucket:     jd.Bucket,
+					Key:        jd.Key,
+					UploadID:   jd.UploadID,
+					PartNumber: jd.PartNumber,
+				},
+				Actor: auditlog.ActorDetails{
+					CredentialID: jd.Actor,
+					AuthType:     auditlog.AuthTypeAnonymous,
+				},
+				Outcome: auditlog.OutcomeDetails{
+					StatusCode: statusCode,
+					Outcome:    outcomeType,
+					Error:      jd.Error,
+				},
+			}
+			break
+		}
+
 		var jd jsonLogDetails
 		if err := json.Unmarshal(je.Details, &jd); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal log details: %w", err)
 		}
 		e.Details = &auditlog.LogDetails{
-			Operation:  auditlog.Operation(jd.Operation),
-			Phase:      auditlog.Phase(jd.Phase),
-			Bucket:     jd.Bucket,
-			Key:        jd.Key,
-			UploadID:   jd.UploadID,
-			PartNumber: jd.PartNumber,
-			Actor:      jd.Actor,
-			Error:      jd.Error,
+			Operation: auditlog.Operation(jd.Operation),
+			Phase:     auditlog.Phase(jd.Phase),
+			Resource: auditlog.ResourceDetails{
+				Bucket:     jd.Resource.Bucket,
+				Key:        jd.Resource.Key,
+				UploadID:   jd.Resource.UploadID,
+				PartNumber: jd.Resource.PartNumber,
+			},
+			Actor: auditlog.ActorDetails{
+				CredentialID: jd.Actor.CredentialID,
+				AuthType:     auditlog.AuthType(jd.Actor.AuthType),
+			},
+			Request: auditlog.RequestDetails{
+				RequestID: jd.Request.RequestID,
+				TraceID:   jd.Request.TraceID,
+				ClientIP:  jd.Request.ClientIP,
+			},
+			Outcome: auditlog.OutcomeDetails{
+				StatusCode: jd.Outcome.StatusCode,
+				Outcome:    auditlog.OutcomeType(jd.Outcome.Outcome),
+				ErrorCode:  jd.Outcome.ErrorCode,
+				Error:      jd.Outcome.Error,
+				DurationMs: jd.Outcome.DurationMs,
+			},
 		}
 	case auditlog.EntryTypeGrounding:
 		var jd jsonGroundingDetails

--- a/internal/auditlog/serialization/serialization_test.go
+++ b/internal/auditlog/serialization/serialization_test.go
@@ -33,11 +33,26 @@ func TestSerializers(t *testing.T) {
 			Timestamp: time.Date(2025, 12, 22, 10, 0, 1, 0, time.UTC),
 			Type:      auditlog.EntryTypeLog,
 			Details: &auditlog.LogDetails{
-				Operation:  auditlog.OpCreateBucket,
-				Phase:      auditlog.PhaseStart,
-				Bucket:     "test-bucket",
-				Key:        "test-key",
-				Actor:      "test-actor",
+				Operation: auditlog.OpCreateBucket,
+				Phase:     auditlog.PhaseStart,
+				Resource: auditlog.ResourceDetails{
+					Bucket: "test-bucket",
+					Key:    "test-key",
+				},
+				Actor: auditlog.ActorDetails{
+					CredentialID: "test-actor",
+					AuthType:     auditlog.AuthTypeSigV4Header,
+				},
+				Request: auditlog.RequestDetails{
+					RequestID: "req-1",
+					TraceID:   "trace-1",
+					ClientIP:  "127.0.0.1",
+				},
+				Outcome: auditlog.OutcomeDetails{
+					StatusCode: 200,
+					Outcome:    auditlog.OutcomeSuccess,
+					DurationMs: 5,
+				},
 			},
 			PreviousHash:     make([]byte, sha512.Size),
 			Hash:             make([]byte, sha512.Size),
@@ -50,7 +65,7 @@ func TestSerializers(t *testing.T) {
 			Details: &auditlog.GroundingDetails{
 				MerkleRootHash:   make([]byte, sha512.Size),
 				SignatureEd25519: make([]byte, ed25519.SignatureSize),
-				SignatureMlDsa87:   make([]byte, mldsa87.SignatureSize),
+				SignatureMlDsa87: make([]byte, mldsa87.SignatureSize),
 			},
 			PreviousHash:     make([]byte, sha512.Size),
 			Hash:             make([]byte, sha512.Size),
@@ -136,9 +151,18 @@ func BenchmarkSerializers(b *testing.B) {
 			Details: &auditlog.LogDetails{
 				Operation: auditlog.OpPutObject,
 				Phase:     auditlog.PhaseComplete,
-				Bucket:    "benchmark-bucket",
-				Key:       fmt.Sprintf("object-%d", i),
-				Actor:     "admin",
+				Resource: auditlog.ResourceDetails{
+					Bucket: "benchmark-bucket",
+					Key:    fmt.Sprintf("object-%d", i),
+				},
+				Actor: auditlog.ActorDetails{
+					CredentialID: "admin",
+					AuthType:     auditlog.AuthTypeSigV4Header,
+				},
+				Outcome: auditlog.OutcomeDetails{
+					StatusCode: 200,
+					Outcome:    auditlog.OutcomeSuccess,
+				},
 			},
 			PreviousHash: prevHash,
 		}

--- a/internal/auditlog/serialization/text.go
+++ b/internal/auditlog/serialization/text.go
@@ -25,21 +25,47 @@ func (s *TextSerializer) Encode(w io.Writer, e *auditlog.Entry) error {
 	case *auditlog.GenesisDetails:
 		base += " | GENESIS"
 	case *auditlog.LogDetails:
-		base += fmt.Sprintf(" | %s %s Bucket: %s", escape(string(d.Operation)), escape(string(d.Phase)), escape(d.Bucket))
-		if d.Key != "" {
-			base += fmt.Sprintf(" | Key: %s", escape(d.Key))
+		base += fmt.Sprintf(" | Op: %s", escape(string(d.Operation)))
+		base += fmt.Sprintf(" | Phase: %s", escape(string(d.Phase)))
+		base += fmt.Sprintf(" | Bucket: %s", escape(d.Resource.Bucket))
+		if d.Resource.Key != "" {
+			base += fmt.Sprintf(" | Key: %s", escape(d.Resource.Key))
 		}
-		if d.UploadID != "" {
-			base += fmt.Sprintf(" | UploadID: %s", escape(d.UploadID))
+		if d.Resource.UploadID != "" {
+			base += fmt.Sprintf(" | UploadID: %s", escape(d.Resource.UploadID))
 		}
-		if d.PartNumber != 0 {
-			base += fmt.Sprintf(" | Part: %d", d.PartNumber)
+		if d.Resource.PartNumber != 0 {
+			base += fmt.Sprintf(" | Part: %d", d.Resource.PartNumber)
 		}
-		if d.Actor != "" {
-			base += fmt.Sprintf(" | Actor: %s", escape(d.Actor))
+		if d.Actor.CredentialID != "" {
+			base += fmt.Sprintf(" | CredentialID: %s", escape(d.Actor.CredentialID))
 		}
-		if d.Error != "" {
-			base += fmt.Sprintf(" | Error: %s", escape(d.Error))
+		if d.Actor.AuthType != "" {
+			base += fmt.Sprintf(" | AuthType: %s", escape(string(d.Actor.AuthType)))
+		}
+		if d.Request.RequestID != "" {
+			base += fmt.Sprintf(" | RequestID: %s", escape(d.Request.RequestID))
+		}
+		if d.Request.TraceID != "" {
+			base += fmt.Sprintf(" | TraceID: %s", escape(d.Request.TraceID))
+		}
+		if d.Request.ClientIP != "" {
+			base += fmt.Sprintf(" | ClientIP: %s", escape(d.Request.ClientIP))
+		}
+		if d.Outcome.StatusCode != 0 {
+			base += fmt.Sprintf(" | StatusCode: %d", d.Outcome.StatusCode)
+		}
+		if d.Outcome.Outcome != "" {
+			base += fmt.Sprintf(" | Outcome: %s", escape(string(d.Outcome.Outcome)))
+		}
+		if d.Outcome.ErrorCode != "" {
+			base += fmt.Sprintf(" | ErrorCode: %s", escape(d.Outcome.ErrorCode))
+		}
+		if d.Outcome.Error != "" {
+			base += fmt.Sprintf(" | Error: %s", escape(d.Outcome.Error))
+		}
+		if d.Outcome.DurationMs != 0 {
+			base += fmt.Sprintf(" | DurationMs: %d", d.Outcome.DurationMs)
 		}
 	case *auditlog.GroundingDetails:
 		base += fmt.Sprintf(" | MerkleRoot: %x | Ed25519: %x | ML-DSA-87: %x", d.MerkleRootHash, d.SignatureEd25519, d.SignatureMlDsa87)
@@ -90,24 +116,24 @@ func (d *TextDecoder) Decode() (*auditlog.Entry, error) {
 	}
 
 	parts := strings.Split(line, " | ")
-	
+
 	switch entry.Type {
 	case auditlog.EntryTypeGenesis:
 		entry.Details = &auditlog.GenesisDetails{}
 	case auditlog.EntryTypeLog:
 		dls := &auditlog.LogDetails{}
-		if len(parts) > 1 {
+		if len(parts) > 1 && !strings.Contains(parts[1], ": ") {
 			opPhase := strings.Fields(parts[1])
 			if len(opPhase) >= 2 {
 				dls.Operation = auditlog.Operation(unescape(opPhase[0]))
 				dls.Phase = auditlog.Phase(unescape(opPhase[1]))
 			}
 			if idx := strings.Index(parts[1], "Bucket: "); idx != -1 {
-				dls.Bucket = unescape(strings.TrimSpace(parts[1][idx+8:]))
+				dls.Resource.Bucket = unescape(strings.TrimSpace(parts[1][idx+8:]))
 			}
 		}
-		
-		for _, part := range parts[2:] {
+
+		for _, part := range parts[1:] {
 			kv := strings.SplitN(part, ": ", 2)
 			if len(kv) != 2 {
 				continue
@@ -116,17 +142,53 @@ func (d *TextDecoder) Decode() (*auditlog.Entry, error) {
 			val := strings.TrimSpace(kv[1])
 
 			switch key {
+			case "Op":
+				dls.Operation = auditlog.Operation(unescape(val))
+			case "Phase":
+				dls.Phase = auditlog.Phase(unescape(val))
+			case "Bucket":
+				dls.Resource.Bucket = unescape(val)
 			case "Key":
-				dls.Key = unescape(val)
+				dls.Resource.Key = unescape(val)
 			case "UploadID":
-				dls.UploadID = unescape(val)
+				dls.Resource.UploadID = unescape(val)
 			case "Part":
 				p, _ := strconv.Atoi(val)
-				dls.PartNumber = int32(p)
-			case "Actor":
-				dls.Actor = unescape(val)
+				dls.Resource.PartNumber = int32(p)
+			case "Actor", "CredentialID":
+				dls.Actor.CredentialID = unescape(val)
+			case "AuthType":
+				dls.Actor.AuthType = auditlog.AuthType(unescape(val))
+			case "RequestID":
+				dls.Request.RequestID = unescape(val)
+			case "TraceID":
+				dls.Request.TraceID = unescape(val)
+			case "ClientIP":
+				dls.Request.ClientIP = unescape(val)
+			case "StatusCode":
+				s, _ := strconv.Atoi(val)
+				dls.Outcome.StatusCode = int32(s)
+			case "Outcome":
+				dls.Outcome.Outcome = auditlog.OutcomeType(unescape(val))
+			case "ErrorCode":
+				dls.Outcome.ErrorCode = unescape(val)
 			case "Error":
-				dls.Error = unescape(val)
+				dls.Outcome.Error = unescape(val)
+			case "DurationMs":
+				duration, _ := strconv.ParseInt(val, 10, 64)
+				dls.Outcome.DurationMs = duration
+			}
+		}
+		if version <= 1 {
+			dls.Actor.AuthType = auditlog.AuthTypeAnonymous
+			if dls.Outcome.Outcome == "" {
+				dls.Outcome.Outcome = auditlog.OutcomeSuccess
+				if dls.Outcome.Error != "" {
+					dls.Outcome.Outcome = auditlog.OutcomeError
+					dls.Outcome.StatusCode = 500
+				} else {
+					dls.Outcome.StatusCode = 200
+				}
 			}
 		}
 		entry.Details = dls

--- a/internal/auditlog/sink/writer_test.go
+++ b/internal/auditlog/sink/writer_test.go
@@ -16,14 +16,16 @@ func TestWriterSink_WriteEntry(t *testing.T) {
 	sink := NewWriterSink(&buf, serializer)
 
 	entry := &auditlog.Entry{
-		Version:   1,
+		Version:   auditlog.CurrentVersion,
 		Timestamp: time.Date(2025, 12, 23, 10, 0, 0, 0, time.UTC),
 		Type:      auditlog.EntryTypeLog,
 		Details: &auditlog.LogDetails{
 			Operation: auditlog.OpPutObject,
 			Phase:     auditlog.PhaseComplete,
-			Bucket:    "test-bucket",
-			Key:       "test-key",
+			Resource: auditlog.ResourceDetails{
+				Bucket: "test-bucket",
+				Key:    "test-key",
+			},
 		},
 	}
 
@@ -35,7 +37,7 @@ func TestWriterSink_WriteEntry(t *testing.T) {
 	if output == "" {
 		t.Error("Output is empty")
 	}
-	
+
 	// Basic check if output contains expected string
 	if !bytes.Contains(buf.Bytes(), []byte("test-bucket")) {
 		t.Errorf("Output does not contain bucket name. Got: %s", output)

--- a/internal/auditlog/tool/cli.go
+++ b/internal/auditlog/tool/cli.go
@@ -120,15 +120,15 @@ func (t *AuditLogTool) Dump(inputFormat string, outputFormat string, out io.Writ
 }
 
 type LogStats struct {
-	TotalEntries    int
-	GenesisEntries  int
-	LogEntries      int
+	TotalEntries     int
+	GenesisEntries   int
+	LogEntries       int
 	GroundingEntries int
-	StartTime       time.Time
-	EndTime         time.Time
-	Operations      map[auditlog.Operation]int
-	Actors          map[string]int
-	Errors          int
+	StartTime        time.Time
+	EndTime          time.Time
+	Operations       map[auditlog.Operation]int
+	Actors           map[string]int
+	Errors           int
 }
 
 func (t *AuditLogTool) Stats(inputFormat string) (*LogStats, error) {
@@ -178,8 +178,12 @@ func (t *AuditLogTool) Stats(inputFormat string) (*LogStats, error) {
 			stats.LogEntries++
 			details := entry.Details.(*auditlog.LogDetails)
 			stats.Operations[details.Operation]++
-			stats.Actors[details.Actor]++
-			if details.Error != "" {
+			actor := details.Actor.CredentialID
+			if actor == "" {
+				actor = "anonymous"
+			}
+			stats.Actors[actor]++
+			if details.Outcome.Error != "" || details.Outcome.Outcome == auditlog.OutcomeError {
 				stats.Errors++
 			}
 		case auditlog.EntryTypeGrounding:

--- a/internal/auditlog/tool/cli_test.go
+++ b/internal/auditlog/tool/cli_test.go
@@ -54,7 +54,12 @@ func TestRunAuditLogTool(t *testing.T) {
 			Type:      auditlog.EntryTypeLog,
 			Details: &auditlog.LogDetails{
 				Operation: auditlog.OpPutObject,
-				Bucket:    "test",
+				Resource: auditlog.ResourceDetails{
+					Bucket: "test",
+				},
+				Actor: auditlog.ActorDetails{
+					CredentialID: "test",
+				},
 			},
 			PreviousHash: prevHash,
 		}
@@ -80,7 +85,7 @@ func TestRunAuditLogTool(t *testing.T) {
 		Details: &auditlog.GroundingDetails{
 			MerkleRootHash:   root,
 			SignatureEd25519: sigEd,
-			SignatureMlDsa87:   sigMl,
+			SignatureMlDsa87: sigMl,
 		},
 		PreviousHash: prevHash,
 	}

--- a/internal/http/server/authentication/signature.go
+++ b/internal/http/server/authentication/signature.go
@@ -43,6 +43,9 @@ const maxMemoryCacheSize = 10 * 1000 * 1000
 var ErrChunkSignatureMismatch = errors.New("chunk signature mismatch")
 
 type AccessKeyIdContextKey struct{}
+type AuthTypeContextKey struct{}
+type RequestIDContextKey struct{}
+type ClientIPContextKey struct{}
 
 func hmacSha256(secret []byte, data []byte) []byte {
 	hmac := hmac.New(sha256.New, secret)
@@ -595,6 +598,19 @@ type Credentials struct {
 
 type IsAuthenticatedContextKey struct{}
 
+func authTypeForRequest(r *http.Request) string {
+	if isAnonymousRequest(r) {
+		return "anonymous"
+	}
+	if r.Header.Get("Authorization") != "" {
+		return "sigv4-header"
+	}
+	if r.URL.Query().Get("X-Amz-Credential") != "" {
+		return "sigv4-presign"
+	}
+	return "anonymous"
+}
+
 func isAnonymousRequest(r *http.Request) bool {
 	authorizationHeader := r.Header.Get("Authorization")
 	if authorizationHeader != "" {
@@ -615,6 +631,7 @@ func MakeSignatureMiddleware(validCredentials []Credentials, region string, next
 		// will check bucket policies to decide whether to allow access.
 		if isAnonymousRequest(r) {
 			ctx := context.WithValue(r.Context(), IsAuthenticatedContextKey{}, false)
+			ctx = context.WithValue(ctx, AuthTypeContextKey{}, authTypeForRequest(r))
 			r = r.Clone(ctx)
 			next.ServeHTTP(w, r)
 			return
@@ -624,6 +641,7 @@ func MakeSignatureMiddleware(validCredentials []Credentials, region string, next
 		if isAuthenticated {
 			ctx := context.WithValue(r.Context(), AccessKeyIdContextKey{}, *usedAccessKeyId)
 			ctx = context.WithValue(ctx, IsAuthenticatedContextKey{}, true)
+			ctx = context.WithValue(ctx, AuthTypeContextKey{}, authTypeForRequest(r))
 			r = r.Clone(ctx)
 			next.ServeHTTP(w, r)
 		} else {

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -83,6 +83,7 @@ func SetupServer(credentials []settings.Credentials, region string, apiEndpoint 
 
 	// Set up handler with hostname-based routing.
 	rootHandler := middlewares.MakeHostnameRoutingHandler(apiEndpoint, apiHandler, websiteEndpoint, websiteHandler, fallbackHandler)
+	rootHandler = makeAuditRequestContextMiddleware(rootHandler)
 
 	var authCreds []authentication.Credentials
 	if credentials != nil {
@@ -99,6 +100,16 @@ func SetupServer(credentials []settings.Credentials, region string, apiEndpoint 
 	}
 
 	return rootHandler
+}
+
+func makeAuditRequestContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), authentication.RequestIDContextKey{}, ulid.Make().String())
+		if ip := getRemoteIP(r.RemoteAddr); ip != nil {
+			ctx = context.WithValue(ctx, authentication.ClientIPContextKey{}, *ip)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 func makeHealthCheckHandler(dbs []database.Database) http.HandlerFunc {

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jdillenkofer/pithos/internal/http/server/authentication"
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/storage"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type AuditLogMiddleware struct {
@@ -66,12 +67,39 @@ func NewAuditLogMiddleware(next storage.Storage, sink sink.Sink, signer signing.
 	return m
 }
 
-func (m *AuditLogMiddleware) log(ctx context.Context, op auditlog.Operation, phase auditlog.Phase, bucket string, key string, uploadId string, partNumber int32, err error) {
-	actor := "anonymous"
+func (m *AuditLogMiddleware) log(ctx context.Context, op auditlog.Operation, phase auditlog.Phase, bucket string, key string, uploadId string, partNumber int32, err error, statusCode int32, durationMs int64) {
+	credentialID := ""
 	if val := ctx.Value(authentication.AccessKeyIdContextKey{}); val != nil {
 		if s, ok := val.(string); ok {
-			actor = s
+			credentialID = s
 		}
+	}
+
+	authType := auditlog.AuthTypeAnonymous
+	if val := ctx.Value(authentication.AuthTypeContextKey{}); val != nil {
+		if s, ok := val.(string); ok {
+			authType = auditlog.AuthType(s)
+		}
+	}
+
+	requestID := ""
+	if val := ctx.Value(authentication.RequestIDContextKey{}); val != nil {
+		if s, ok := val.(string); ok {
+			requestID = s
+		}
+	}
+
+	clientIP := ""
+	if val := ctx.Value(authentication.ClientIPContextKey{}); val != nil {
+		if s, ok := val.(string); ok {
+			clientIP = s
+		}
+	}
+
+	traceID := ""
+	spanContext := trace.SpanContextFromContext(ctx)
+	if spanContext.HasTraceID() {
+		traceID = spanContext.TraceID().String()
 	}
 
 	errMsg := ""
@@ -79,19 +107,43 @@ func (m *AuditLogMiddleware) log(ctx context.Context, op auditlog.Operation, pha
 		errMsg = err.Error()
 	}
 
+	outcome := auditlog.OutcomePending
+	if phase == auditlog.PhaseComplete {
+		if err != nil {
+			outcome = auditlog.OutcomeError
+		} else {
+			outcome = auditlog.OutcomeSuccess
+		}
+	}
+
 	entry := &auditlog.Entry{
 		Version:   auditlog.CurrentVersion,
 		Timestamp: time.Now(),
 		Type:      auditlog.EntryTypeLog,
 		Details: &auditlog.LogDetails{
-			Operation:  op,
-			Phase:      phase,
-			Bucket:     bucket,
-			Key:        key,
-			UploadID:   uploadId,
-			PartNumber: partNumber,
-			Actor:      actor,
-			Error:      errMsg,
+			Operation: op,
+			Phase:     phase,
+			Resource: auditlog.ResourceDetails{
+				Bucket:     bucket,
+				Key:        key,
+				UploadID:   uploadId,
+				PartNumber: partNumber,
+			},
+			Actor: auditlog.ActorDetails{
+				CredentialID: credentialID,
+				AuthType:     authType,
+			},
+			Request: auditlog.RequestDetails{
+				RequestID: requestID,
+				TraceID:   traceID,
+				ClientIP:  clientIP,
+			},
+			Outcome: auditlog.OutcomeDetails{
+				StatusCode: statusCode,
+				Outcome:    outcome,
+				Error:      errMsg,
+				DurationMs: durationMs,
+			},
 		},
 	}
 
@@ -146,147 +198,174 @@ func (m *AuditLogMiddleware) Stop(ctx context.Context) error {
 }
 
 func (m *AuditLogMiddleware) CreateBucket(ctx context.Context, bucketName storage.BucketName) error {
-	m.log(ctx, auditlog.OpCreateBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpCreateBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	err := m.next.CreateBucket(ctx, bucketName)
-	m.log(ctx, auditlog.OpCreateBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpCreateBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return err
 }
 
 func (m *AuditLogMiddleware) DeleteBucket(ctx context.Context, bucketName storage.BucketName) error {
-	m.log(ctx, auditlog.OpDeleteBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpDeleteBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	err := m.next.DeleteBucket(ctx, bucketName)
-	m.log(ctx, auditlog.OpDeleteBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpDeleteBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return err
 }
 
 func (m *AuditLogMiddleware) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
-	m.log(ctx, auditlog.OpListBuckets, auditlog.PhaseStart, "", "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpListBuckets, auditlog.PhaseStart, "", "", "", 0, nil, 0, 0)
 	buckets, err := m.next.ListBuckets(ctx)
-	m.log(ctx, auditlog.OpListBuckets, auditlog.PhaseComplete, "", "", "", 0, err)
+	m.log(ctx, auditlog.OpListBuckets, auditlog.PhaseComplete, "", "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return buckets, err
 }
 
 func (m *AuditLogMiddleware) HeadBucket(ctx context.Context, bucketName storage.BucketName) (*storage.Bucket, error) {
-	m.log(ctx, auditlog.OpHeadBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpHeadBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	bucket, err := m.next.HeadBucket(ctx, bucketName)
-	m.log(ctx, auditlog.OpHeadBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpHeadBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return bucket, err
 }
 
 func (m *AuditLogMiddleware) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
-	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	config, err := m.next.GetBucketWebsiteConfiguration(ctx, bucketName)
-	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return config, err
 }
 
 func (m *AuditLogMiddleware) PutBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.WebsiteConfiguration) error {
-	m.log(ctx, auditlog.OpPutBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpPutBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	err := m.next.PutBucketWebsiteConfiguration(ctx, bucketName, config)
-	m.log(ctx, auditlog.OpPutBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpPutBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return err
 }
 
 func (m *AuditLogMiddleware) DeleteBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) error {
-	m.log(ctx, auditlog.OpDeleteBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpDeleteBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	err := m.next.DeleteBucketWebsiteConfiguration(ctx, bucketName)
-	m.log(ctx, auditlog.OpDeleteBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpDeleteBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return err
 }
 
 func (m *AuditLogMiddleware) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
-	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	res, err := m.next.ListObjects(ctx, bucketName, opts)
-	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
-	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
 	obj, err := m.next.HeadObject(ctx, bucketName, key, opts)
-	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
+	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return obj, err
 }
 
 func (m *AuditLogMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
-	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
 	obj, readers, err := m.next.GetObject(ctx, bucketName, key, ranges, opts)
-	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
+	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return obj, readers, err
 }
 
 func (m *AuditLogMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
-	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
 	res, err := m.next.PutObject(ctx, bucketName, key, contentType, data, checksumInput, opts)
-	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
+	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
-	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
 	res, err := m.next.AppendObject(ctx, bucketName, key, data, checksumInput, opts)
-	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
+	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
-	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
 	err := m.next.DeleteObject(ctx, bucketName, key, opts)
-	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err)
+	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return err
 }
 
 func (m *AuditLogMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
-	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	result, err := m.next.DeleteObjects(ctx, bucketName, entries)
-	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return result, err
 }
 
 func (m *AuditLogMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
-	m.log(ctx, auditlog.OpCreateMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpCreateMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
 	res, err := m.next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
 	uid := ""
 	if res != nil {
 		uid = res.UploadId.String()
 	}
-	m.log(ctx, auditlog.OpCreateMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uid, 0, err)
+	m.log(ctx, auditlog.OpCreateMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uid, 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) UploadPart(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, partNumber int32, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.UploadPartResult, error) {
-	m.log(ctx, auditlog.OpUploadPart, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), partNumber, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpUploadPart, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), partNumber, nil, 0, 0)
 	res, err := m.next.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
-	m.log(ctx, auditlog.OpUploadPart, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), partNumber, err)
+	m.log(ctx, auditlog.OpUploadPart, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), partNumber, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
-	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil, 0, 0)
 	res, err := m.next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
-	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err)
+	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {
-	m.log(ctx, auditlog.OpAbortMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpAbortMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil, 0, 0)
 	err := m.next.AbortMultipartUpload(ctx, bucketName, key, uploadId)
-	m.log(ctx, auditlog.OpAbortMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err)
+	m.log(ctx, auditlog.OpAbortMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return err
 }
 
 func (m *AuditLogMiddleware) ListMultipartUploads(ctx context.Context, bucketName storage.BucketName, opts storage.ListMultipartUploadsOptions) (*storage.ListMultipartUploadsResult, error) {
-	m.log(ctx, auditlog.OpListMultipartUploads, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpListMultipartUploads, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	res, err := m.next.ListMultipartUploads(ctx, bucketName, opts)
-	m.log(ctx, auditlog.OpListMultipartUploads, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err)
+	m.log(ctx, auditlog.OpListMultipartUploads, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
 func (m *AuditLogMiddleware) ListParts(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, opts storage.ListPartsOptions) (*storage.ListPartsResult, error) {
-	m.log(ctx, auditlog.OpListParts, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil)
+	start := time.Now()
+	m.log(ctx, auditlog.OpListParts, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil, 0, 0)
 	res, err := m.next.ListParts(ctx, bucketName, key, uploadId, opts)
-	m.log(ctx, auditlog.OpListParts, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err)
+	m.log(ctx, auditlog.OpListParts, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
+}
+
+func statusCodeFromError(err error) int32 {
+	if err != nil {
+		return 500
+	}
+	return 200
 }
 
 // Ensure interface compliance

--- a/internal/storage/middlewares/audit/audit_test.go
+++ b/internal/storage/middlewares/audit/audit_test.go
@@ -116,8 +116,8 @@ func TestAuditLogMiddleware(t *testing.T) {
 	if dStart.Phase != auditlog.PhaseStart {
 		t.Errorf("expected START phase, got %s", dStart.Phase)
 	}
-	if dStart.Bucket != "test-bucket" {
-		t.Errorf("expected bucket test-bucket, got %s", dStart.Bucket)
+	if dStart.Resource.Bucket != "test-bucket" {
+		t.Errorf("expected bucket test-bucket, got %s", dStart.Resource.Bucket)
 	}
 	if !entryStart.Verify(signing.NewEd25519Verifier(pub)) {
 		t.Error("entryStart signature verification failed")
@@ -137,6 +137,9 @@ func TestAuditLogMiddleware(t *testing.T) {
 	}
 	if dEnd.Phase != auditlog.PhaseComplete {
 		t.Errorf("expected COMPLETE phase, got %s", dEnd.Phase)
+	}
+	if dEnd.Outcome.Outcome != auditlog.OutcomeSuccess {
+		t.Errorf("expected success outcome, got %s", dEnd.Outcome.Outcome)
 	}
 	if !entryEnd.Verify(signing.NewEd25519Verifier(pub)) {
 		t.Error("entryEnd signature verification failed")


### PR DESCRIPTION
## Summary
- Introduce audit log v2 nested request/outcome schema.
- Update audit log serialization formats (binary, JSON, text), CLI tooling, settings/docs, and middleware integration to consume the new structure.
- Expand audit-focused test coverage across serialization, writer/CLI behavior, middleware, and command surfaces.

## Merge Order
- Merge this PR after the extend-authorizer PR.