### PR TITLE
refactor(boundaries): remove metadatastore import from HTTP server

### DIFF
--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -26,7 +26,6 @@ import (
 	"github.com/jdillenkofer/pithos/internal/settings"
 	"github.com/jdillenkofer/pithos/internal/sliceutils"
 	"github.com/jdillenkofer/pithos/internal/storage/database"
-	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -1990,7 +1989,7 @@ func (s *Server) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 		ChecksumSHA1:      putObjectResult.ChecksumSHA1,
 		ChecksumSHA256:    putObjectResult.ChecksumSHA256,
 	})
-	setChecksumType(responseHeaders, metadatastore.ChecksumTypeFullObject)
+	setChecksumType(responseHeaders, storage.ChecksumTypeFullObject)
 	w.WriteHeader(200)
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -83,6 +83,9 @@ type AppendObjectResult struct {
 
 type CompleteMultipartUploadOptions = metadatastore.CompleteMultipartUploadOptions
 
+const ChecksumTypeFullObject = metadatastore.ChecksumTypeFullObject
+const ChecksumTypeComposite = metadatastore.ChecksumTypeComposite
+
 type DeleteObjectOptions struct {
 	// IfMatchETag, when non-nil, requires the stored object's ETag to equal this
 	// value before deleting; otherwise ErrPreconditionFailed is returned.


### PR DESCRIPTION
## Summary
- expose checksum type constants through `internal/storage`
- switch HTTP server checksum header path to use `storage.ChecksumTypeFullObject`
- remove direct HTTP dependency on `metadatastore` internals

## Testing
- `go test ./...`

## Related
- Closes #676