### PR TITLE
Replace object ETag CAS with optimistic lock version

### DIFF
--- a/internal/storage/database/pgx/migrations/11_object_optimistic_lock_version.down.sql
+++ b/internal/storage/database/pgx/migrations/11_object_optimistic_lock_version.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE objects DROP COLUMN optimistic_lock_version;

--- a/internal/storage/database/pgx/migrations/11_object_optimistic_lock_version.up.sql
+++ b/internal/storage/database/pgx/migrations/11_object_optimistic_lock_version.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE objects ADD COLUMN optimistic_lock_version BIGINT NOT NULL DEFAULT 1;

--- a/internal/storage/database/pgx/repository/object/pgx.go
+++ b/internal/storage/database/pgx/repository/object/pgx.go
@@ -15,18 +15,19 @@ type pgxRepository struct {
 }
 
 const (
-	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"
-	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) ON CONFLICT DO NOTHING"
-	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, updated_at = $14 WHERE id = $15"
+	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)"
+	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT DO NOTHING"
+	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15"
+	updateObjectByIdAndOptimisticLockVersionStmt                                                 = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15 AND optimistic_lock_version = $16"
 	containsBucketObjectsByBucketNameStmt                                                        = "SELECT id FROM objects WHERE bucket_name = $1"
-	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
-	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
-	findObjectByBucketNameAndKeyAndUploadIdStmt                                                  = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
-	findObjectByBucketNameAndKeyStmt                                                             = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3"
+	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
+	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
+	findObjectByBucketNameAndKeyAndUploadIdStmt                                                  = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
+	findObjectByBucketNameAndKeyStmt                                                             = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3"
 	countObjectsByBucketNameAndPrefixAndStartAfterStmt                                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_status = $4"
 	countObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerStmt                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5"
 	deleteObjectByIdStmt                                                                         = "DELETE FROM objects WHERE id = $1"
-	deleteObjectByIdAndETagStmt                                                                  = "DELETE FROM objects WHERE id = $1 AND etag = $2"
+	deleteObjectByIdAndOptimisticLockVersionStmt                                                 = "DELETE FROM objects WHERE id = $1 AND optimistic_lock_version = $2"
 )
 
 func NewRepository() (object.Repository, error) {
@@ -48,30 +49,32 @@ func convertRowToObjectEntity(objectRows *sql.Rows) (*object.Entity, error) {
 	var size int64
 	var uploadStatus string
 	var uploadId *string
+	var optimisticLockVersion int64
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &uploadStatus, &uploadId, &createdAt, &updatedAt)
+	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &uploadStatus, &uploadId, &optimisticLockVersion, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
 	ulidId := ulid.MustParse(id)
 	objectEntity := object.Entity{
-		Id:                &ulidId,
-		BucketName:        storage.MustNewBucketName(bucketName),
-		Key:               storage.MustNewObjectKey(key),
-		ContentType:       contentType,
-		ETag:              etag,
-		ChecksumCRC32:     checksumCRC32,
-		ChecksumCRC32C:    checksumCRC32C,
-		ChecksumCRC64NVME: checksumCRC64NVME,
-		ChecksumSHA1:      checksumSHA1,
-		ChecksumSHA256:    checksumSHA256,
-		ChecksumType:      checksumType,
-		Size:              size,
-		UploadStatus:      uploadStatus,
-		UploadId:          ptrutils.MapPtr(uploadId, storage.MustNewUploadId),
-		CreatedAt:         createdAt,
-		UpdatedAt:         updatedAt,
+		Id:                    &ulidId,
+		BucketName:            storage.MustNewBucketName(bucketName),
+		Key:                   storage.MustNewObjectKey(key),
+		ContentType:           contentType,
+		ETag:                  etag,
+		ChecksumCRC32:         checksumCRC32,
+		ChecksumCRC32C:        checksumCRC32C,
+		ChecksumCRC64NVME:     checksumCRC64NVME,
+		ChecksumSHA1:          checksumSHA1,
+		ChecksumSHA256:        checksumSHA256,
+		ChecksumType:          checksumType,
+		Size:                  size,
+		UploadStatus:          uploadStatus,
+		UploadId:              ptrutils.MapPtr(uploadId, storage.MustNewUploadId),
+		OptimisticLockVersion: optimisticLockVersion,
+		CreatedAt:             createdAt,
+		UpdatedAt:             updatedAt,
 	}
 	return &objectEntity, nil
 }
@@ -85,11 +88,24 @@ func (or *pgxRepository) SaveObject(ctx context.Context, tx *sql.Tx, object *obj
 		object.Id = &id
 		object.CreatedAt = time.Now().UTC()
 		object.UpdatedAt = object.CreatedAt
-		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.CreatedAt, object.UpdatedAt)
+		if object.OptimisticLockVersion == 0 {
+			object.OptimisticLockVersion = 1
+		}
+		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 		return err
 	}
 	object.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
+	res, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected > 0 {
+		object.OptimisticLockVersion++
+	}
 	return err
 }
 
@@ -104,9 +120,12 @@ func (or *pgxRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, o
 	if object.CreatedAt.IsZero() {
 		object.CreatedAt = time.Now().UTC()
 	}
+	if object.OptimisticLockVersion == 0 {
+		object.OptimisticLockVersion = 1
+	}
 	object.UpdatedAt = object.CreatedAt
 
-	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.CreatedAt, object.UpdatedAt)
+	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +136,26 @@ func (or *pgxRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, o
 	}
 	inserted := rowsAffected > 0
 	return &inserted, nil
+}
+
+func (or *pgxRepository) UpdateObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, object *object.Entity, optimisticLockVersion int64) (*bool, error) {
+	mapUploadIdToString := func(uploadId storage.UploadId) string {
+		return uploadId.String()
+	}
+	object.UpdatedAt = time.Now().UTC()
+	res, err := tx.ExecContext(ctx, updateObjectByIdAndOptimisticLockVersionStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String(), optimisticLockVersion)
+	if err != nil {
+		return nil, err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	updated := rowsAffected > 0
+	if updated {
+		object.OptimisticLockVersion = optimisticLockVersion + 1
+	}
+	return &updated, nil
 }
 
 func (or *pgxRepository) ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error) {
@@ -230,8 +269,8 @@ func (or *pgxRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objec
 	return &deleted, nil
 }
 
-func (or *pgxRepository) DeleteObjectByIdAndETag(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, etag string) (*bool, error) {
-	res, err := tx.ExecContext(ctx, deleteObjectByIdAndETagStmt, objectId.String(), etag)
+func (or *pgxRepository) DeleteObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, optimisticLockVersion int64) (*bool, error) {
+	res, err := tx.ExecContext(ctx, deleteObjectByIdAndOptimisticLockVersionStmt, objectId.String(), optimisticLockVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/database/repository/object/interface.go
+++ b/internal/storage/database/repository/object/interface.go
@@ -12,6 +12,7 @@ import (
 type Repository interface {
 	SaveObject(ctx context.Context, tx *sql.Tx, object *Entity) error
 	InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, object *Entity) (*bool, error)
+	UpdateObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, object *Entity, optimisticLockVersion int64) (*bool, error)
 	ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error)
 	FindObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAsc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) ([]Entity, error)
 	FindUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAsc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, uploadIdMarker string) ([]Entity, error)
@@ -20,26 +21,27 @@ type Repository interface {
 	CountObjectsByBucketNameAndPrefixAndStartAfter(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) (*int, error)
 	CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarker(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, uploadIdMarker string) (*int, error)
 	DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error)
-	DeleteObjectByIdAndETag(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, etag string) (*bool, error)
+	DeleteObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, optimisticLockVersion int64) (*bool, error)
 }
 
 type Entity struct {
-	Id                *ulid.ULID
-	BucketName        storage.BucketName
-	Key               storage.ObjectKey
-	ContentType       *string
-	ETag              string
-	ChecksumCRC32     *string
-	ChecksumCRC32C    *string
-	ChecksumCRC64NVME *string
-	ChecksumSHA1      *string
-	ChecksumSHA256    *string
-	ChecksumType      *string
-	Size              int64
-	UploadStatus      string
-	UploadId          *storage.UploadId
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	Id                    *ulid.ULID
+	BucketName            storage.BucketName
+	Key                   storage.ObjectKey
+	ContentType           *string
+	ETag                  string
+	ChecksumCRC32         *string
+	ChecksumCRC32C        *string
+	ChecksumCRC64NVME     *string
+	ChecksumSHA1          *string
+	ChecksumSHA256        *string
+	ChecksumType          *string
+	Size                  int64
+	UploadStatus          string
+	UploadId              *storage.UploadId
+	OptimisticLockVersion int64
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
 const (

--- a/internal/storage/database/sqlite/migrations/18_object_optimistic_lock_version.down.sql
+++ b/internal/storage/database/sqlite/migrations/18_object_optimistic_lock_version.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE objects DROP COLUMN optimistic_lock_version;

--- a/internal/storage/database/sqlite/migrations/18_object_optimistic_lock_version.up.sql
+++ b/internal/storage/database/sqlite/migrations/18_object_optimistic_lock_version.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE objects ADD COLUMN optimistic_lock_version INTEGER NOT NULL DEFAULT 1;

--- a/internal/storage/database/sqlite/repository/object/sqlite.go
+++ b/internal/storage/database/sqlite/repository/object/sqlite.go
@@ -15,18 +15,19 @@ type sqliteRepository struct {
 }
 
 const (
-	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"
-	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) ON CONFLICT DO NOTHING"
-	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, updated_at = $14 WHERE id = $15"
+	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)"
+	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT DO NOTHING"
+	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15"
+	updateObjectByIdAndOptimisticLockVersionStmt                                                 = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15 AND optimistic_lock_version = $16"
 	containsBucketObjectsByBucketNameStmt                                                        = "SELECT id FROM objects WHERE bucket_name = $1"
-	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
-	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
-	findObjectByBucketNameAndKeyAndUploadIdStmt                                                  = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
-	findObjectByBucketNameAndKeyStmt                                                             = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3"
+	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
+	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
+	findObjectByBucketNameAndKeyAndUploadIdStmt                                                  = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
+	findObjectByBucketNameAndKeyStmt                                                             = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3"
 	countObjectsByBucketNameAndPrefixAndStartAfterStmt                                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_status = $4"
 	countObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerStmt                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5"
 	deleteObjectByIdStmt                                                                         = "DELETE FROM objects WHERE id = $1"
-	deleteObjectByIdAndETagStmt                                                                  = "DELETE FROM objects WHERE id = $1 AND etag = $2"
+	deleteObjectByIdAndOptimisticLockVersionStmt                                                 = "DELETE FROM objects WHERE id = $1 AND optimistic_lock_version = $2"
 )
 
 func NewRepository() (object.Repository, error) {
@@ -48,30 +49,32 @@ func convertRowToObjectEntity(objectRows *sql.Rows) (*object.Entity, error) {
 	var size int64
 	var uploadStatus string
 	var uploadId *string
+	var optimisticLockVersion int64
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &uploadStatus, &uploadId, &createdAt, &updatedAt)
+	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &uploadStatus, &uploadId, &optimisticLockVersion, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
 	ulidId := ulid.MustParse(id)
 	objectEntity := object.Entity{
-		Id:                &ulidId,
-		BucketName:        storage.MustNewBucketName(bucketName),
-		Key:               storage.MustNewObjectKey(key),
-		ContentType:       contentType,
-		ETag:              etag,
-		ChecksumCRC32:     checksumCRC32,
-		ChecksumCRC32C:    checksumCRC32C,
-		ChecksumCRC64NVME: checksumCRC64NVME,
-		ChecksumSHA1:      checksumSHA1,
-		ChecksumSHA256:    checksumSHA256,
-		ChecksumType:      checksumType,
-		Size:              size,
-		UploadStatus:      uploadStatus,
-		UploadId:          ptrutils.MapPtr(uploadId, storage.MustNewUploadId),
-		CreatedAt:         createdAt,
-		UpdatedAt:         updatedAt,
+		Id:                    &ulidId,
+		BucketName:            storage.MustNewBucketName(bucketName),
+		Key:                   storage.MustNewObjectKey(key),
+		ContentType:           contentType,
+		ETag:                  etag,
+		ChecksumCRC32:         checksumCRC32,
+		ChecksumCRC32C:        checksumCRC32C,
+		ChecksumCRC64NVME:     checksumCRC64NVME,
+		ChecksumSHA1:          checksumSHA1,
+		ChecksumSHA256:        checksumSHA256,
+		ChecksumType:          checksumType,
+		Size:                  size,
+		UploadStatus:          uploadStatus,
+		UploadId:              ptrutils.MapPtr(uploadId, storage.MustNewUploadId),
+		OptimisticLockVersion: optimisticLockVersion,
+		CreatedAt:             createdAt,
+		UpdatedAt:             updatedAt,
 	}
 	return &objectEntity, nil
 }
@@ -85,11 +88,24 @@ func (or *sqliteRepository) SaveObject(ctx context.Context, tx *sql.Tx, object *
 		object.Id = &id
 		object.CreatedAt = time.Now().UTC()
 		object.UpdatedAt = object.CreatedAt
-		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.CreatedAt, object.UpdatedAt)
+		if object.OptimisticLockVersion == 0 {
+			object.OptimisticLockVersion = 1
+		}
+		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 		return err
 	}
 	object.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
+	res, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected > 0 {
+		object.OptimisticLockVersion++
+	}
 	return err
 }
 
@@ -104,9 +120,12 @@ func (or *sqliteRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx
 	if object.CreatedAt.IsZero() {
 		object.CreatedAt = time.Now().UTC()
 	}
+	if object.OptimisticLockVersion == 0 {
+		object.OptimisticLockVersion = 1
+	}
 	object.UpdatedAt = object.CreatedAt
 
-	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.CreatedAt, object.UpdatedAt)
+	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +136,26 @@ func (or *sqliteRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx
 	}
 	inserted := rowsAffected > 0
 	return &inserted, nil
+}
+
+func (or *sqliteRepository) UpdateObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, object *object.Entity, optimisticLockVersion int64) (*bool, error) {
+	mapUploadIdToString := func(uploadId storage.UploadId) string {
+		return uploadId.String()
+	}
+	object.UpdatedAt = time.Now().UTC()
+	res, err := tx.ExecContext(ctx, updateObjectByIdAndOptimisticLockVersionStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String(), optimisticLockVersion)
+	if err != nil {
+		return nil, err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	updated := rowsAffected > 0
+	if updated {
+		object.OptimisticLockVersion = optimisticLockVersion + 1
+	}
+	return &updated, nil
 }
 
 func (or *sqliteRepository) ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error) {
@@ -230,8 +269,8 @@ func (or *sqliteRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, ob
 	return &deleted, nil
 }
 
-func (or *sqliteRepository) DeleteObjectByIdAndETag(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, etag string) (*bool, error) {
-	res, err := tx.ExecContext(ctx, deleteObjectByIdAndETagStmt, objectId.String(), etag)
+func (or *sqliteRepository) DeleteObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, optimisticLockVersion int64) (*bool, error) {
+	res, err := tx.ExecContext(ctx, deleteObjectByIdAndOptimisticLockVersionStmt, objectId.String(), optimisticLockVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -406,28 +406,27 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		Size:              obj.Size,
 		UploadStatus:      object.UploadStatusCompleted,
 	}
+
+	oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
+	if err != nil {
+		return err
+	}
+
 	if opts != nil && opts.IfMatchETag != nil {
-		oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
-		if err != nil {
-			return err
-		}
 		if oldObjectEntity == nil || oldObjectEntity.ETag != *opts.IfMatchETag {
 			return metadatastore.ErrPreconditionFailed
 		}
 
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
+		objectEntity.Id = oldObjectEntity.Id
+		updated, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &objectEntity, oldObjectEntity.OptimisticLockVersion)
 		if err != nil {
 			return err
 		}
-		deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *oldObjectEntity.Id, *opts.IfMatchETag)
-		if err != nil {
-			return err
-		}
-		if !*deleted {
+		if !*updated {
 			return metadatastore.ErrPreconditionFailed
 		}
 
-		err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
+		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
 		if err != nil {
 			return err
 		}
@@ -439,23 +438,19 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		if !*inserted {
 			return metadatastore.ErrPreconditionFailed
 		}
-	} else {
-		oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
+	} else if oldObjectEntity != nil {
+		objectEntity.Id = oldObjectEntity.Id
+		objectEntity.OptimisticLockVersion = oldObjectEntity.OptimisticLockVersion
+		err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
 		if err != nil {
 			return err
 		}
-		if oldObjectEntity != nil {
-			// object already exists
-			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
-			if err != nil {
-				return err
-			}
-			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
-			if err != nil {
-				return err
-			}
-		}
 
+		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
+		if err != nil {
+			return err
+		}
+	} else {
 		err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
 		if err != nil {
 			return err
@@ -506,25 +501,8 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 	}
 
 	if oldObjectEntity != nil {
-		// Delete old parts metadata rows (the new part list is supplied in obj.Parts).
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
-		if err != nil {
-			return err
-		}
-
-		// Use a conditional delete (WHERE id=X AND etag=Y) as the CAS step so
-		// that a concurrent append or put that already changed the ETag causes
-		// this transaction to fail rather than silently overwriting.
-		deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *oldObjectEntity.Id, oldObjectEntity.ETag)
-		if err != nil {
-			return err
-		}
-		if !*deleted {
-			return metadatastore.ErrCASFailure
-		}
-
-		// Re-insert to get a fresh row (same approach as PutObject).
-		newEntity := object.Entity{
+		updatedEntity := object.Entity{
+			Id:           oldObjectEntity.Id,
 			BucketName:   bucketName,
 			Key:          obj.Key,
 			ContentType:  oldObjectEntity.ContentType,
@@ -533,7 +511,15 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 			Size:         obj.Size,
 			UploadStatus: object.UploadStatusCompleted,
 		}
-		err = sms.objectRepository.SaveObject(ctx, tx, &newEntity)
+		updated, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &updatedEntity, oldObjectEntity.OptimisticLockVersion)
+		if err != nil {
+			return err
+		}
+		if !*updated {
+			return metadatastore.ErrCASFailure
+		}
+
+		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
 		if err != nil {
 			return err
 		}
@@ -542,7 +528,7 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 		for _, partStruc := range obj.Parts {
 			partEntity := part.Entity{
 				PartId:            partStruc.Id,
-				ObjectId:          *newEntity.Id,
+				ObjectId:          *updatedEntity.Id,
 				ETag:              partStruc.ETag,
 				ChecksumCRC32:     partStruc.ChecksumCRC32,
 				ChecksumCRC32C:    partStruc.ChecksumCRC32C,
@@ -631,13 +617,22 @@ func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucke
 	}
 
 	if objectEntity != nil {
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
-		if err != nil {
-			return err
-		}
+		if opts != nil && opts.IfMatchETag != nil {
+			lockedObjectEntity := *objectEntity
+			locked, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, objectEntity.OptimisticLockVersion)
+			if err != nil {
+				return err
+			}
+			if !*locked {
+				return metadatastore.ErrPreconditionFailed
+			}
 
-		if opts != nil && opts.IfMatchETag != nil && *opts.IfMatchETag != metadatastore.ETagWildcard {
-			deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *objectEntity.Id, *opts.IfMatchETag)
+			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *lockedObjectEntity.Id)
+			if err != nil {
+				return err
+			}
+
+			deleted, err := sms.objectRepository.DeleteObjectByIdAndOptimisticLockVersion(ctx, tx, *lockedObjectEntity.Id, lockedObjectEntity.OptimisticLockVersion)
 			if err != nil {
 				return err
 			}
@@ -645,14 +640,15 @@ func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucke
 				return metadatastore.ErrPreconditionFailed
 			}
 		} else {
-			deleted, err := sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
+			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
 			if err != nil {
 				return err
 			}
-			// 0 rows affected means a concurrent writer already deleted the object.
-			// Since there was no client-supplied condition, the desired outcome
-			// (object gone) is already achieved — treat it as success.
-			_ = deleted
+
+			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -853,12 +849,8 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 			}
 		}, oldPartEntities)
 
-		// Optimistic locking: when If-Match was supplied with an exact ETag,
-		// use an atomic DELETE WHERE id=$1 AND etag=$2 as the final guard.
-		// A zero rows-affected result means a concurrent writer already changed
-		// the object between our read and this delete, so we abort with 412.
-		if opts != nil && opts.IfMatchETag != nil && *opts.IfMatchETag != metadatastore.ETagWildcard {
-			deleted, err := sms.objectRepository.DeleteObjectByIdAndETag(ctx, tx, *oldObjectEntity.Id, *opts.IfMatchETag)
+		if opts != nil && opts.IfMatchETag != nil {
+			deleted, err := sms.objectRepository.DeleteObjectByIdAndOptimisticLockVersion(ctx, tx, *oldObjectEntity.Id, oldObjectEntity.OptimisticLockVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -884,26 +876,12 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 	objectEntity.ChecksumSHA256 = calculatedChecksums.ChecksumSHA256
 	objectEntity.ChecksumType = ptrutils.ToPtr(checksumType)
 
-	if opts != nil && opts.IfNoneMatchStar {
-		// Optimistic locking: attempt to UPDATE the pending row to COMPLETED.
-		// If a concurrent transaction has already committed a completed object at
-		// this (bucket_name, key) the partial unique index
-		// objects_completed_unique will fire a unique-constraint violation, which
-		// we catch here and convert to ErrPreconditionFailed (412).
-		// This is atomic: the database enforces the constraint at write time
-		// regardless of the isolation level's snapshot visibility.
-		err = sms.objectRepository.SaveObject(ctx, tx, objectEntity)
-		if err != nil {
-			if isUniqueConstraintViolation(err) {
-				return nil, metadatastore.ErrPreconditionFailed
-			}
-			return nil, err
+	err = sms.objectRepository.SaveObject(ctx, tx, objectEntity)
+	if err != nil {
+		if opts != nil && opts.IfNoneMatchStar && isUniqueConstraintViolation(err) {
+			return nil, metadatastore.ErrPreconditionFailed
 		}
-	} else {
-		err = sms.objectRepository.SaveObject(ctx, tx, objectEntity)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	return &metadatastore.CompleteMultipartUploadResult{


### PR DESCRIPTION
## Summary
- add `optimistic_lock_version` to object schema in pgx/sqlite and wire it through object repository entities and SQL statements
- replace internal ETag-coupled CAS with explicit id+optimistic_lock_version update/delete CAS methods and atomic version increments
- refactor object mutation paths (`PutObject`, `AppendObject`, `DeleteObject`, `CompleteMultipartUpload`) to use row-specific versioned updates while preserving S3 conditional header behavior

## Testing
- go test ./internal/storage/database/sqlite
- go test ./internal/storage/database/pgx
- go test ./internal/storage/metadatapart/...

Closes #696