### PR TITLE
security(vault): add HTTP client and transport timeouts

### DIFF
--- a/internal/pkg/vault/auth.go
+++ b/internal/pkg/vault/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -43,8 +44,19 @@ func AuthenticateWithAppRole(vaultAddr, roleID, secretID string, tlsConfig *tls.
 	// Configure HTTP client
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
 	}
-	client := &http.Client{Transport: transport}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   15 * time.Second,
+	}
 
 	// Make the login request
 	loginURL := strings.TrimRight(httpAddr, "/") + "/v1/auth/approle/login"


### PR DESCRIPTION
## Summary
- configure dial, TLS handshake, response header, and idle connection timeouts for Vault AppRole HTTP transport
- add a request-level timeout on the Vault auth HTTP client
- prevent auth and token-refresh code paths from hanging indefinitely under network stalls

## Testing
- `go test ./...`

## Related
- Closes #673