### PR TITLE
security(audit): default audit log file sink to mode 0600

### DIFF
--- a/internal/auditlog/sink/writer.go
+++ b/internal/auditlog/sink/writer.go
@@ -37,7 +37,7 @@ func (s *WriterSink) InitialState() (*InitialState, error) {
 }
 
 func NewFileSink(path string, serializer serialization.Serializer) (*WriterSink, error) {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- tighten default permissions for audit log files from `0644` to `0600`
- keep audit sink behavior unchanged while reducing default data exposure risk

## Testing
- `go test ./...`

## Related
- Closes #672