### PR TITLE
fix(http): return early when append request exceeds max entity size

### DIFF
--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -2024,6 +2024,9 @@ func (s *Server) appendObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	shouldReturn = validateMaxEntitySize(r, w)
+	if shouldReturn {
+		return
+	}
 
 	checksumInput, err := extractChecksumInput(r)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add the missing early return in `appendObjectHandler` after `validateMaxEntitySize`
- prevent request processing from continuing after an error response has already been written
- align append behavior with other upload handlers that fail fast on oversized bodies

## Testing
- `go test ./...`

## Related
- Closes #666