### PR TITLE
fix(auth): make SigV4 presign canonicalization host-style safe

### DIFF
--- a/internal/http/server/authentication/signature.go
+++ b/internal/http/server/authentication/signature.go
@@ -10,6 +10,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"log/slog"
@@ -79,7 +80,53 @@ func generateCanonicalHttpMethod(r *http.Request) string {
 }
 
 func generateCanonicalURI(r *http.Request) string {
-	return r.URL.EscapedPath()
+	escapedPath := r.URL.EscapedPath()
+	if escapedPath == "" {
+		return "/"
+	}
+
+	canonicalURI := ""
+	for idx := 0; idx < len(escapedPath); idx++ {
+		ch := escapedPath[idx]
+		if ch == '/' {
+			canonicalURI += "/"
+			continue
+		}
+
+		if ch == '%' && idx+2 < len(escapedPath) && isHexChar(escapedPath[idx+1]) && isHexChar(escapedPath[idx+2]) {
+			canonicalURI += "%"
+			canonicalURI += strings.ToUpper(string(escapedPath[idx+1]))
+			canonicalURI += strings.ToUpper(string(escapedPath[idx+2]))
+			idx += 2
+			continue
+		}
+
+		if isUnreservedChar(ch) {
+			canonicalURI += string(ch)
+			continue
+		}
+
+		canonicalURI += fmt.Sprintf("%%%02X", ch)
+	}
+
+	return canonicalURI
+}
+
+func isHexChar(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}
+
+func isUnreservedChar(ch byte) bool {
+	if ch >= 'A' && ch <= 'Z' {
+		return true
+	}
+	if ch >= 'a' && ch <= 'z' {
+		return true
+	}
+	if ch >= '0' && ch <= '9' {
+		return true
+	}
+	return ch == '-' || ch == '.' || ch == '_' || ch == '~'
 }
 
 func uriEncode(input string) string {

--- a/internal/http/server/authentication/signature_test.go
+++ b/internal/http/server/authentication/signature_test.go
@@ -257,3 +257,81 @@ func TestGenerateCanonicalQueryStringSortsAfterEncoding(t *testing.T) {
 	queryString := generateCanonicalQueryString(r)
 	assert.Equal(t, "%C3%A4=1&z=1", queryString)
 }
+
+func TestGenerateCanonicalURIUsesAwsStyleEscaping(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodPut, "http://examplebucket.s3.amazonaws.com/test$file.text", nil)
+	assert.NoError(t, err)
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/test%24file.text", canonicalURI)
+}
+
+func TestGenerateCanonicalURIDoesNotNormalizePath(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodGet, "http://examplebucket.s3.amazonaws.com/my-object//example//photo.user", nil)
+	assert.NoError(t, err)
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/my-object//example//photo.user", canonicalURI)
+}
+
+func TestGenerateCanonicalURIUsesRawPathWhenPresent(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodGet, "http://examplebucket.s3.amazonaws.com", nil)
+	assert.NoError(t, err)
+	r.URL.Path = "/photos/month/sample.jpg"
+	r.URL.RawPath = "/photos%2Fmonth%2Fsample.jpg"
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/photos%2Fmonth%2Fsample.jpg", canonicalURI)
+}
+
+func TestGenerateCanonicalURIEncodesReservedPathChars(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodGet, "http://examplebucket.s3.amazonaws.com/photos/month/a b+c*.txt", nil)
+	assert.NoError(t, err)
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/photos/month/a%20b%2Bc%2A.txt", canonicalURI)
+}
+
+func TestGenerateCanonicalURINormalizesPercentEscapesToUppercase(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodGet, "http://examplebucket.s3.amazonaws.com", nil)
+	assert.NoError(t, err)
+	r.URL.Path = "/photos/month/sample.jpg"
+	r.URL.RawPath = "/photos%2fmonth%2fsample.jpg"
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/photos%2Fmonth%2Fsample.jpg", canonicalURI)
+}
+
+func TestGenerateCanonicalURIReturnsSlashForEmptyPath(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodGet, "http://examplebucket.s3.amazonaws.com", nil)
+	assert.NoError(t, err)
+	r.URL.Path = ""
+	r.URL.RawPath = ""
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/", canonicalURI)
+}
+
+func TestGenerateCanonicalURIEncodesInvalidPercentSequences(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+
+	r, err := http.NewRequest(http.MethodGet, "http://examplebucket.s3.amazonaws.com", nil)
+	assert.NoError(t, err)
+	r.URL.Path = "/photos/%zz/sample"
+	r.URL.RawPath = "/photos/%zz/sample"
+
+	canonicalURI := generateCanonicalURI(r)
+	assert.Equal(t, "/photos/%25zz/sample", canonicalURI)
+}


### PR DESCRIPTION
## Summary
- align SigV4 canonicalization with AWS behavior by using `SignedHeaders` exactly when building canonical headers and signed header lists
- normalize canonical query generation for presigned URLs (AWS-style URI encoding and key-then-value sorting)
- enforce that security-sensitive request headers (`host`, `content-md5`, and any `x-amz-*` present on the request) must be signed
- add unit regression tests for header inclusion, query sorting, and URI encoding behavior

## Validation
- `go test ./internal/http/server/authentication -count=1`
- `go test ./cmd -run 'Test(PutObject|GetObject|DeleteObject|DeleteBucket)/.*presigned.*host style' -integration -path-style=host -count=1`

Closes #698.