### PR TITLE
security(http): enforce bounded XML request body reads

### DIFF
--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -1765,7 +1765,7 @@ func (s *Server) completeMultipartUploadHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedBody(r, w, maxCompleteMultipartUploadBodySize)
 	if err != nil {
 		handleError(err, w, r)
 		return
@@ -2160,6 +2160,22 @@ func (s *Server) postBucketHandler(w http.ResponseWriter, r *http.Request) {
 
 const maxDeleteObjects = 1000
 
+const maxCompleteMultipartUploadBodySize int64 = 10 * 1024 * 1024
+const maxDeleteObjectsBodySize int64 = 5 * 1024 * 1024
+const maxPutBucketWebsiteBodySize int64 = 128 * 1024
+
+func readLimitedBody(r *http.Request, w http.ResponseWriter, maxBodySize int64) ([]byte, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			return nil, storage.ErrEntityTooLarge
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
 func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, span := s.tracer.Start(r.Context(), "Server.deleteObjectsHandler")
 	defer span.End()
@@ -2175,7 +2191,7 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedBody(r, w, maxDeleteObjectsBodySize)
 	if err != nil {
 		handleError(err, w, r)
 		return
@@ -2353,7 +2369,7 @@ func (s *Server) putBucketWebsiteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedBody(r, w, maxPutBucketWebsiteBodySize)
 	if err != nil {
 		handleError(err, w, r)
 		return


### PR DESCRIPTION
## Summary
- add explicit request body limits for XML-heavy endpoints (`CompleteMultipartUpload`, `DeleteObjects`, and `PutBucketWebsite`)
- introduce a shared helper that applies `http.MaxBytesReader` and maps over-limit reads to `EntityTooLarge`
- keep existing XML parsing behavior while preventing unbounded `io.ReadAll` allocations

## Testing
- `go test ./...`

## Related
- Closes #664