### PR TITLE
fix(startup): fail fast when Lua authorizer cannot initialize

### DIFF
--- a/cmd/pithos.go
+++ b/cmd/pithos.go
@@ -171,6 +171,7 @@ func serve(ctx context.Context, logLevelVar *slog.LevelVar) {
 	requestAuthorizer, err := loadRequestAuthorizer(settings.AuthorizerPath(), hasCredentials, settings.TrustForwardedHeaders(), settings.TrustedProxyCIDRs())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Could not create LuaAuthorizer: %s", err))
+		os.Exit(1)
 	}
 
 	handler := server.SetupServer(settings.Credentials(), settings.Region(), settings.Domain(), settings.WebsiteDomain(), requestAuthorizer, store)


### PR DESCRIPTION
## Summary
- make `serve` exit immediately when Lua authorizer creation fails
- avoid starting the HTTP server in an invalid authorization state
- surface startup misconfiguration as a clear boot-time failure

## Testing
- `go test ./...`

## Related
- Closes #667