### PR TITLE
security(observability): attach request IDs to API error responses

### DIFF
--- a/cmd/pithos.go
+++ b/cmd/pithos.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jdillenkofer/pithos/internal/dependencyinjection"
 	"github.com/jdillenkofer/pithos/internal/http/server"
 	"github.com/jdillenkofer/pithos/internal/http/server/authorization/lua"
+	"github.com/jdillenkofer/pithos/internal/logging"
 	"github.com/jdillenkofer/pithos/internal/settings"
 	"github.com/jdillenkofer/pithos/internal/storage"
 	"github.com/jdillenkofer/pithos/internal/storage/benchmark"
@@ -116,10 +117,11 @@ func main() {
 
 func setupLogging() *slog.LevelVar {
 	var logLevelVar = new(slog.LevelVar)
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	baseHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		AddSource: true,
 		Level:     logLevelVar,
-	}))
+	})
+	logger := slog.New(logging.NewContextEnrichingHandler(baseHandler))
 	slog.SetDefault(logger)
 	return logLevelVar
 }

--- a/internal/http/middleware/hostrouting.go
+++ b/internal/http/middleware/hostrouting.go
@@ -1,20 +1,16 @@
-package middlewares
+package middleware
 
 import (
 	"net/http"
 	"strings"
 )
 
-// MakeHostnameRoutingHandler creates an http.Handler that routes requests
-// based on the hostname. It delegates to apiHandler for API hostnames and
-// to websiteHandler for website hostnames and custom domain fallbacks.
 func MakeHostnameRoutingHandler(apiEndpoint string, apiHandler http.Handler, websiteEndpoint string, websiteHandler http.Handler, fallbackHandler http.Handler) http.Handler {
 	apiSuffix := "." + apiEndpoint
 	websiteSuffix := "." + websiteEndpoint
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
-		// Strip port if present
 		if colonIdx := strings.LastIndex(host, ":"); colonIdx != -1 {
 			if bracketIdx := strings.LastIndex(host, "]"); bracketIdx < colonIdx {
 				host = host[:colonIdx]

--- a/internal/http/middleware/requestcontext.go
+++ b/internal/http/middleware/requestcontext.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/jdillenkofer/pithos/internal/http/server/authentication"
+	"github.com/oklog/ulid/v2"
+)
+
+const requestIDHeader = "x-amz-request-id"
+
+type requestIDContextKey struct{}
+
+type statusResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (w *statusResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func MakeRequestContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ctx := r.Context()
+		requestID, ok := ctx.Value(authentication.RequestIDContextKey{}).(string)
+		if !ok || requestID == "" {
+			requestID = ulid.Make().String()
+			ctx = context.WithValue(ctx, authentication.RequestIDContextKey{}, requestID)
+		}
+		ctx = context.WithValue(ctx, requestIDContextKey{}, requestID)
+
+		w.Header().Set(requestIDHeader, requestID)
+		wrappedWriter := &statusResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(wrappedWriter, r.WithContext(ctx))
+
+		slog.InfoContext(
+			ctx,
+			"Request completed",
+			"method", r.Method,
+			"host", r.Host,
+			"path", r.URL.Path,
+			"status", wrappedWriter.statusCode,
+			"durationMs", time.Since(start).Milliseconds(),
+		)
+	})
+}
+
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	requestID, ok := ctx.Value(requestIDContextKey{}).(string)
+	if !ok || requestID == "" {
+		return "", false
+	}
+	return requestID, true
+}

--- a/internal/http/middleware/virtualhostbucketaddressing.go
+++ b/internal/http/middleware/virtualhostbucketaddressing.go
@@ -1,4 +1,4 @@
-package middlewares
+package middleware
 
 import (
 	"net/http"
@@ -9,9 +9,7 @@ func MakeVirtualHostBucketAddressingMiddleware(baseEndpoint string, next http.Ha
 	endpointSuffix := "." + baseEndpoint
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hostname := r.Host
-		// Strip port if present (e.g. "test.s3.localhost:9000" → "test.s3.localhost")
 		if colonIdx := strings.LastIndex(hostname, ":"); colonIdx != -1 {
-			// Make sure it's not an IPv6 address
 			if bracketIdx := strings.LastIndex(hostname, "]"); bracketIdx < colonIdx {
 				hostname = hostname[:colonIdx]
 			}

--- a/internal/http/server/authentication/signature.go
+++ b/internal/http/server/authentication/signature.go
@@ -301,43 +301,43 @@ func checkAuthentication(validCredentials []Credentials, expectedRegion string, 
 
 	authorizationHeader := r.Header.Get("Authorization")
 	if authorizationHeader == "" {
-		slog.Debug("Authorization header is missing checking for query parameters")
+		slog.DebugContext(r.Context(), "Authorization header is missing checking for query parameters")
 		isPresigned = true
 		query := r.URL.Query()
 		credential = query.Get("X-Amz-Credential")
 		timestamp = query.Get("X-Amz-Date")
 		expires := query.Get("X-Amz-Expires")
-		slog.Debug("Using presigned auth query parameters")
+		slog.DebugContext(r.Context(), "Using presigned auth query parameters")
 		parsedExpired, err := strconv.ParseInt(expires, 10, 32)
 		if err != nil {
-			slog.Debug("Failed to parse X-Amz-Expires: " + err.Error())
+			slog.DebugContext(r.Context(), "Failed to parse X-Amz-Expires: "+err.Error())
 			return nil, false
 		}
 		if parsedExpired < 1 || parsedExpired > 604800 {
-			slog.Debug("X-Amz-Expires must be between 1 and 604800 seconds")
+			slog.DebugContext(r.Context(), "X-Amz-Expires must be between 1 and 604800 seconds")
 			return nil, false
 		}
 		expirationDuration = time.Duration(parsedExpired) * time.Second
 		signedHeaders = query.Get("X-Amz-SignedHeaders")
 		signature = query.Get("X-Amz-Signature")
 	} else {
-		slog.Debug("Authorization header is present")
+		slog.DebugContext(r.Context(), "Authorization header is present")
 		isPresigned = false
 		authorizationHeader, found := strings.CutPrefix(authorizationHeader, signatureAlgorithm)
 		if !found {
-			slog.Debug("Authorization header does not start with " + signatureAlgorithm)
+			slog.DebugContext(r.Context(), "Authorization header does not start with "+signatureAlgorithm)
 			return nil, false
 		}
 		authFields := strings.Split(authorizationHeader, ",")
 		if len(authFields) != 3 {
-			slog.Debug("Authorization header does not contain exactly 3 fields")
+			slog.DebugContext(r.Context(), "Authorization header does not contain exactly 3 fields")
 			return nil, false
 		}
 
 		credential = strings.TrimSpace(authFields[0])
 		credential, found = strings.CutPrefix(credential, "Credential=")
 		if !found {
-			slog.Debug("Authorization header does not contain Credential field")
+			slog.DebugContext(r.Context(), "Authorization header does not contain Credential field")
 			return nil, false
 		}
 
@@ -353,21 +353,21 @@ func checkAuthentication(validCredentials []Credentials, expectedRegion string, 
 		signedHeaders = strings.TrimSpace(authFields[1])
 		signedHeaders, found = strings.CutPrefix(signedHeaders, "SignedHeaders=")
 		if !found {
-			slog.Debug("Authorization header does not contain SignedHeaders field")
+			slog.DebugContext(r.Context(), "Authorization header does not contain SignedHeaders field")
 			return nil, false
 		}
 
 		signature = strings.TrimSpace(authFields[2])
 		signature, found = strings.CutPrefix(signature, "Signature=")
 		if !found {
-			slog.Debug("Authorization header does not contain Signature field")
+			slog.DebugContext(r.Context(), "Authorization header does not contain Signature field")
 			return nil, false
 		}
 	}
 
 	accessKeyIdAndScope := strings.Split(credential, "/")
 	if len(accessKeyIdAndScope) != 5 {
-		slog.Debug("Credential field does not contain exactly 5 parts")
+		slog.DebugContext(r.Context(), "Credential field does not contain exactly 5 parts")
 		return nil, false
 	}
 	accessKeyId := accessKeyIdAndScope[0]
@@ -375,30 +375,30 @@ func checkAuthentication(validCredentials []Credentials, expectedRegion string, 
 		return c.AccessKeyId == accessKeyId
 	})
 	if foundIndex < 0 {
-		slog.Debug("Access key ID not found in valid credentials")
+		slog.DebugContext(r.Context(), "Access key ID not found in valid credentials")
 		return nil, false
 	}
 	expectedCredentials := validCredentials[foundIndex]
 	date := accessKeyIdAndScope[1]
 	if date != expectedDate {
-		slog.Debug("Date in credential does not match expected date")
+		slog.DebugContext(r.Context(), "Date in credential does not match expected date")
 		return nil, false
 	}
 	region := accessKeyIdAndScope[2]
 	if region != expectedRegion {
-		slog.Debug("Region in credential does not match expected region")
+		slog.DebugContext(r.Context(), "Region in credential does not match expected region")
 		return nil, false
 	}
 
 	service := accessKeyIdAndScope[3]
 	if service != expectedService {
-		slog.Debug("Service in credential does not match expected service")
+		slog.DebugContext(r.Context(), "Service in credential does not match expected service")
 		return nil, false
 	}
 
 	request := accessKeyIdAndScope[4]
 	if request != expectedRequest {
-		slog.Debug("Request in credential does not match expected request")
+		slog.DebugContext(r.Context(), "Request in credential does not match expected request")
 		return nil, false
 	}
 
@@ -406,13 +406,13 @@ func checkAuthentication(validCredentials []Credentials, expectedRegion string, 
 
 	parsedTimestamp, err := time.Parse("20060102T150405Z", timestamp)
 	if err != nil {
-		slog.Debug("Failed to parse timestamp: " + err.Error())
+		slog.DebugContext(r.Context(), "Failed to parse timestamp: "+err.Error())
 		return nil, false
 	}
 	beforeTimestamp := parsedTimestamp.Add(-15 * time.Minute)
 	expiredTimestamp := parsedTimestamp.Add(expirationDuration)
 	if now.Before(beforeTimestamp) || now.After(expiredTimestamp) {
-		slog.Debug("Timestamp is not within the valid range (" + beforeTimestamp.Format(time.RFC3339) + " - " + expiredTimestamp.Format(time.RFC3339) + ")")
+		slog.DebugContext(r.Context(), "Timestamp is not within the valid range ("+beforeTimestamp.Format(time.RFC3339)+" - "+expiredTimestamp.Format(time.RFC3339)+")")
 		return nil, false
 	}
 
@@ -420,19 +420,19 @@ func checkAuthentication(validCredentials []Credentials, expectedRegion string, 
 
 	stringToSign, err := generateStringToSign(r, timestamp, scope, signedHeadersArray, isPresigned)
 	if err != nil {
-		slog.Debug("Failed to generate string to sign: " + err.Error())
+		slog.DebugContext(r.Context(), "Failed to generate string to sign: "+err.Error())
 		return nil, false
 	}
 	signingKey := createSigningKey(expectedCredentials.SecretAccessKey, expectedDate, region, expectedService, expectedRequest)
 	calculatedSignature := createSignature(signingKey, *stringToSign)
 	isSignatureValid := subtle.ConstantTimeCompare([]byte(signature), []byte(calculatedSignature)) == 1
 	if !isSignatureValid {
-		slog.Debug("Signature does not match calculated signature")
+		slog.DebugContext(r.Context(), "Signature does not match calculated signature")
 		return nil, false
 	}
 
 	if isAwsChunked {
-		slog.Debug("Request is using AWS Chunked Transfer Encoding")
+		slog.DebugContext(r.Context(), "Request is using AWS Chunked Transfer Encoding")
 		contentEncodingHeader, _ := strings.CutPrefix(contentEncodingHeader, contentEncodingAwsChunked+",")
 		if contentEncodingHeader != "" {
 			r.Header.Set("Content-Encoding", contentEncodingHeader)
@@ -445,13 +445,14 @@ func checkAuthentication(validCredentials []Credentials, expectedRegion string, 
 		trailingHeader := contentSHA256 == contentSHA256StreamingUnsignedPayloadTrailing || contentSHA256 == contentSHA256StreamingPayloadTrailing
 		hasTrailingHeaderWithSignature := contentSHA256 == contentSHA256StreamingPayloadTrailing
 		skipChunkValidation := contentSHA256 == contentSHA256StreamingUnsignedPayloadTrailing || contentSHA256 == contentSHA256StreamingUnsignedPayload
-		r.Body = newAwsChunkReadCloser(r.Body, timestamp, scope, calculatedSignature, signingKey, trailingHeader, hasTrailingHeaderWithSignature, skipChunkValidation)
+		r.Body = newAwsChunkReadCloser(r.Context(), r.Body, timestamp, scope, calculatedSignature, signingKey, trailingHeader, hasTrailingHeaderWithSignature, skipChunkValidation)
 	}
 
 	return &accessKeyId, isSignatureValid
 }
 
 type awsChunkReadCloser struct {
+	ctx                            context.Context
 	innerCloser                    io.Closer
 	innerBuf                       *bufio.Reader
 	chunkBytesRemaining            int64
@@ -466,8 +467,9 @@ type awsChunkReadCloser struct {
 	skipChunkValidation            bool
 }
 
-func newAwsChunkReadCloser(inner io.ReadCloser, timestamp string, scope string, previousSignature string, signingKey []byte, hasTrailingHeader bool, hasTrailingHeaderWithSignature bool, skipChunkValidation bool) *awsChunkReadCloser {
+func newAwsChunkReadCloser(ctx context.Context, inner io.ReadCloser, timestamp string, scope string, previousSignature string, signingKey []byte, hasTrailingHeader bool, hasTrailingHeaderWithSignature bool, skipChunkValidation bool) *awsChunkReadCloser {
 	return &awsChunkReadCloser{
+		ctx:                            ctx,
 		innerCloser:                    inner,
 		innerBuf:                       bufio.NewReader(inner),
 		chunkBytesRemaining:            -1, // -1 indicates that we are not currently reading a chunk
@@ -488,7 +490,7 @@ func (r *awsChunkReadCloser) validateSignature() error {
 	calculatedSignature := createSignature(r.signingKey, stringToSign)
 	isSignatureValid := subtle.ConstantTimeCompare([]byte(r.chunkSignature), []byte(calculatedSignature)) == 1
 	if !isSignatureValid {
-		slog.Debug("Chunk signature does not match calculated chunk signature")
+		slog.DebugContext(r.ctx, "Chunk signature does not match calculated chunk signature")
 		return ErrChunkSignatureMismatch
 	}
 
@@ -537,14 +539,14 @@ func (r *awsChunkReadCloser) Read(p []byte) (n int, err error) {
 				checksumHeader = strings.TrimSpace(checksumHeader)
 				trailerSignature = strings.TrimSpace(trailerSignature)
 				trailerSignature = strings.TrimPrefix(trailerSignature, "x-amz-trailer-signature:")
-				slog.Debug("Validating trailing headers")
+				slog.DebugContext(r.ctx, "Validating trailing headers")
 
 				if r.hasTrailingHeaderWithSignature {
 					stringToSign := generateStringToSignForTrailerChunk(r.timestamp, r.scope, r.previousSignature, checksumHeader)
 					calculatedSignature := createSignature(r.signingKey, stringToSign)
 					isSignatureValid := subtle.ConstantTimeCompare([]byte(trailerSignature), []byte(calculatedSignature)) == 1
 					if !isSignatureValid {
-						slog.Debug("Trailing header signature does not match calculated signature")
+						slog.DebugContext(r.ctx, "Trailing header signature does not match calculated signature")
 						return 0, ErrChunkSignatureMismatch
 					}
 				}

--- a/internal/http/server/authentication/signature_test.go
+++ b/internal/http/server/authentication/signature_test.go
@@ -2,6 +2,7 @@ package authentication
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -102,7 +103,7 @@ func TestCreateSeedSignatureFromAwsChunkRequest(t *testing.T) {
 	hasTrailingHeader := false
 	hasTrailingHeaderWithSignature := false
 	skipChunkValidation := false
-	r.Body = newAwsChunkReadCloser(io.NopCloser(bytes.NewReader(content)), timestamp, scope, expectedSignature, signingKey, hasTrailingHeader, hasTrailingHeaderWithSignature, skipChunkValidation)
+	r.Body = newAwsChunkReadCloser(context.Background(), io.NopCloser(bytes.NewReader(content)), timestamp, scope, expectedSignature, signingKey, hasTrailingHeader, hasTrailingHeaderWithSignature, skipChunkValidation)
 
 	seedSignature := createSignature(signingKey, *stringToSign)
 	assert.Equal(t, expectedSignature, seedSignature)
@@ -162,7 +163,7 @@ func TestCreateSeedSignatureFromAwsChunkRequestWithTrailingHeader(t *testing.T) 
 	hasTrailingHeader := true
 	hasTrailingHeaderWithSignature := true
 	skipChunkValidation := false
-	r.Body = newAwsChunkReadCloser(io.NopCloser(bytes.NewReader(content)), timestamp, scope, expectedSignature, signingKey, hasTrailingHeader, hasTrailingHeaderWithSignature, skipChunkValidation)
+	r.Body = newAwsChunkReadCloser(context.Background(), io.NopCloser(bytes.NewReader(content)), timestamp, scope, expectedSignature, signingKey, hasTrailingHeader, hasTrailingHeaderWithSignature, skipChunkValidation)
 
 	seedSignature := createSignature(signingKey, *stringToSign)
 	assert.Equal(t, expectedSignature, seedSignature)

--- a/internal/http/server/authorization/lua/luaauthorizer.go
+++ b/internal/http/server/authorization/lua/luaauthorizer.go
@@ -373,13 +373,13 @@ func (authorizer *LuaAuthorizer) callAuthorizerFunction(ctx context.Context, fun
 	L.Pop(1)
 	err := lua.DoString(L, authorizer.code)
 	if err != nil {
-		slog.Error("Error while executing Lua code", "error", err)
+		slog.ErrorContext(ctx, "Error while executing Lua code", "error", err)
 		return false, err
 	}
 	L.Global(functionName)
 	if !L.IsFunction(-1) {
 		if functionName == authorizationFunctionName {
-			slog.Error("Authorization function not found in Lua code", "functionName", authorizationFunctionName)
+			slog.ErrorContext(ctx, "Authorization function not found in Lua code", "functionName", authorizationFunctionName)
 			return false, errAuthorizationFunctionNotFound
 		}
 		return true, nil
@@ -391,12 +391,12 @@ func (authorizer *LuaAuthorizer) callAuthorizerFunction(ctx context.Context, fun
 	}
 	err = L.ProtectedCall(argCount, 1, 0)
 	if err != nil {
-		slog.Error("Error while calling authorization function", "error", err)
+		slog.ErrorContext(ctx, "Error while calling authorization function", "error", err)
 		return false, err
 	}
 	res := L.ToBoolean(1)
 	L.Pop(1)
-	slog.Debug("Authorization result", "operation", request.Operation, "isAuthorized", res)
+	slog.DebugContext(ctx, "Authorization result", "operation", request.Operation, "isAuthorized", res)
 	return res, nil
 }
 

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/jdillenkofer/pithos/internal/http/httputils"
-	"github.com/jdillenkofer/pithos/internal/http/middlewares"
+	httpmiddleware "github.com/jdillenkofer/pithos/internal/http/middleware"
 	"github.com/jdillenkofer/pithos/internal/http/server/authentication"
 	"github.com/jdillenkofer/pithos/internal/http/server/authorization"
 	"github.com/jdillenkofer/pithos/internal/ioutils"
@@ -59,7 +59,7 @@ func SetupServer(credentials []settings.Credentials, region string, apiEndpoint 
 	apiMux.HandleFunc("PUT /{bucket}/{key...}", server.uploadPartOrPutObjectHandler)
 	apiMux.HandleFunc("DELETE /{bucket}/{key...}", server.abortMultipartUploadOrDeleteObjectHandler)
 	var apiHandler http.Handler = apiMux
-	apiHandler = middlewares.MakeVirtualHostBucketAddressingMiddleware(apiEndpoint, apiHandler)
+	apiHandler = httpmiddleware.MakeVirtualHostBucketAddressingMiddleware(apiEndpoint, apiHandler)
 
 	websiteMux := http.NewServeMux()
 	websiteMux.HandleFunc("GET /{bucket}/{key...}", server.serveWebsiteGetObject)
@@ -77,12 +77,12 @@ func SetupServer(credentials []settings.Credentials, region string, apiEndpoint 
 			}
 		}
 		r.URL.Path = "/" + host + r.URL.Path
-		slog.Debug("Custom domain website request", "host", r.Host, "bucket", host, "path", r.URL.Path)
+		slog.DebugContext(r.Context(), "Custom domain website request", "host", r.Host, "bucket", host, "path", r.URL.Path)
 		websiteHandler.ServeHTTP(w, r)
 	})
 
 	// Set up handler with hostname-based routing.
-	rootHandler := middlewares.MakeHostnameRoutingHandler(apiEndpoint, apiHandler, websiteEndpoint, websiteHandler, fallbackHandler)
+	rootHandler := httpmiddleware.MakeHostnameRoutingHandler(apiEndpoint, apiHandler, websiteEndpoint, websiteHandler, fallbackHandler)
 	rootHandler = makeAuditRequestContextMiddleware(rootHandler)
 
 	var authCreds []authentication.Credentials
@@ -98,6 +98,7 @@ func SetupServer(credentials []settings.Credentials, region string, apiEndpoint 
 	} else {
 		slog.Warn("Authentication is disabled, this is not recommended for production use")
 	}
+	rootHandler = httpmiddleware.MakeRequestContextMiddleware(rootHandler)
 
 	return rootHandler
 }
@@ -111,7 +112,6 @@ func makeAuditRequestContextMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
-
 func makeHealthCheckHandler(dbs []database.Database) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -508,6 +508,9 @@ func handleError(err error, w http.ResponseWriter, r *http.Request) {
 	errResponse.Code = err.Error()
 	errResponse.Message = err.Error()
 	errResponse.Resource = r.URL.Path
+	if requestID, ok := httpmiddleware.RequestIDFromContext(r.Context()); ok {
+		errResponse.RequestId = requestID
+	}
 	switch err {
 	case storage.ErrInvalidBucketName:
 		statusCode = 400
@@ -538,14 +541,14 @@ func handleError(err error, w http.ResponseWriter, r *http.Request) {
 	case storage.ErrNotModified:
 		statusCode = 304
 	default:
-		slog.Error(fmt.Sprintf("Unhandled internal error: %v", err))
+		slog.ErrorContext(r.Context(), fmt.Sprintf("Unhandled internal error: %v", err))
 		statusCode = 500
 		errResponse.Code = "InternalError"
 		errResponse.Message = "InternalError"
 	}
 	xmlErrorResponse, err := xmlMarshalWithDocType(errResponse)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Error during handleError: %v", err))
+		slog.ErrorContext(r.Context(), fmt.Sprintf("Error during handleError: %v", err))
 		return
 	}
 	w.WriteHeader(statusCode)
@@ -556,12 +559,12 @@ func (s *Server) authorizeRequest(ctx context.Context, operation string, bucket 
 	request, isAuthenticated := makeAuthorizationRequest(ctx, operation, bucket, key, r)
 	authorized, err := s.requestAuthorizer.AuthorizeRequest(ctx, request)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Authorization error: %v", err))
+		slog.ErrorContext(ctx, fmt.Sprintf("Authorization error: %v", err))
 		handleError(err, w, r)
 		return true
 	}
 	if !authorized {
-		slog.Debug(fmt.Sprintf("Unauthorized request: %v", request))
+		slog.DebugContext(ctx, fmt.Sprintf("Unauthorized request: %v", request))
 		if !isAuthenticated {
 			w.WriteHeader(401)
 		} else {
@@ -715,7 +718,7 @@ func (s *Server) listBucketsHandler(w http.ResponseWriter, r *http.Request) {
 	if shouldReturn {
 		return
 	}
-	slog.Info("Listing Buckets")
+	slog.InfoContext(r.Context(), "Listing Buckets")
 	buckets, err := s.storage.ListBuckets(ctx)
 	if err != nil {
 		handleError(err, w, r)
@@ -759,7 +762,7 @@ func (s *Server) headBucketHandler(w http.ResponseWriter, r *http.Request) {
 	if shouldReturn {
 		return
 	}
-	slog.Info("Head bucket", "bucket", bucketName)
+	slog.InfoContext(r.Context(), "Head bucket", "bucket", bucketName)
 	_, err = s.storage.HeadBucket(ctx, bucketName)
 	if err != nil {
 		handleError(err, w, r)
@@ -816,7 +819,7 @@ func (s *Server) listMultipartUploadsHandler(w http.ResponseWriter, r *http.Requ
 	maxUploadsI32 := int32(maxUploadsI64)
 
 	opts := storage.ListMultipartUploadsOptions{Prefix: prefix, Delimiter: delimiter, KeyMarker: keyMarker, UploadIdMarker: uploadIdMarker, MaxUploads: maxUploadsI32}
-	slog.Info("Listing MultipartUploads")
+	slog.InfoContext(r.Context(), "Listing MultipartUploads")
 	result, nextKeyMarker, nextUploadIDMarker, err := s.listAndFilterMultipartUploads(ctx, r, bucketName, opts)
 	if err != nil {
 		handleError(err, w, r)
@@ -972,7 +975,7 @@ func (s *Server) listObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	maxKeysI32 := int32(maxKeysI64)
 
 	opts := storage.ListObjectsOptions{Prefix: prefix, Delimiter: delimiter, StartAfter: startAfter, MaxKeys: maxKeysI32}
-	slog.Info("Listing objects", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Listing objects", "bucket", bucketName.String())
 	result, nextMarker, err := s.listAndFilterObjects(ctx, r, bucketName, opts)
 	if err != nil {
 		handleError(err, w, r)
@@ -1123,7 +1126,7 @@ func (s *Server) listObjectsV2Handler(w http.ResponseWriter, r *http.Request) {
 	maxKeysI32 := int32(maxKeysI64)
 
 	opts := storage.ListObjectsOptions{Prefix: prefix, Delimiter: delimiter, StartAfter: startAfter, MaxKeys: maxKeysI32}
-	slog.Info("Listing objects V2", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Listing objects V2", "bucket", bucketName.String())
 	result, nextToken, err := s.listAndFilterObjects(ctx, r, bucketName, opts)
 	if err != nil {
 		handleError(err, w, r)
@@ -1196,7 +1199,7 @@ func (s *Server) createBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Creating bucket", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Creating bucket", "bucket", bucketName.String())
 	err = s.storage.CreateBucket(ctx, bucketName)
 	if err != nil {
 		handleError(err, w, r)
@@ -1231,7 +1234,7 @@ func (s *Server) deleteBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Deleting bucket", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Deleting bucket", "bucket", bucketName.String())
 	err = s.storage.DeleteBucket(ctx, bucketName)
 	if err != nil {
 		handleError(err, w, r)
@@ -1260,7 +1263,7 @@ func (s *Server) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Head object", "bucket", bucketName.String(), "key", key.String())
+	slog.InfoContext(r.Context(), "Head object", "bucket", bucketName.String(), "key", key.String())
 
 	var headOpts *storage.HeadObjectOptions
 	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
@@ -1546,7 +1549,7 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rangeHeaderValue := r.Header.Get(rangeHeader)
-	slog.Info("Getting object", "bucket", bucketName.String(), "key", key.String())
+	slog.InfoContext(r.Context(), "Getting object", "bucket", bucketName.String(), "key", key.String())
 
 	// Parse range header and convert to storage.ByteRange (validation will be done in GetObject)
 	storageRanges, err := parseRangeHeader(rangeHeaderValue)
@@ -1699,7 +1702,7 @@ func (s *Server) createMultipartUploadHandler(w http.ResponseWriter, r *http.Req
 
 	contentType := getHeaderAsPtr(r.Header, contentTypeHeader)
 	checksumType := getHeaderAsPtr(r.Header, checksumTypeHeader)
-	slog.Info("CreateMultipartUpload", "bucket", bucketName.String(), "key", key.String())
+	slog.InfoContext(r.Context(), "CreateMultipartUpload", "bucket", bucketName.String(), "key", key.String())
 	result, err := s.storage.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
 	if err != nil {
 		handleError(err, w, r)
@@ -1776,7 +1779,7 @@ func (s *Server) completeMultipartUploadHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedBody(r, w, maxCompleteMultipartUploadBodySize)
 	if err != nil {
 		handleError(err, w, r)
 		return
@@ -1791,7 +1794,7 @@ func (s *Server) completeMultipartUploadHandler(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	slog.Info("CompleteMultipartUpload", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String())
+	slog.InfoContext(r.Context(), "CompleteMultipartUpload", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String())
 	result, err := s.storage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, completeOpts)
 	if err != nil {
 		handleError(err, w, r)
@@ -1892,7 +1895,7 @@ func (s *Server) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("UploadPart", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String(), "partNumber", partNumber)
+	slog.InfoContext(r.Context(), "UploadPart", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String(), "partNumber", partNumber)
 	if !query.Has(uploadIdQuery) || !query.Has(partNumberQuery) {
 		w.WriteHeader(400)
 		return
@@ -1979,7 +1982,7 @@ func (s *Server) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Putting object", "bucket", bucketName.String(), "key", key.String())
+	slog.InfoContext(r.Context(), "Putting object", "bucket", bucketName.String(), "key", key.String())
 	if r.Header.Get(expectHeader) == "100-continue" {
 		w.WriteHeader(100)
 	}
@@ -2045,7 +2048,7 @@ func (s *Server) appendObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Appending to object", "bucket", bucketName.String(), "key", key.String())
+	slog.InfoContext(r.Context(), "Appending to object", "bucket", bucketName.String(), "key", key.String())
 	if r.Header.Get(expectHeader) == "100-continue" {
 		w.WriteHeader(100)
 	}
@@ -2108,7 +2111,7 @@ func (s *Server) abortMultipartUploadHandler(w http.ResponseWriter, r *http.Requ
 		handleError(err, w, r)
 		return
 	}
-	slog.Info("AbortMultipartUpload", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String())
+	slog.InfoContext(r.Context(), "AbortMultipartUpload", "bucket", bucketName.String(), "key", key.String(), "uploadId", uploadId.String())
 	err = s.storage.AbortMultipartUpload(ctx, bucketName, key, uploadId)
 	if err != nil {
 		handleError(err, w, r)
@@ -2136,7 +2139,7 @@ func (s *Server) deleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Deleting object", "bucket", bucketName.String(), "key", key.String())
+	slog.InfoContext(r.Context(), "Deleting object", "bucket", bucketName.String(), "key", key.String())
 	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
 	var deleteOpts *storage.DeleteObjectOptions
 	if ifMatch != nil {
@@ -2174,6 +2177,22 @@ func (s *Server) postBucketHandler(w http.ResponseWriter, r *http.Request) {
 
 const maxDeleteObjects = 1000
 
+const maxCompleteMultipartUploadBodySize int64 = 10 * 1024 * 1024
+const maxDeleteObjectsBodySize int64 = 5 * 1024 * 1024
+const maxPutBucketWebsiteBodySize int64 = 128 * 1024
+
+func readLimitedBody(r *http.Request, w http.ResponseWriter, maxBodySize int64) ([]byte, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			return nil, storage.ErrEntityTooLarge
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
 func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, span := s.tracer.Start(r.Context(), "Server.deleteObjectsHandler")
 	defer span.End()
@@ -2189,7 +2208,7 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedBody(r, w, maxDeleteObjectsBodySize)
 	if err != nil {
 		handleError(err, w, r)
 		return
@@ -2271,7 +2290,7 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 			inputEntries[i] = storage.DeleteObjectsInputEntry{Key: ve.key, IfMatchETag: ve.etag}
 		}
 
-		slog.Info("DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(inputEntries))
+		slog.InfoContext(r.Context(), "DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(inputEntries))
 		deleteResult, err := s.storage.DeleteObjects(ctx, bucketName, inputEntries)
 		if err != nil {
 			if err == storage.ErrNoSuchBucket {
@@ -2326,7 +2345,7 @@ func (s *Server) getBucketWebsiteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	slog.Info("Getting bucket website configuration", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Getting bucket website configuration", "bucket", bucketName.String())
 	config, err := s.storage.GetBucketWebsiteConfiguration(ctx, bucketName)
 	if err != nil {
 		handleError(err, w, r)
@@ -2367,7 +2386,7 @@ func (s *Server) putBucketWebsiteHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedBody(r, w, maxPutBucketWebsiteBodySize)
 	if err != nil {
 		handleError(err, w, r)
 		return
@@ -2403,7 +2422,7 @@ func (s *Server) putBucketWebsiteHandler(w http.ResponseWriter, r *http.Request)
 		config.ErrorDocumentKey = &request.ErrorDocument.Key
 	}
 
-	slog.Info("Putting bucket website configuration", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Putting bucket website configuration", "bucket", bucketName.String())
 	err = s.storage.PutBucketWebsiteConfiguration(ctx, bucketName, config)
 	if err != nil {
 		handleError(err, w, r)
@@ -2427,7 +2446,7 @@ func (s *Server) deleteBucketWebsiteHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	slog.Info("Deleting bucket website configuration", "bucket", bucketName.String())
+	slog.InfoContext(r.Context(), "Deleting bucket website configuration", "bucket", bucketName.String())
 	err = s.storage.DeleteBucketWebsiteConfiguration(ctx, bucketName)
 	if err != nil {
 		handleError(err, w, r)
@@ -2528,7 +2547,7 @@ func (s *Server) serveWebsiteGetObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("Website: getting object", "bucket", bucketName.String(), "key", resolvedKey)
+	slog.InfoContext(r.Context(), "Website: getting object", "bucket", bucketName.String(), "key", resolvedKey)
 
 	object, readers, err := s.storage.GetObject(ctx, bucketName, objectKey, nil, nil)
 	if err != nil {
@@ -2578,7 +2597,7 @@ func (s *Server) serveWebsiteHeadObject(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	slog.Info("Website: head object", "bucket", bucketName.String(), "key", resolvedKey)
+	slog.InfoContext(r.Context(), "Website: head object", "bucket", bucketName.String(), "key", resolvedKey)
 
 	object, err := s.storage.HeadObject(ctx, bucketName, objectKey, nil)
 	if err != nil {

--- a/internal/logging/contextenrichinghandler.go
+++ b/internal/logging/contextenrichinghandler.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	httpmiddleware "github.com/jdillenkofer/pithos/internal/http/middleware"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ContextEnrichingHandler struct {
+	next slog.Handler
+}
+
+func NewContextEnrichingHandler(next slog.Handler) *ContextEnrichingHandler {
+	return &ContextEnrichingHandler{next: next}
+}
+
+func (h *ContextEnrichingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *ContextEnrichingHandler) Handle(ctx context.Context, record slog.Record) error {
+	record = record.Clone()
+	if requestID, ok := httpmiddleware.RequestIDFromContext(ctx); ok {
+		record.AddAttrs(slog.String("requestId", requestID))
+	}
+
+	spanContext := trace.SpanContextFromContext(ctx)
+	if spanContext.IsValid() {
+		record.AddAttrs(
+			slog.String("traceId", spanContext.TraceID().String()),
+			slog.String("spanId", spanContext.SpanID().String()),
+		)
+	}
+
+	return h.next.Handle(ctx, record)
+}
+
+func (h *ContextEnrichingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ContextEnrichingHandler{next: h.next.WithAttrs(attrs)}
+}
+
+func (h *ContextEnrichingHandler) WithGroup(name string) slog.Handler {
+	return &ContextEnrichingHandler{next: h.next.WithGroup(name)}
+}


### PR DESCRIPTION
## Summary
- move HTTP middleware from `internal/http/middlewares` to `internal/http/middleware`
- add request context middleware that sets `x-amz-request-id`, propagates request IDs through context, and keeps audit request metadata intact
- include request IDs in XML API error responses (`ErrorResponse.RequestId`) for client-visible correlation
- add a context-enriching slog handler to attach `requestId` plus OpenTelemetry `traceId`/`spanId` to context-aware logs
- switch HTTP request-path logging to `slog.*Context(...)` so IDs are injected without changing each log message manually

## Testing
- `go test ./...`

## Related
- Closes #677