### PR TITLE
feat(versioning): implement S3-compatible bucket versioning behavior

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -4782,8 +4782,10 @@ func TestBucketVersioning(t *testing.T) {
 			})
 			assert.Nil(t, err)
 
-			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader(body)})
+			putOut, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader(body)})
 			assert.Nil(t, err)
+			assert.NotNil(t, putOut.VersionId)
+			assert.NotEmpty(t, aws.ToString(putOut.VersionId))
 
 			deleteOut, err := s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{Bucket: bucketName, Key: key})
 			if err != nil {
@@ -4853,10 +4855,15 @@ func TestBucketVersioning(t *testing.T) {
 			})
 			assert.Nil(t, err)
 
-			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v1"))})
+			putV1, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v1"))})
 			assert.Nil(t, err)
-			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v2"))})
+			assert.NotNil(t, putV1.VersionId)
+			assert.NotEmpty(t, aws.ToString(putV1.VersionId))
+			putV2, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v2"))})
 			assert.Nil(t, err)
+			assert.NotNil(t, putV2.VersionId)
+			assert.NotEmpty(t, aws.ToString(putV2.VersionId))
+			assert.NotEqual(t, aws.ToString(putV1.VersionId), aws.ToString(putV2.VersionId))
 
 			page1, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, MaxKeys: aws.Int32(1)})
 			assert.Nil(t, err)
@@ -4885,10 +4892,14 @@ func TestBucketVersioning(t *testing.T) {
 			})
 			assert.Nil(t, err)
 
-			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: aws.String("a/one.txt"), Body: bytes.NewReader(body)})
+			putA, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: aws.String("a/one.txt"), Body: bytes.NewReader(body)})
 			assert.Nil(t, err)
-			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: aws.String("b/two.txt"), Body: bytes.NewReader(body)})
+			assert.NotNil(t, putA.VersionId)
+			assert.NotEmpty(t, aws.ToString(putA.VersionId))
+			putB, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: aws.String("b/two.txt"), Body: bytes.NewReader(body)})
 			assert.Nil(t, err)
+			assert.NotNil(t, putB.VersionId)
+			assert.NotEmpty(t, aws.ToString(putB.VersionId))
 
 			page1, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, Delimiter: aws.String("/"), MaxKeys: aws.Int32(1)})
 			assert.Nil(t, err)

--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -4803,6 +4803,57 @@ func TestDeleteObjects(t *testing.T) {
 			assert.Nil(t, err)
 		})
 
+		t.Run("it should return DeleteMarkerVersionId for key-only deletes on versioned buckets"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket: bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{
+					Status: types.BucketVersioningStatusEnabled,
+				},
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{
+					Objects: []types.ObjectIdentifier{
+						{Key: key},
+					},
+				},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Deleted, 1)
+			assert.Len(t, result.Errors, 0)
+			assert.Equal(t, *key, *result.Deleted[0].Key)
+			if assert.NotNil(t, result.Deleted[0].DeleteMarker) {
+				assert.True(t, *result.Deleted[0].DeleteMarker)
+			}
+			assert.Nil(t, result.Deleted[0].VersionId)
+			if assert.NotNil(t, result.Deleted[0].DeleteMarkerVersionId) {
+				assert.NotEmpty(t, *result.Deleted[0].DeleteMarkerVersionId)
+			}
+
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.NotNil(t, err)
+			var responseErr *awshttp.ResponseError
+			if assert.True(t, errors.As(err, &responseErr)) {
+				assert.Equal(t, http.StatusNotFound, responseErr.HTTPStatusCode())
+				assert.Equal(t, "true", responseErr.HTTPResponse().Header.Get("x-amz-delete-marker"))
+				assert.Equal(t, aws.ToString(result.Deleted[0].DeleteMarkerVersionId), responseErr.HTTPResponse().Header.Get("x-amz-version-id"))
+			}
+		})
+
 		t.Run("it should handle duplicate keys with different VersionIds"+testSuffix, func(t *testing.T) {
 			t.Parallel()
 			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)

--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -4986,6 +4986,203 @@ func TestBucketVersioning(t *testing.T) {
 	t.Parallel()
 
 	runIntegrationTest(t, func(t *testing.T, testSuffix string, dbType database.DatabaseType, usePathStyle bool, useReplication bool, useFilesystemPartStore bool, encryptionType storageFactory.EncryptionType, wrapPartStoreWithOutbox bool) {
+		t.Run("it should keep prior versions and reuse null version after suspend"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err := s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusEnabled, versioningOut.Status)
+
+			putV1, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v1"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, putV1.VersionId)
+			assert.NotEmpty(t, aws.ToString(putV1.VersionId))
+
+			putV2, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v2"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, putV2.VersionId)
+			assert.NotEmpty(t, aws.ToString(putV2.VersionId))
+			assert.NotEqual(t, aws.ToString(putV1.VersionId), aws.ToString(putV2.VersionId))
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusSuspended},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err = s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusSuspended, versioningOut.Status)
+
+			putNull1, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v3"))})
+			assert.Nil(t, err)
+			assert.Equal(t, "null", aws.ToString(putNull1.VersionId))
+
+			putNull2, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v4"))})
+			assert.Nil(t, err)
+			assert.Equal(t, "null", aws.ToString(putNull2.VersionId))
+
+			versionsOut, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, Prefix: key})
+			assert.Nil(t, err)
+
+			versionIDs := map[string]bool{}
+			nullVersionCount := 0
+			nullLatest := false
+			for _, version := range versionsOut.Versions {
+				if aws.ToString(version.Key) != aws.ToString(key) {
+					continue
+				}
+				versionID := aws.ToString(version.VersionId)
+				versionIDs[versionID] = true
+				if versionID == "null" {
+					nullVersionCount++
+					nullLatest = aws.ToBool(version.IsLatest)
+				}
+			}
+
+			assert.True(t, versionIDs[aws.ToString(putV1.VersionId)])
+			assert.True(t, versionIDs[aws.ToString(putV2.VersionId)])
+			assert.True(t, versionIDs["null"])
+			assert.Equal(t, 1, nullVersionCount)
+			assert.True(t, nullLatest)
+		})
+
+		t.Run("it should resume unique version ids after re-enabling versioning"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusSuspended},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err := s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusSuspended, versioningOut.Status)
+
+			putNull1, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("sv1"))})
+			assert.Nil(t, err)
+			assert.Equal(t, "null", aws.ToString(putNull1.VersionId))
+
+			putNull2, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("sv2"))})
+			assert.Nil(t, err)
+			assert.Equal(t, "null", aws.ToString(putNull2.VersionId))
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err = s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusEnabled, versioningOut.Status)
+
+			putV1, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("ev1"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, putV1.VersionId)
+			assert.NotEmpty(t, aws.ToString(putV1.VersionId))
+			assert.NotEqual(t, "null", aws.ToString(putV1.VersionId))
+
+			putV2, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("ev2"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, putV2.VersionId)
+			assert.NotEmpty(t, aws.ToString(putV2.VersionId))
+			assert.NotEqual(t, "null", aws.ToString(putV2.VersionId))
+			assert.NotEqual(t, aws.ToString(putV1.VersionId), aws.ToString(putV2.VersionId))
+
+			versionsOut, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, Prefix: key})
+			assert.Nil(t, err)
+
+			versionIDs := map[string]bool{}
+			latestByID := map[string]bool{}
+			for _, version := range versionsOut.Versions {
+				if aws.ToString(version.Key) != aws.ToString(key) {
+					continue
+				}
+				versionID := aws.ToString(version.VersionId)
+				versionIDs[versionID] = true
+				latestByID[versionID] = aws.ToBool(version.IsLatest)
+			}
+
+			assert.True(t, versionIDs["null"])
+			assert.True(t, versionIDs[aws.ToString(putV1.VersionId)])
+			assert.True(t, versionIDs[aws.ToString(putV2.VersionId)])
+			assert.True(t, latestByID[aws.ToString(putV2.VersionId)])
+		})
+
+		t.Run("it should keep api status and put semantics across enable suspend re-enable transitions"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err := s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusEnabled, versioningOut.Status)
+
+			enabledPut, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("enabled"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, enabledPut.VersionId)
+			assert.NotEmpty(t, aws.ToString(enabledPut.VersionId))
+			assert.NotEqual(t, "null", aws.ToString(enabledPut.VersionId))
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusSuspended},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err = s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusSuspended, versioningOut.Status)
+
+			suspendedPut, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("suspended"))})
+			assert.Nil(t, err)
+			assert.Equal(t, "null", aws.ToString(suspendedPut.VersionId))
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			versioningOut, err = s3Client.GetBucketVersioning(context.Background(), &s3.GetBucketVersioningInput{Bucket: bucketName})
+			assert.Nil(t, err)
+			assert.Equal(t, types.BucketVersioningStatusEnabled, versioningOut.Status)
+
+			reenabledPut, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("reenabled"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, reenabledPut.VersionId)
+			assert.NotEmpty(t, aws.ToString(reenabledPut.VersionId))
+			assert.NotEqual(t, "null", aws.ToString(reenabledPut.VersionId))
+			assert.NotEqual(t, aws.ToString(enabledPut.VersionId), aws.ToString(reenabledPut.VersionId))
+		})
+
 		t.Run("it should return delete-marker semantics for current and explicit versions"+testSuffix, func(t *testing.T) {
 			t.Parallel()
 			s3Client, listenerAddr, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)

--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -4538,7 +4538,7 @@ func TestDeleteObjects(t *testing.T) {
 			assert.NotNil(t, err)
 		})
 
-		t.Run("it should return an error entry for objects with a VersionId"+testSuffix, func(t *testing.T) {
+		t.Run("it should delete an explicit object VersionId"+testSuffix, func(t *testing.T) {
 			t.Parallel()
 			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
 			t.Cleanup(cleanup)
@@ -4546,8 +4546,22 @@ func TestDeleteObjects(t *testing.T) {
 			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
 			assert.Nil(t, err)
 
-			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket: bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{
+					Status: types.BucketVersioningStatusEnabled,
+				},
+			})
+			assert.Nil(t, err)
+
+			firstPut, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
 				Bucket: bucketName, Key: key, Body: bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, firstPut.VersionId)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("second")),
 			})
 			assert.Nil(t, err)
 
@@ -4555,15 +4569,62 @@ func TestDeleteObjects(t *testing.T) {
 				Bucket: bucketName,
 				Delete: &types.Delete{
 					Objects: []types.ObjectIdentifier{
-						{Key: key, VersionId: aws.String("some-version-id")},
+						{Key: key, VersionId: firstPut.VersionId},
 					},
 				},
 			})
 			assert.Nil(t, err)
-			assert.Len(t, result.Deleted, 0)
-			assert.Len(t, result.Errors, 1)
-			assert.Equal(t, *key, *result.Errors[0].Key)
-			assert.Equal(t, "NotImplemented", *result.Errors[0].Code)
+			assert.Len(t, result.Deleted, 1)
+			assert.Len(t, result.Errors, 0)
+			assert.Equal(t, *key, *result.Deleted[0].Key)
+			assert.NotNil(t, result.Deleted[0].VersionId)
+			assert.Equal(t, *firstPut.VersionId, *result.Deleted[0].VersionId)
+
+			// Latest version must still exist.
+			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
+			assert.Nil(t, err)
+		})
+
+		t.Run("it should handle duplicate keys with different VersionIds"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket: bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{
+					Status: types.BucketVersioningStatusEnabled,
+				},
+			})
+			assert.Nil(t, err)
+
+			put1, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v1"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, put1.VersionId)
+
+			put2, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v2"))})
+			assert.Nil(t, err)
+			assert.NotNil(t, put2.VersionId)
+
+			result, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+				Bucket: bucketName,
+				Delete: &types.Delete{Objects: []types.ObjectIdentifier{{Key: key, VersionId: put1.VersionId}, {Key: key, VersionId: put2.VersionId}}},
+			})
+			assert.Nil(t, err)
+			assert.Len(t, result.Errors, 0)
+			assert.Len(t, result.Deleted, 2)
+
+			deletedVersions := map[string]bool{}
+			for _, deleted := range result.Deleted {
+				if deleted.VersionId != nil {
+					deletedVersions[*deleted.VersionId] = true
+				}
+			}
+			assert.True(t, deletedVersions[*put1.VersionId])
+			assert.True(t, deletedVersions[*put2.VersionId])
 		})
 
 		t.Run("it should return 404 when the bucket does not exist"+testSuffix, func(t *testing.T) {
@@ -4697,6 +4758,147 @@ func TestDeleteObjects(t *testing.T) {
 			// Object must still exist.
 			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
 			assert.Nil(t, err)
+		})
+	})
+}
+
+func TestBucketVersioning(t *testing.T) {
+	testutils.SkipIfNotIntegration(t)
+
+	t.Parallel()
+
+	runIntegrationTest(t, func(t *testing.T, testSuffix string, dbType database.DatabaseType, usePathStyle bool, useReplication bool, useFilesystemPartStore bool, encryptionType storageFactory.EncryptionType, wrapPartStoreWithOutbox bool) {
+		t.Run("it should return delete-marker semantics for current and explicit versions"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, listenerAddr, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader(body)})
+			assert.Nil(t, err)
+
+			deleteOut, err := s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{Bucket: bucketName, Key: key})
+			if err != nil {
+				t.Fatalf("DeleteObject failed: %v", err)
+			}
+			markerVersionID := ""
+			if deleteOut != nil && deleteOut.VersionId != nil {
+				markerVersionID = *deleteOut.VersionId
+			}
+
+			addr, _ := net.ResolveTCPAddr("tcp", listenerAddr)
+			httpClient := buildHttpClient()
+			objectURL := fmt.Sprintf("http://%s:%d/%s/%s", testAPIEndpoint, addr.Port, *bucketName, *key)
+
+			headReq, _ := http.NewRequest(http.MethodHead, objectURL, nil)
+			headResp, err := httpClient.Do(headReq)
+			assert.Nil(t, err)
+			defer headResp.Body.Close()
+			assert.Equal(t, http.StatusNotFound, headResp.StatusCode)
+			assert.Equal(t, "true", headResp.Header.Get("x-amz-delete-marker"))
+			if markerVersionID == "" {
+				markerVersionID = headResp.Header.Get("x-amz-version-id")
+			}
+			if markerVersionID == "" {
+				t.Fatalf("missing delete marker version id in DeleteObject output and HEAD response")
+			}
+			assert.Equal(t, markerVersionID, headResp.Header.Get("x-amz-version-id"))
+
+			getReq, _ := http.NewRequest(http.MethodGet, objectURL, nil)
+			getResp, err := httpClient.Do(getReq)
+			assert.Nil(t, err)
+			defer getResp.Body.Close()
+			assert.Equal(t, http.StatusNotFound, getResp.StatusCode)
+			assert.Equal(t, "true", getResp.Header.Get("x-amz-delete-marker"))
+			assert.Equal(t, markerVersionID, getResp.Header.Get("x-amz-version-id"))
+
+			headVersionReq, _ := http.NewRequest(http.MethodHead, objectURL+"?versionId="+markerVersionID, nil)
+			headVersionResp, err := httpClient.Do(headVersionReq)
+			assert.Nil(t, err)
+			defer headVersionResp.Body.Close()
+			assert.Equal(t, http.StatusMethodNotAllowed, headVersionResp.StatusCode)
+			assert.Equal(t, "true", headVersionResp.Header.Get("x-amz-delete-marker"))
+			assert.Equal(t, markerVersionID, headVersionResp.Header.Get("x-amz-version-id"))
+			assert.NotEmpty(t, headVersionResp.Header.Get("Last-Modified"))
+
+			getVersionReq, _ := http.NewRequest(http.MethodGet, objectURL+"?versionId="+markerVersionID, nil)
+			getVersionResp, err := httpClient.Do(getVersionReq)
+			assert.Nil(t, err)
+			defer getVersionResp.Body.Close()
+			assert.Equal(t, http.StatusMethodNotAllowed, getVersionResp.StatusCode)
+			assert.Equal(t, "true", getVersionResp.Header.Get("x-amz-delete-marker"))
+			assert.Equal(t, markerVersionID, getVersionResp.Header.Get("x-amz-version-id"))
+			assert.NotEmpty(t, getVersionResp.Header.Get("Last-Modified"))
+		})
+
+		t.Run("it should paginate ListObjectVersions with key and version markers"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v1"))})
+			assert.Nil(t, err)
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: key, Body: bytes.NewReader([]byte("v2"))})
+			assert.Nil(t, err)
+
+			page1, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, MaxKeys: aws.Int32(1)})
+			assert.Nil(t, err)
+			assert.True(t, aws.ToBool(page1.IsTruncated))
+			assert.NotNil(t, page1.NextKeyMarker)
+			assert.NotNil(t, page1.NextVersionIdMarker)
+			assert.Len(t, page1.Versions, 1)
+
+			page2, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, MaxKeys: aws.Int32(1), KeyMarker: page1.NextKeyMarker, VersionIdMarker: page1.NextVersionIdMarker})
+			assert.Nil(t, err)
+			assert.Len(t, page2.Versions, 1)
+			assert.NotEqual(t, aws.ToString(page1.Versions[0].VersionId), aws.ToString(page2.Versions[0].VersionId))
+		})
+
+		t.Run("it should count common prefixes in ListObjectVersions pagination"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: aws.String("a/one.txt"), Body: bytes.NewReader(body)})
+			assert.Nil(t, err)
+			_, err = s3Client.PutObject(context.Background(), &s3.PutObjectInput{Bucket: bucketName, Key: aws.String("b/two.txt"), Body: bytes.NewReader(body)})
+			assert.Nil(t, err)
+
+			page1, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, Delimiter: aws.String("/"), MaxKeys: aws.Int32(1)})
+			assert.Nil(t, err)
+			assert.True(t, aws.ToBool(page1.IsTruncated))
+			assert.Len(t, page1.CommonPrefixes, 1)
+
+			page2, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, Delimiter: aws.String("/"), MaxKeys: aws.Int32(1), KeyMarker: page1.NextKeyMarker, VersionIdMarker: page1.NextVersionIdMarker})
+			assert.Nil(t, err)
+			assert.Len(t, page2.CommonPrefixes, 1)
+			assert.NotEqual(t, aws.ToString(page1.CommonPrefixes[0].Prefix), aws.ToString(page2.CommonPrefixes[0].Prefix))
 		})
 	})
 }

--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -5059,6 +5059,59 @@ func TestBucketVersioning(t *testing.T) {
 			assert.NotEmpty(t, getVersionResp.Header.Get("Last-Modified"))
 		})
 
+		t.Run("it should return version id for completed multipart upload in versioned bucket"+testSuffix, func(t *testing.T) {
+			t.Parallel()
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			_, err = s3Client.PutBucketVersioning(context.Background(), &s3.PutBucketVersioningInput{
+				Bucket:                  bucketName,
+				VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+			})
+			assert.Nil(t, err)
+
+			createOut, err := s3Client.CreateMultipartUpload(context.Background(), &s3.CreateMultipartUploadInput{Bucket: bucketName, Key: key})
+			assert.Nil(t, err)
+			assert.NotNil(t, createOut)
+			assert.NotNil(t, createOut.UploadId)
+
+			_, err = s3Client.UploadPart(context.Background(), &s3.UploadPartInput{
+				Bucket:     bucketName,
+				Key:        key,
+				UploadId:   createOut.UploadId,
+				PartNumber: aws.Int32(1),
+				Body:       bytes.NewReader(body),
+			})
+			assert.Nil(t, err)
+
+			completeOut, err := s3Client.CompleteMultipartUpload(context.Background(), &s3.CompleteMultipartUploadInput{
+				Bucket:   bucketName,
+				Key:      key,
+				UploadId: createOut.UploadId,
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, completeOut)
+			assert.NotNil(t, completeOut.VersionId)
+			assert.NotEmpty(t, aws.ToString(completeOut.VersionId))
+
+			versionsOut, err := s3Client.ListObjectVersions(context.Background(), &s3.ListObjectVersionsInput{Bucket: bucketName, Prefix: key})
+			assert.Nil(t, err)
+			assert.NotEmpty(t, versionsOut.Versions)
+
+			versionFound := false
+			for _, version := range versionsOut.Versions {
+				if aws.ToString(version.Key) == aws.ToString(key) && aws.ToString(version.VersionId) == aws.ToString(completeOut.VersionId) {
+					versionFound = true
+					assert.True(t, aws.ToBool(version.IsLatest))
+					break
+				}
+			}
+			assert.True(t, versionFound)
+		})
+
 		t.Run("it should paginate ListObjectVersions with key and version markers"+testSuffix, func(t *testing.T) {
 			t.Parallel()
 			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)

--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -2314,6 +2314,172 @@ func TestMultipartUpload(t *testing.T) {
 			assert.Equal(t, body, objectBytes)
 		})
 
+		t.Run("it should reject stale If-Match CompleteMultipartUpload during concurrent completes"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			initialPut, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("initial-state")),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, initialPut.ETag)
+
+			prepareUpload := func(payload []byte) *string {
+				createOut, createErr := s3Client.CreateMultipartUpload(context.Background(), &s3.CreateMultipartUploadInput{
+					Bucket: bucketName,
+					Key:    key,
+				})
+				if !assert.Nil(t, createErr) {
+					return nil
+				}
+				if !assert.NotNil(t, createOut.UploadId) {
+					return nil
+				}
+
+				_, uploadErr := s3Client.UploadPart(context.Background(), &s3.UploadPartInput{
+					Bucket:     bucketName,
+					Key:        key,
+					UploadId:   createOut.UploadId,
+					PartNumber: aws.Int32(1),
+					Body:       bytes.NewReader(payload),
+				})
+				if !assert.Nil(t, uploadErr) {
+					return nil
+				}
+
+				return createOut.UploadId
+			}
+
+			uploadIDs := []*string{
+				prepareUpload([]byte("payload-a")),
+				prepareUpload([]byte("payload-b")),
+			}
+			if !assert.NotNil(t, uploadIDs[0]) || !assert.NotNil(t, uploadIDs[1]) {
+				return
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			errs := make([]error, 2)
+
+			for i := range 2 {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					<-start
+					_, errs[i] = s3Client.CompleteMultipartUpload(context.Background(), &s3.CompleteMultipartUploadInput{
+						Bucket:   bucketName,
+						Key:      key,
+						UploadId: uploadIDs[i],
+						IfMatch:  initialPut.ETag,
+					})
+				}(i)
+			}
+
+			close(start)
+			wg.Wait()
+
+			successCount := 0
+			for i := range 2 {
+				if errs[i] == nil {
+					successCount++
+					continue
+				}
+
+				var apiErr smithy.APIError
+				if !errors.As(errs[i], &apiErr) {
+					assert.Fail(t, "Expected smithy.APIError", "err %v", errs[i])
+					continue
+				}
+				assert.Equal(t, "PreconditionFailed", apiErr.ErrorCode())
+			}
+
+			assert.LessOrEqual(t, successCount, 1, "at most one concurrent stale If-Match CompleteMultipartUpload may succeed")
+		})
+
+		t.Run("it should allow at most one concurrent create-if-absent CompleteMultipartUpload"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			prepareUpload := func(payload []byte) *string {
+				createOut, createErr := s3Client.CreateMultipartUpload(context.Background(), &s3.CreateMultipartUploadInput{
+					Bucket: bucketName,
+					Key:    key,
+				})
+				if !assert.Nil(t, createErr) {
+					return nil
+				}
+				if !assert.NotNil(t, createOut.UploadId) {
+					return nil
+				}
+
+				_, uploadErr := s3Client.UploadPart(context.Background(), &s3.UploadPartInput{
+					Bucket:     bucketName,
+					Key:        key,
+					UploadId:   createOut.UploadId,
+					PartNumber: aws.Int32(1),
+					Body:       bytes.NewReader(payload),
+				})
+				if !assert.Nil(t, uploadErr) {
+					return nil
+				}
+
+				return createOut.UploadId
+			}
+
+			uploadIDs := []*string{
+				prepareUpload([]byte("payload-1")),
+				prepareUpload([]byte("payload-2")),
+			}
+			if !assert.NotNil(t, uploadIDs[0]) || !assert.NotNil(t, uploadIDs[1]) {
+				return
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			errs := make([]error, 2)
+
+			for i := range 2 {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					<-start
+					_, errs[i] = s3Client.CompleteMultipartUpload(context.Background(), &s3.CompleteMultipartUploadInput{
+						Bucket:      bucketName,
+						Key:         key,
+						UploadId:    uploadIDs[i],
+						IfNoneMatch: aws.String("*"),
+					})
+				}(i)
+			}
+
+			close(start)
+			wg.Wait()
+
+			successCount := 0
+			for i := range 2 {
+				if errs[i] == nil {
+					successCount++
+					continue
+				}
+
+				var apiErr smithy.APIError
+				if !errors.As(errs[i], &apiErr) {
+					assert.Fail(t, "Expected smithy.APIError", "err %v", errs[i])
+					continue
+				}
+				assert.Equal(t, "PreconditionFailed", apiErr.ErrorCode())
+			}
+
+			assert.LessOrEqual(t, successCount, 1, "at most one concurrent If-None-Match CompleteMultipartUpload may succeed")
+		})
+
 		t.Run("it should hit the upload limit when uploading a part that is too large"+testSuffix, func(t *testing.T) {
 			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
 			t.Cleanup(cleanup)
@@ -2892,6 +3058,58 @@ func TestDeleteObject(t *testing.T) {
 			// Verify the object still exists.
 			_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: bucketName, Key: key})
 			assert.Nil(t, err)
+		})
+
+		t.Run("it should reject stale If-Match deletes during concurrent writes"+testSuffix, func(t *testing.T) {
+			s3Client, _, cleanup := setupTestServer(dbType, usePathStyle, useReplication, useFilesystemPartStore, encryptionType, wrapPartStoreWithOutbox)
+			t.Cleanup(cleanup)
+			_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: bucketName})
+			assert.Nil(t, err)
+
+			putResult, err := s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: bucketName,
+				Key:    key,
+				Body:   bytes.NewReader([]byte("Hello, first object!")),
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, putResult.ETag)
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			errs := make([]error, 2)
+
+			for i := range 2 {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					<-start
+					_, errs[i] = s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+						Bucket:  bucketName,
+						Key:     key,
+						IfMatch: putResult.ETag,
+					})
+				}(i)
+			}
+
+			close(start)
+			wg.Wait()
+
+			successCount := 0
+			for i := range 2 {
+				if errs[i] == nil {
+					successCount++
+					continue
+				}
+
+				var apiErr smithy.APIError
+				if !errors.As(errs[i], &apiErr) {
+					assert.Fail(t, "Expected smithy.APIError", "err %v", errs[i])
+					continue
+				}
+				assert.Equal(t, "PreconditionFailed", apiErr.ErrorCode())
+			}
+
+			assert.LessOrEqual(t, successCount, 1, "at most one concurrent If-Match delete may succeed")
 		})
 	})
 }

--- a/internal/http/server/authorization/authorization.go
+++ b/internal/http/server/authorization/authorization.go
@@ -29,8 +29,10 @@ const (
 	OperationCreateBucket            = "CreateBucket"
 	OperationDeleteBucket            = "DeleteBucket"
 	OperationHeadObject              = "HeadObject"
+	OperationHeadObjectVersion       = "HeadObjectVersion"
 	OperationListParts               = "ListParts"
 	OperationGetObject               = "GetObject"
+	OperationGetObjectVersion        = "GetObjectVersion"
 	OperationCreateMultipartUpload   = "CreateMultipartUpload"
 	OperationCompleteMultipartUpload = "CompleteMultipartUpload"
 	OperationUploadPart              = "UploadPart"
@@ -38,10 +40,14 @@ const (
 	OperationAppendObject            = "AppendObject"
 	OperationAbortMultipartUpload    = "AbortMultipartUpload"
 	OperationDeleteObject            = "DeleteObject"
+	OperationDeleteObjectVersion     = "DeleteObjectVersion"
 	OperationDeleteObjects           = "DeleteObjects"
 	OperationGetBucketWebsite        = "GetBucketWebsite"
 	OperationPutBucketWebsite        = "PutBucketWebsite"
 	OperationDeleteBucketWebsite     = "DeleteBucketWebsite"
+	OperationGetBucketVersioning     = "GetBucketVersioning"
+	OperationPutBucketVersioning     = "PutBucketVersioning"
+	OperationListObjectVersions      = "ListObjectVersions"
 )
 
 type Request struct {

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -157,6 +157,9 @@ const listTypeQuery = "list-type"
 const continuationTokenQuery = "continuation-token"
 const websiteQuery = "website"
 const appendQuery = "append"
+const versioningQuery = "versioning"
+const versionsQuery = "versions"
+const versionIDQuery = "versionId"
 
 const acceptRangesHeader = "Accept-Ranges"
 const expectHeader = "Expect"
@@ -178,6 +181,8 @@ const checksumCRC64NVMEHeader = "x-amz-checksum-crc64nvme"
 const checksumSHA1Header = "x-amz-checksum-sha1"
 const checksumSHA256Header = "x-amz-checksum-sha256"
 const writeOffsetBytesHeader = "x-amz-write-offset-bytes"
+const versionIDHeader = "x-amz-version-id"
+const deleteMarkerHeader = "x-amz-delete-marker"
 
 const applicationXmlContentType = "application/xml"
 
@@ -365,6 +370,45 @@ type WebsiteConfigurationResponse struct {
 	ErrorDocument *WebsiteConfigurationErrorDocument `xml:"ErrorDocument,omitempty"`
 }
 
+type BucketVersioningConfiguration struct {
+	XMLName xml.Name `xml:"VersioningConfiguration"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Status  *string  `xml:"Status,omitempty"`
+}
+
+type VersionEntry struct {
+	Key          string `xml:"Key"`
+	VersionID    string `xml:"VersionId"`
+	IsLatest     bool   `xml:"IsLatest"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag,omitempty"`
+	Size         int64  `xml:"Size,omitempty"`
+	StorageClass string `xml:"StorageClass,omitempty"`
+}
+
+type DeleteMarkerVersionEntry struct {
+	Key          string `xml:"Key"`
+	VersionID    string `xml:"VersionId"`
+	IsLatest     bool   `xml:"IsLatest"`
+	LastModified string `xml:"LastModified"`
+}
+
+type ListObjectVersionsResult struct {
+	XMLName             xml.Name                    `xml:"ListVersionsResult"`
+	Name                string                      `xml:"Name"`
+	Prefix              *string                     `xml:"Prefix"`
+	Delimiter           *string                     `xml:"Delimiter"`
+	KeyMarker           *string                     `xml:"KeyMarker"`
+	VersionIDMarker     *string                     `xml:"VersionIdMarker"`
+	NextKeyMarker       *string                     `xml:"NextKeyMarker,omitempty"`
+	NextVersionIDMarker *string                     `xml:"NextVersionIdMarker,omitempty"`
+	MaxKeys             int32                       `xml:"MaxKeys"`
+	IsTruncated         bool                        `xml:"IsTruncated"`
+	Versions            []*VersionEntry             `xml:"Version"`
+	DeleteMarkers       []*DeleteMarkerVersionEntry `xml:"DeleteMarker"`
+	CommonPrefixes      []*CommonPrefixResult       `xml:"CommonPrefixes"`
+}
+
 type DeleteObjectEntry struct {
 	Key       string  `xml:"Key"`
 	VersionId *string `xml:"VersionId"`
@@ -378,13 +422,17 @@ type DeleteObjectsRequest struct {
 }
 
 type DeletedEntry struct {
-	Key string `xml:"Key"`
+	Key                   string  `xml:"Key"`
+	VersionId             *string `xml:"VersionId,omitempty"`
+	DeleteMarker          *bool   `xml:"DeleteMarker,omitempty"`
+	DeleteMarkerVersionId *string `xml:"DeleteMarkerVersionId,omitempty"`
 }
 
 type DeleteErrorEntry struct {
-	Key     string `xml:"Key"`
-	Code    string `xml:"Code"`
-	Message string `xml:"Message"`
+	Key       string  `xml:"Key"`
+	VersionId *string `xml:"VersionId,omitempty"`
+	Code      string  `xml:"Code"`
+	Message   string  `xml:"Message"`
 }
 
 type DeleteObjectsResult struct {
@@ -774,6 +822,14 @@ func (s *Server) headBucketHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listObjectsOrListMultipartUploadsOrGetBucketWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
+	if query.Has(versioningQuery) {
+		s.getBucketVersioningHandler(w, r)
+		return
+	}
+	if query.Has(versionsQuery) {
+		s.listObjectVersionsHandler(w, r)
+		return
+	}
 	if query.Has(websiteQuery) {
 		s.getBucketWebsiteHandler(w, r)
 		return
@@ -1178,6 +1234,10 @@ func (s *Server) listObjectsV2Handler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) createBucketOrPutBucketWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
+	if query.Has(versioningQuery) {
+		s.putBucketVersioningHandler(w, r)
+		return
+	}
 	if query.Has(websiteQuery) {
 		s.putBucketWebsiteHandler(w, r)
 		return
@@ -1259,7 +1319,12 @@ func (s *Server) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shouldReturn := s.authorizeRequest(ctx, authorization.OperationHeadObject, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
+	versionID := httputils.GetQueryParam(r.URL.Query(), versionIDQuery)
+	authOperation := authorization.OperationHeadObject
+	if versionID != nil {
+		authOperation = authorization.OperationHeadObjectVersion
+	}
+	shouldReturn := s.authorizeRequest(ctx, authOperation, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
 	if shouldReturn {
 		return
 	}
@@ -1269,8 +1334,11 @@ func (s *Server) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	var headOpts *storage.HeadObjectOptions
 	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
 	ifNoneMatch := getHeaderAsPtr(r.Header, ifNoneMatchHeader)
-	if ifMatch != nil || ifNoneMatch != nil {
+	if ifMatch != nil || ifNoneMatch != nil || versionID != nil {
 		headOpts = &storage.HeadObjectOptions{}
+		if versionID != nil {
+			headOpts.VersionID = versionID
+		}
 		if ifMatch != nil {
 			headOpts.IfMatchETag = ifMatch
 		}
@@ -1281,6 +1349,25 @@ func (s *Server) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	object, err := s.storage.HeadObject(ctx, bucketName, key, headOpts)
 	if err != nil {
+		if currentDeleteMarkerErr, ok := err.(*storage.CurrentDeleteMarkerError); ok {
+			responseHeaders := w.Header()
+			responseHeaders.Set(deleteMarkerHeader, "true")
+			if currentDeleteMarkerErr.VersionID != "" {
+				responseHeaders.Set(versionIDHeader, currentDeleteMarkerErr.VersionID)
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if versionDeleteMarkerErr, ok := err.(*storage.VersionDeleteMarkerMethodNotAllowedError); ok {
+			responseHeaders := w.Header()
+			responseHeaders.Set(deleteMarkerHeader, "true")
+			if versionDeleteMarkerErr.VersionID != "" {
+				responseHeaders.Set(versionIDHeader, versionDeleteMarkerErr.VersionID)
+			}
+			responseHeaders.Set(lastModifiedHeader, versionDeleteMarkerErr.LastModified.UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		if err == storage.ErrNotModified {
 			w.WriteHeader(304)
 			return
@@ -1295,6 +1382,9 @@ func (s *Server) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	responseHeaders := w.Header()
 	setETagHeaderFromObject(responseHeaders, object)
 	setChecksumHeadersFromObject(responseHeaders, object)
+	if object.VersionID != nil {
+		responseHeaders.Set(versionIDHeader, *object.VersionID)
+	}
 
 	gmtTimeLoc := time.FixedZone("GMT", 0)
 	responseHeaders.Set(lastModifiedHeader, object.LastModified.In(gmtTimeLoc).Format(time.RFC1123))
@@ -1544,7 +1634,12 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shouldReturn := s.authorizeRequest(ctx, authorization.OperationGetObject, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
+	versionID := httputils.GetQueryParam(r.URL.Query(), versionIDQuery)
+	authOperation := authorization.OperationGetObject
+	if versionID != nil {
+		authOperation = authorization.OperationGetObjectVersion
+	}
+	shouldReturn := s.authorizeRequest(ctx, authOperation, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
 	if shouldReturn {
 		return
 	}
@@ -1562,8 +1657,11 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	var getOpts *storage.GetObjectOptions
 	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
 	ifNoneMatch := getHeaderAsPtr(r.Header, ifNoneMatchHeader)
-	if ifMatch != nil || ifNoneMatch != nil {
+	if ifMatch != nil || ifNoneMatch != nil || versionID != nil {
 		getOpts = &storage.GetObjectOptions{}
+		if versionID != nil {
+			getOpts.VersionID = versionID
+		}
 		if ifMatch != nil {
 			getOpts.IfMatchETag = ifMatch
 		}
@@ -1576,6 +1674,25 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	// It also validates the ranges and returns ErrInvalidRange if invalid
 	object, readers, err := s.storage.GetObject(ctx, bucketName, key, storageRanges, getOpts)
 	if err != nil {
+		if currentDeleteMarkerErr, ok := err.(*storage.CurrentDeleteMarkerError); ok {
+			responseHeaders := w.Header()
+			responseHeaders.Set(deleteMarkerHeader, "true")
+			if currentDeleteMarkerErr.VersionID != "" {
+				responseHeaders.Set(versionIDHeader, currentDeleteMarkerErr.VersionID)
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if versionDeleteMarkerErr, ok := err.(*storage.VersionDeleteMarkerMethodNotAllowedError); ok {
+			responseHeaders := w.Header()
+			responseHeaders.Set(deleteMarkerHeader, "true")
+			if versionDeleteMarkerErr.VersionID != "" {
+				responseHeaders.Set(versionIDHeader, versionDeleteMarkerErr.VersionID)
+			}
+			responseHeaders.Set(lastModifiedHeader, versionDeleteMarkerErr.LastModified.UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		if err == storage.ErrNotModified {
 			w.WriteHeader(304)
 			return
@@ -1591,6 +1708,9 @@ func (s *Server) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	responseHeaders := w.Header()
 	responseHeaders.Set(contentTypeHeader, contentType)
 	setETagHeaderFromObject(responseHeaders, object)
+	if object.VersionID != nil {
+		responseHeaders.Set(versionIDHeader, *object.VersionID)
+	}
 
 	// Calculate sizes for each range
 	var sizes []int64
@@ -2005,6 +2125,9 @@ func (s *Server) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 		ChecksumSHA1:      putObjectResult.ChecksumSHA1,
 		ChecksumSHA256:    putObjectResult.ChecksumSHA256,
 	})
+	if putObjectResult.VersionID != nil {
+		responseHeaders.Set(versionIDHeader, *putObjectResult.VersionID)
+	}
 	setChecksumType(responseHeaders, storage.ChecksumTypeFullObject)
 	w.WriteHeader(200)
 }
@@ -2135,7 +2258,12 @@ func (s *Server) deleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shouldReturn := s.authorizeRequest(ctx, authorization.OperationDeleteObject, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
+	versionID := httputils.GetQueryParam(r.URL.Query(), versionIDQuery)
+	authOperation := authorization.OperationDeleteObject
+	if versionID != nil {
+		authOperation = authorization.OperationDeleteObjectVersion
+	}
+	shouldReturn := s.authorizeRequest(ctx, authOperation, ptrutils.ToPtr(bucketName.String()), ptrutils.ToPtr(key.String()), w, r)
 	if shouldReturn {
 		return
 	}
@@ -2143,13 +2271,21 @@ func (s *Server) deleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 	slog.InfoContext(r.Context(), "Deleting object", "bucket", bucketName.String(), "key", key.String())
 	ifMatch := getHeaderAsPtr(r.Header, ifMatchHeader)
 	var deleteOpts *storage.DeleteObjectOptions
-	if ifMatch != nil {
-		deleteOpts = &storage.DeleteObjectOptions{IfMatchETag: ifMatch}
+	if ifMatch != nil || versionID != nil {
+		deleteOpts = &storage.DeleteObjectOptions{IfMatchETag: ifMatch, VersionID: versionID}
 	}
-	err = s.storage.DeleteObject(ctx, bucketName, key, deleteOpts)
+	deleteResult, err := s.storage.DeleteObject(ctx, bucketName, key, deleteOpts)
 	if err != nil {
 		handleError(err, w, r)
 		return
+	}
+	if deleteResult != nil {
+		if deleteResult.VersionID != nil {
+			w.Header().Set(versionIDHeader, *deleteResult.VersionID)
+		}
+		if deleteResult.IsDeleteMarker {
+			w.Header().Set(deleteMarkerHeader, "true")
+		}
 	}
 	w.WriteHeader(204)
 }
@@ -2181,6 +2317,7 @@ const maxDeleteObjects = 1000
 const maxCompleteMultipartUploadBodySize int64 = 10 * 1024 * 1024
 const maxDeleteObjectsBodySize int64 = 5 * 1024 * 1024
 const maxPutBucketWebsiteBodySize int64 = 128 * 1024
+const maxPutBucketVersioningBodySize int64 = 16 * 1024
 
 func readLimitedBody(r *http.Request, w http.ResponseWriter, maxBodySize int64) ([]byte, error) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
@@ -2235,23 +2372,15 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	// We track the original string key alongside the parsed ObjectKey so we can
 	// build the response even when validation fails.
 	type validEntry struct {
-		rawKey string
-		key    storage.ObjectKey
-		etag   *string
+		rawKey    string
+		key       storage.ObjectKey
+		versionID *string
+		etag      *string
 	}
 	validEntries := make([]validEntry, 0, len(req.Objects))
 	baseRequest, _ := makeAuthorizationRequest(ctx, authorization.OperationDeleteObjects, ptrutils.ToPtr(bucketName.String()), nil, r)
 
 	for _, obj := range req.Objects {
-		if obj.VersionId != nil {
-			result.Errors = append(result.Errors, &DeleteErrorEntry{
-				Key:     obj.Key,
-				Code:    "NotImplemented",
-				Message: "versioning is not supported",
-			})
-			continue
-		}
-
 		key, err := storage.NewObjectKey(obj.Key)
 		if err != nil {
 			result.Errors = append(result.Errors, &DeleteErrorEntry{
@@ -2262,7 +2391,7 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key, etag: obj.ETag})
+		validEntries = append(validEntries, validEntry{rawKey: obj.Key, key: key, versionID: obj.VersionId, etag: obj.ETag})
 	}
 
 	// Second pass: authorize valid entries and collect entries to bulk-delete.
@@ -2288,7 +2417,7 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	if len(authorizedEntries) > 0 {
 		inputEntries := make([]storage.DeleteObjectsInputEntry, len(authorizedEntries))
 		for i, ve := range authorizedEntries {
-			inputEntries[i] = storage.DeleteObjectsInputEntry{Key: ve.key, IfMatchETag: ve.etag}
+			inputEntries[i] = storage.DeleteObjectsInputEntry{Key: ve.key, VersionID: ve.versionID, IfMatchETag: ve.etag}
 		}
 
 		slog.InfoContext(r.Context(), "DeleteObjects: deleting objects", "bucket", bucketName.String(), "count", len(inputEntries))
@@ -2302,23 +2431,40 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Build a map from key string → entry for result lookup.
-		resultByKey := make(map[string]storage.DeleteObjectsEntry, len(deleteResult.Entries))
+		// Build a map from key+versionId -> ordered entries for result lookup.
+		// Multiple request entries can share the same key (and version id), so we
+		// keep a slice and consume in request order.
+		resultByKeyVersion := make(map[string][]storage.DeleteObjectsEntry, len(deleteResult.Entries))
 		for _, entry := range deleteResult.Entries {
-			resultByKey[entry.Key.String()] = entry
+			k := entry.Key.String() + "\x00"
+			if entry.VersionID != nil {
+				k += *entry.VersionID
+			}
+			resultByKeyVersion[k] = append(resultByKeyVersion[k], entry)
 		}
 
 		for _, ve := range authorizedEntries {
-			entry, ok := resultByKey[ve.key.String()]
+			k := ve.key.String() + "\x00"
+			if ve.versionID != nil {
+				k += *ve.versionID
+			}
+			entriesForKey := resultByKeyVersion[k]
+			entry := storage.DeleteObjectsEntry{Key: ve.key, Deleted: true}
+			ok := len(entriesForKey) > 0
+			if ok {
+				entry = entriesForKey[0]
+				resultByKeyVersion[k] = entriesForKey[1:]
+			}
 			if !ok || entry.Deleted {
 				if !req.Quiet {
-					result.Deleted = append(result.Deleted, &DeletedEntry{Key: ve.rawKey})
+					result.Deleted = append(result.Deleted, &DeletedEntry{Key: ve.rawKey, VersionId: entry.VersionID, DeleteMarker: entry.DeleteMarker, DeleteMarkerVersionId: entry.DeleteMarkerVersionID})
 				}
 			} else {
 				result.Errors = append(result.Errors, &DeleteErrorEntry{
-					Key:     ve.rawKey,
-					Code:    entry.ErrCode,
-					Message: entry.ErrMsg,
+					Key:       ve.rawKey,
+					VersionId: entry.VersionID,
+					Code:      entry.ErrCode,
+					Message:   entry.ErrMsg,
 				})
 			}
 		}
@@ -2328,6 +2474,158 @@ func (s *Server) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	responseHeaders.Set(contentTypeHeader, applicationXmlContentType)
 	w.WriteHeader(http.StatusOK)
 	out, _ := xmlMarshalWithDocType(result)
+	w.Write(out)
+}
+
+func (s *Server) getBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "Server.getBucketVersioningHandler")
+	defer span.End()
+
+	bucketName, err := storage.NewBucketName(r.PathValue(bucketPath))
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	if s.authorizeRequest(ctx, authorization.OperationGetBucketVersioning, ptrutils.ToPtr(bucketName.String()), nil, w, r) {
+		return
+	}
+
+	config, err := s.storage.GetBucketVersioningConfiguration(ctx, bucketName)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	response := BucketVersioningConfiguration{Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/"}
+	if config.Status != nil {
+		status := string(*config.Status)
+		response.Status = &status
+	}
+
+	w.Header().Set(contentTypeHeader, applicationXmlContentType)
+	w.WriteHeader(http.StatusOK)
+	out, _ := xmlMarshalWithDocType(response)
+	w.Write(out)
+}
+
+func (s *Server) putBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "Server.putBucketVersioningHandler")
+	defer span.End()
+
+	bucketName, err := storage.NewBucketName(r.PathValue(bucketPath))
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	if s.authorizeRequest(ctx, authorization.OperationPutBucketVersioning, ptrutils.ToPtr(bucketName.String()), nil, w, r) {
+		return
+	}
+
+	data, err := readLimitedBody(r, w, maxPutBucketVersioningBodySize)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	var request BucketVersioningConfiguration
+	if err := xml.Unmarshal(data, &request); err != nil {
+		handleError(ErrInvalidRequest, w, r)
+		return
+	}
+
+	if request.Status == nil {
+		handleError(ErrInvalidRequest, w, r)
+		return
+	}
+
+	var status storage.BucketVersioningStatus
+	switch *request.Status {
+	case string(storage.BucketVersioningStatusEnabled):
+		status = storage.BucketVersioningStatusEnabled
+	case string(storage.BucketVersioningStatusSuspended):
+		status = storage.BucketVersioningStatusSuspended
+	default:
+		handleError(ErrInvalidRequest, w, r)
+		return
+	}
+
+	err = s.storage.PutBucketVersioningConfiguration(ctx, bucketName, &storage.BucketVersioningConfiguration{Status: &status})
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) listObjectVersionsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "Server.listObjectVersionsHandler")
+	defer span.End()
+
+	bucketName, err := storage.NewBucketName(r.PathValue(bucketPath))
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	if s.authorizeRequest(ctx, authorization.OperationListObjectVersions, ptrutils.ToPtr(bucketName.String()), nil, w, r) {
+		return
+	}
+
+	query := r.URL.Query()
+	prefix := httputils.GetQueryParam(query, prefixQuery)
+	delimiter := httputils.GetQueryParam(query, delimiterQuery)
+	keyMarker := httputils.GetQueryParam(query, keyMarkerQuery)
+	versionIDMarker := httputils.GetQueryParam(query, "version-id-marker")
+
+	maxKeys := query.Get(maxKeysQuery)
+	maxKeysI64, err := strconv.ParseInt(maxKeys, 10, 32)
+	if err != nil || maxKeysI64 < 0 || maxKeysI64 > maxListLimit {
+		maxKeysI64 = 1000
+	}
+	maxKeysI32 := int32(maxKeysI64)
+
+	result, err := s.storage.ListObjectVersions(ctx, bucketName, storage.ListObjectVersionsOptions{Prefix: prefix, Delimiter: delimiter, KeyMarker: keyMarker, VersionIDMarker: versionIDMarker, MaxKeys: maxKeysI32})
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	response := ListObjectVersionsResult{
+		Name:                bucketName.String(),
+		Prefix:              prefix,
+		Delimiter:           delimiter,
+		KeyMarker:           keyMarker,
+		VersionIDMarker:     versionIDMarker,
+		NextKeyMarker:       result.NextKeyMarker,
+		NextVersionIDMarker: result.NextVersionIDMarker,
+		MaxKeys:             maxKeysI32,
+		IsTruncated:         result.IsTruncated,
+		Versions:            []*VersionEntry{},
+		DeleteMarkers:       []*DeleteMarkerVersionEntry{},
+		CommonPrefixes:      []*CommonPrefixResult{},
+	}
+
+	for _, version := range result.Versions {
+		if version.IsDeleteMarker {
+			response.DeleteMarkers = append(response.DeleteMarkers, &DeleteMarkerVersionEntry{Key: version.Key.String(), VersionID: version.VersionID, IsLatest: version.IsLatest, LastModified: version.LastModified.UTC().Format(time.RFC3339)})
+		} else {
+			etag := ""
+			if version.ETag != nil {
+				etag = *version.ETag
+			}
+			response.Versions = append(response.Versions, &VersionEntry{Key: version.Key.String(), VersionID: version.VersionID, IsLatest: version.IsLatest, LastModified: version.LastModified.UTC().Format(time.RFC3339), ETag: etag, Size: version.Size, StorageClass: storageClassStandard})
+		}
+	}
+	for _, commonPrefix := range result.CommonPrefixes {
+		response.CommonPrefixes = append(response.CommonPrefixes, &CommonPrefixResult{Prefix: commonPrefix})
+	}
+
+	w.Header().Set(contentTypeHeader, applicationXmlContentType)
+	w.WriteHeader(http.StatusOK)
+	out, _ := xmlMarshalWithDocType(response)
 	w.Write(out)
 }
 

--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -1934,6 +1934,9 @@ func (s *Server) completeMultipartUploadHandler(w http.ResponseWriter, r *http.R
 		ChecksumSHA256:    result.ChecksumSHA256,
 		ChecksumType:      result.ChecksumType,
 	}
+	if result.VersionID != nil {
+		w.Header().Set(versionIDHeader, *result.VersionID)
+	}
 
 	w.WriteHeader(200)
 	out, _ := xmlMarshalWithDocType(completeMultipartUploadResult)

--- a/internal/storage/benchmark/benchmark.go
+++ b/internal/storage/benchmark/benchmark.go
@@ -185,7 +185,7 @@ func cleanupObjectsInBucket(ctx context.Context, st storage.Storage, bucketName 
 	}
 
 	for _, obj := range objects {
-		err = st.DeleteObject(ctx, bucketName, obj.Key, nil)
+		_, err = st.DeleteObject(ctx, bucketName, obj.Key, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -98,6 +98,18 @@ func (cs *CacheStorage) HeadBucket(ctx context.Context, bucketName storage.Bucke
 	return bucket, nil
 }
 
+func (cs *CacheStorage) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := cs.tracer.Start(ctx, "CacheStorage.GetBucketVersioningConfiguration")
+	defer span.End()
+	return cs.innerStorage.GetBucketVersioningConfiguration(ctx, bucketName)
+}
+
+func (cs *CacheStorage) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := cs.tracer.Start(ctx, "CacheStorage.PutBucketVersioningConfiguration")
+	defer span.End()
+	return cs.innerStorage.PutBucketVersioningConfiguration(ctx, bucketName, config)
+}
+
 func (cs *CacheStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.ListObjects")
 	defer span.End()
@@ -107,6 +119,12 @@ func (cs *CacheStorage) ListObjects(ctx context.Context, bucketName storage.Buck
 		return nil, err
 	}
 	return objects, nil
+}
+
+func (cs *CacheStorage) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := cs.tracer.Start(ctx, "CacheStorage.ListObjectVersions")
+	defer span.End()
+	return cs.innerStorage.ListObjectVersions(ctx, bucketName, opts)
 }
 
 func (cs *CacheStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
@@ -124,13 +142,19 @@ func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.Bucket
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.GetObject")
 	defer span.End()
 
+	// Version-specific or conditional reads should bypass cache to avoid serving
+	// stale or wrong versions from a key-only cache entry.
+	if opts != nil && (opts.VersionID != nil || opts.IfMatchETag != nil || opts.IfNoneMatchETag != nil) {
+		return cs.innerStorage.GetObject(ctx, bucketName, key, ranges, opts)
+	}
+
 	// If no ranges specified, get the entire object
 	if len(ranges) == 0 {
 		ranges = []storage.ByteRange{{Start: nil, End: nil}}
 	}
 
 	// Get object metadata
-	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key, nil)
+	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key, &storage.HeadObjectOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -233,21 +257,21 @@ func (cs *CacheStorage) AppendObject(ctx context.Context, bucketName storage.Buc
 	return appendObjectResult, nil
 }
 
-func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObject")
 	defer span.End()
 
-	err := cs.innerStorage.DeleteObject(ctx, bucketName, key, opts)
+	result, err := cs.innerStorage.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cacheKey := getObjectCacheKeyForBucketAndKey(bucketName, key)
 	err = cs.cache.Remove(cacheKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return result, nil
 }
 
 func (cs *CacheStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {

--- a/internal/storage/database/pgx/migrations/12_bucket_versioning_and_object_versions.down.sql
+++ b/internal/storage/database/pgx/migrations/12_bucket_versioning_and_object_versions.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS objects_completed_version_unique;
+DROP INDEX IF EXISTS objects_completed_latest_unique;
+
+CREATE UNIQUE INDEX objects_completed_unique ON objects (bucket_name, key, upload_status)
+WHERE upload_status = 'COMPLETED';
+
+ALTER TABLE objects DROP COLUMN is_latest;
+ALTER TABLE objects DROP COLUMN is_delete_marker;
+ALTER TABLE objects DROP COLUMN version_id;
+ALTER TABLE buckets DROP COLUMN versioning_status;

--- a/internal/storage/database/pgx/migrations/12_bucket_versioning_and_object_versions.up.sql
+++ b/internal/storage/database/pgx/migrations/12_bucket_versioning_and_object_versions.up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE buckets ADD COLUMN versioning_status TEXT;
+
+ALTER TABLE objects ADD COLUMN version_id TEXT;
+ALTER TABLE objects ADD COLUMN is_delete_marker BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE objects ADD COLUMN is_latest BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE objects
+SET version_id = 'null', is_delete_marker = FALSE, is_latest = TRUE
+WHERE upload_status = 'COMPLETED';
+
+DROP INDEX objects_completed_unique;
+
+CREATE UNIQUE INDEX objects_completed_latest_unique ON objects (bucket_name, key, upload_status, is_latest)
+WHERE upload_status = 'COMPLETED' AND is_latest = TRUE;
+
+CREATE UNIQUE INDEX objects_completed_version_unique ON objects (bucket_name, key, upload_status, version_id)
+WHERE upload_status = 'COMPLETED' AND version_id IS NOT NULL;

--- a/internal/storage/database/pgx/migrations/13_storage_outbox_version_id.down.sql
+++ b/internal/storage/database/pgx/migrations/13_storage_outbox_version_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE storage_outbox_entries DROP COLUMN version_id;

--- a/internal/storage/database/pgx/migrations/13_storage_outbox_version_id.up.sql
+++ b/internal/storage/database/pgx/migrations/13_storage_outbox_version_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE storage_outbox_entries ADD COLUMN version_id TEXT;

--- a/internal/storage/database/pgx/repository/bucket/pgx.go
+++ b/internal/storage/database/pgx/repository/bucket/pgx.go
@@ -14,10 +14,10 @@ type pgxRepository struct {
 }
 
 const (
-	findAllBucketsStmt     = "SELECT id, name, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets"
-	findBucketByNameStmt   = "SELECT id, name, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets WHERE name = $1"
-	insertBucketStmt       = "INSERT INTO buckets (id, name, website_index_document_suffix, website_error_document_key, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6)"
-	updateBucketByIdStmt   = "UPDATE buckets SET name = $1, website_index_document_suffix = $2, website_error_document_key = $3, updated_at = $4 WHERE id = $5"
+	findAllBucketsStmt     = "SELECT id, name, versioning_status, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets"
+	findBucketByNameStmt   = "SELECT id, name, versioning_status, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets WHERE name = $1"
+	insertBucketStmt       = "INSERT INTO buckets (id, name, versioning_status, website_index_document_suffix, website_error_document_key, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
+	updateBucketByIdStmt   = "UPDATE buckets SET name = $1, versioning_status = $2, website_index_document_suffix = $3, website_error_document_key = $4, updated_at = $5 WHERE id = $6"
 	existsBucketByNameStmt = "SELECT id FROM buckets WHERE name = $1"
 	deleteBucketByNameStmt = "DELETE FROM buckets WHERE name = $1"
 )
@@ -29,11 +29,12 @@ func NewRepository() (bucket.Repository, error) {
 func convertRowToBucketEntity(bucketRows *sql.Rows) (*bucket.Entity, error) {
 	var id string
 	var name string
+	var versioningStatus *string
 	var websiteIndexDocumentSuffix *string
 	var websiteErrorDocumentKey *string
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := bucketRows.Scan(&id, &name, &websiteIndexDocumentSuffix, &websiteErrorDocumentKey, &createdAt, &updatedAt)
+	err := bucketRows.Scan(&id, &name, &versioningStatus, &websiteIndexDocumentSuffix, &websiteErrorDocumentKey, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -41,6 +42,7 @@ func convertRowToBucketEntity(bucketRows *sql.Rows) (*bucket.Entity, error) {
 	bucketEntity := bucket.Entity{
 		Id:                         &ulidId,
 		Name:                       storage.MustNewBucketName(name),
+		VersioningStatus:           versioningStatus,
 		WebsiteIndexDocumentSuffix: websiteIndexDocumentSuffix,
 		WebsiteErrorDocumentKey:    websiteErrorDocumentKey,
 		CreatedAt:                  createdAt,
@@ -88,11 +90,11 @@ func (br *pgxRepository) SaveBucket(ctx context.Context, tx *sql.Tx, bucket *buc
 		bucket.Id = &id
 		bucket.CreatedAt = time.Now().UTC()
 		bucket.UpdatedAt = bucket.CreatedAt
-		_, err := tx.ExecContext(ctx, insertBucketStmt, bucket.Id.String(), bucket.Name.String(), bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.CreatedAt, bucket.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertBucketStmt, bucket.Id.String(), bucket.Name.String(), bucket.VersioningStatus, bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.CreatedAt, bucket.UpdatedAt)
 		return err
 	}
 	bucket.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateBucketByIdStmt, bucket.Name.String(), bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.UpdatedAt, bucket.Id.String())
+	_, err := tx.ExecContext(ctx, updateBucketByIdStmt, bucket.Name.String(), bucket.VersioningStatus, bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.UpdatedAt, bucket.Id.String())
 	return err
 }
 

--- a/internal/storage/database/pgx/repository/object/pgx.go
+++ b/internal/storage/database/pgx/repository/object/pgx.go
@@ -15,19 +15,25 @@ type pgxRepository struct {
 }
 
 const (
-	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)"
-	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT DO NOTHING"
-	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15"
-	updateObjectByIdAndOptimisticLockVersionStmt                                                 = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15 AND optimistic_lock_version = $16"
-	containsBucketObjectsByBucketNameStmt                                                        = "SELECT id FROM objects WHERE bucket_name = $1"
-	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
-	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
-	findObjectByBucketNameAndKeyAndUploadIdStmt                                                  = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
-	findObjectByBucketNameAndKeyStmt                                                             = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3"
-	countObjectsByBucketNameAndPrefixAndStartAfterStmt                                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_status = $4"
-	countObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerStmt                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5"
-	deleteObjectByIdStmt                                                                         = "DELETE FROM objects WHERE id = $1"
-	deleteObjectByIdAndOptimisticLockVersionStmt                                                 = "DELETE FROM objects WHERE id = $1 AND optimistic_lock_version = $2"
+	insertObjectStmt                                                                                       = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)"
+	insertObjectIfAbsentStmt                                                                               = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) ON CONFLICT DO NOTHING"
+	updateObjectByIdStmt                                                                                   = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, version_id = $12, is_delete_marker = $13, is_latest = $14, upload_status = $15, upload_id = $16, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $17 WHERE id = $18"
+	updateObjectByIdAndOptimisticLockVersionStmt                                                           = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, version_id = $12, is_delete_marker = $13, is_latest = $14, upload_status = $15, upload_id = $16, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $17 WHERE id = $18 AND optimistic_lock_version = $19"
+	containsBucketObjectsByBucketNameStmt                                                                  = "SELECT id FROM objects WHERE bucket_name = $1"
+	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                                         = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 AND is_latest = TRUE AND is_delete_marker = FALSE ORDER BY key ASC"
+	findObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDescStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND upload_status = $3 AND (key > $4 OR (key = $4 AND COALESCE(version_id, '') < $5)) ORDER BY key ASC, created_at DESC"
+	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt           = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
+	findObjectByBucketNameAndKeyAndUploadIdStmt                                                            = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
+	findObjectByBucketNameAndKeyStmt                                                                       = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3 AND is_latest = TRUE"
+	findObjectByBucketNameAndKeyAndVersionIDStmt                                                           = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND version_id = $3 AND upload_status = $4"
+	findNullObjectVersionByBucketNameAndKeyStmt                                                            = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND version_id = 'null' AND upload_status = $3"
+	findLatestObjectByBucketNameAndKeyExcludingIDStmt                                                      = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3 AND id != $4 ORDER BY created_at DESC LIMIT 1"
+	countObjectsByBucketNameAndPrefixAndStartAfterStmt                                                     = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_status = $4 AND is_latest = TRUE AND is_delete_marker = FALSE"
+	countObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerStmt                             = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND upload_status = $3 AND (key > $4 OR (key = $4 AND COALESCE(version_id, '') < $5))"
+	countObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerStmt                                     = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5"
+	clearLatestObjectByBucketNameAndKeyStmt                                                                = "UPDATE objects SET is_latest = FALSE, updated_at = $3 WHERE bucket_name = $1 AND key = $2 AND upload_status = $4 AND is_latest = TRUE"
+	deleteObjectByIdStmt                                                                                   = "DELETE FROM objects WHERE id = $1"
+	deleteObjectByIdAndOptimisticLockVersionStmt                                                           = "DELETE FROM objects WHERE id = $1 AND optimistic_lock_version = $2"
 )
 
 func NewRepository() (object.Repository, error) {
@@ -47,12 +53,15 @@ func convertRowToObjectEntity(objectRows *sql.Rows) (*object.Entity, error) {
 	var checksumSHA256 *string
 	var checksumType *string
 	var size int64
+	var versionID *string
+	var isDeleteMarker bool
+	var isLatest bool
 	var uploadStatus string
 	var uploadId *string
 	var optimisticLockVersion int64
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &uploadStatus, &uploadId, &optimisticLockVersion, &createdAt, &updatedAt)
+	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &versionID, &isDeleteMarker, &isLatest, &uploadStatus, &uploadId, &optimisticLockVersion, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +79,9 @@ func convertRowToObjectEntity(objectRows *sql.Rows) (*object.Entity, error) {
 		ChecksumSHA256:        checksumSHA256,
 		ChecksumType:          checksumType,
 		Size:                  size,
+		VersionID:             versionID,
+		IsDeleteMarker:        isDeleteMarker,
+		IsLatest:              isLatest,
 		UploadStatus:          uploadStatus,
 		UploadId:              ptrutils.MapPtr(uploadId, storage.MustNewUploadId),
 		OptimisticLockVersion: optimisticLockVersion,
@@ -91,11 +103,11 @@ func (or *pgxRepository) SaveObject(ctx context.Context, tx *sql.Tx, object *obj
 		if object.OptimisticLockVersion == 0 {
 			object.OptimisticLockVersion = 1
 		}
-		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 		return err
 	}
 	object.UpdatedAt = time.Now().UTC()
-	res, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
+	res, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
 	if err != nil {
 		return err
 	}
@@ -125,7 +137,7 @@ func (or *pgxRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx, o
 	}
 	object.UpdatedAt = object.CreatedAt
 
-	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
+	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +155,7 @@ func (or *pgxRepository) UpdateObjectByIdAndOptimisticLockVersion(ctx context.Co
 		return uploadId.String()
 	}
 	object.UpdatedAt = time.Now().UTC()
-	res, err := tx.ExecContext(ctx, updateObjectByIdAndOptimisticLockVersionStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String(), optimisticLockVersion)
+	res, err := tx.ExecContext(ctx, updateObjectByIdAndOptimisticLockVersionStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String(), optimisticLockVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -202,6 +214,23 @@ func (or *pgxRepository) FindUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadId
 	return objects, nil
 }
 
+func (or *pgxRepository) FindObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDesc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, versionIDMarker string) ([]object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDescStmt, bucketName.String(), prefix, object.UploadStatusCompleted, keyMarker, versionIDMarker)
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	objects := []object.Entity{}
+	for objectRows.Next() {
+		objectEntity, err := convertRowToObjectEntity(objectRows)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, *objectEntity)
+	}
+	return objects, nil
+}
+
 func (or *pgxRepository) FindObjectByBucketNameAndKeyAndUploadId(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) (*object.Entity, error) {
 	objectRows, err := tx.QueryContext(ctx, findObjectByBucketNameAndKeyAndUploadIdStmt, bucketName.String(), key.String(), uploadId.String(), object.UploadStatusPending)
 	if err != nil {
@@ -236,6 +265,42 @@ func (or *pgxRepository) FindObjectByBucketNameAndKey(ctx context.Context, tx *s
 	return nil, nil
 }
 
+func (or *pgxRepository) FindObjectByBucketNameAndKeyAndVersionID(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, versionID string) (*object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findObjectByBucketNameAndKeyAndVersionIDStmt, bucketName.String(), key.String(), versionID, object.UploadStatusCompleted)
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	if objectRows.Next() {
+		return convertRowToObjectEntity(objectRows)
+	}
+	return nil, nil
+}
+
+func (or *pgxRepository) FindNullObjectVersionByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) (*object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findNullObjectVersionByBucketNameAndKeyStmt, bucketName.String(), key.String(), object.UploadStatusCompleted)
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	if objectRows.Next() {
+		return convertRowToObjectEntity(objectRows)
+	}
+	return nil, nil
+}
+
+func (or *pgxRepository) FindLatestObjectByBucketNameAndKeyExcludingID(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, excludedObjectID ulid.ULID) (*object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findLatestObjectByBucketNameAndKeyExcludingIDStmt, bucketName.String(), key.String(), object.UploadStatusCompleted, excludedObjectID.String())
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	if objectRows.Next() {
+		return convertRowToObjectEntity(objectRows)
+	}
+	return nil, nil
+}
+
 func (or *pgxRepository) CountObjectsByBucketNameAndPrefixAndStartAfter(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) (*int, error) {
 	keyCountRow := tx.QueryRowContext(ctx, countObjectsByBucketNameAndPrefixAndStartAfterStmt, bucketName.String(), prefix, startAfter, object.UploadStatusCompleted)
 	var keyCount int
@@ -254,6 +319,21 @@ func (or *pgxRepository) CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadI
 		return nil, err
 	}
 	return &keyCount, nil
+}
+
+func (or *pgxRepository) CountObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarker(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, versionIDMarker string) (*int, error) {
+	keyCountRow := tx.QueryRowContext(ctx, countObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerStmt, bucketName.String(), prefix, object.UploadStatusCompleted, keyMarker, versionIDMarker)
+	var keyCount int
+	err := keyCountRow.Scan(&keyCount)
+	if err != nil {
+		return nil, err
+	}
+	return &keyCount, nil
+}
+
+func (or *pgxRepository) ClearLatestObjectByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) error {
+	_, err := tx.ExecContext(ctx, clearLatestObjectByBucketNameAndKeyStmt, bucketName.String(), key.String(), time.Now().UTC(), object.UploadStatusCompleted)
+	return err
 }
 
 func (or *pgxRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error) {

--- a/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
@@ -15,14 +15,14 @@ type pgxRepository struct {
 
 const (
 	countStorageOutboxEntriesStmt                    = "SELECT COUNT(*) FROM storage_outbox_entries"
-	findFirstStorageOutboxEntryWithForUpdateLockStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1 FOR UPDATE"
-	findFirstStorageOutboxEntryStmt                  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
-	findFirstStorageOutboxEntryForBucketStmt         = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryForBucketStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryWithForUpdateLockStmt = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1 FOR UPDATE"
+	findFirstStorageOutboxEntryStmt                  = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketStmt         = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketStmt          = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
 	findStorageOutboxEntryChunksByIdStmt             = "SELECT outbox_entry_id, chunk_index, content FROM storage_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
-	insertStorageOutboxEntryStmt                     = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
-	updateStorageOutboxEntryByIdStmt                 = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6"
+	insertStorageOutboxEntryStmt                     = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, version_id, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8)"
+	updateStorageOutboxEntryByIdStmt                 = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, version_id = $4, content_type = $5, updated_at = $6 WHERE id = $7"
 	upsertStorageOutboxContentChunkStmt              = "INSERT INTO storage_outbox_contents (outbox_entry_id, chunk_index, content) VALUES($1, $2, $3) ON CONFLICT (outbox_entry_id, chunk_index) DO UPDATE SET content = EXCLUDED.content"
 	deleteStorageOutboxEntryByIdStmt                 = "DELETE FROM storage_outbox_entries WHERE id = $1"
 )
@@ -45,10 +45,11 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 	var operation string
 	var bucket string
 	var key string
+	var versionID *string
 	var contentType *string
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := storageOutboxRow.Scan(&id, &operation, &bucket, &key, &contentType, &createdAt, &updatedAt)
+	err := storageOutboxRow.Scan(&id, &operation, &bucket, &key, &versionID, &contentType, &createdAt, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -61,6 +62,7 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 		Operation:   operation,
 		Bucket:      storage.MustNewBucketName(bucket),
 		Key:         key,
+		VersionID:   versionID,
 		ContentType: contentType,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
@@ -143,12 +145,12 @@ func (sor *pgxRepository) SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx
 		storageOutboxEntry.Id = &id
 		storageOutboxEntry.CreatedAt = time.Now().UTC()
 		storageOutboxEntry.UpdatedAt = storageOutboxEntry.CreatedAt
-		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.VersionID, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
 		return err
 	}
 
 	storageOutboxEntry.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String())
+	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.VersionID, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String())
 	return err
 }
 

--- a/internal/storage/database/repository/bucket/interface.go
+++ b/internal/storage/database/repository/bucket/interface.go
@@ -20,6 +20,7 @@ type Repository interface {
 type Entity struct {
 	Id                         *ulid.ULID
 	Name                       storage.BucketName
+	VersioningStatus           *string
 	WebsiteIndexDocumentSuffix *string
 	WebsiteErrorDocumentKey    *string
 	CreatedAt                  time.Time

--- a/internal/storage/database/repository/object/interface.go
+++ b/internal/storage/database/repository/object/interface.go
@@ -15,11 +15,17 @@ type Repository interface {
 	UpdateObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, object *Entity, optimisticLockVersion int64) (*bool, error)
 	ContainsBucketObjectsByBucketName(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*bool, error)
 	FindObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAsc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) ([]Entity, error)
+	FindObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDesc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, versionIDMarker string) ([]Entity, error)
 	FindUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAsc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, uploadIdMarker string) ([]Entity, error)
 	FindObjectByBucketNameAndKeyAndUploadId(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) (*Entity, error)
 	FindObjectByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) (*Entity, error)
+	FindObjectByBucketNameAndKeyAndVersionID(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, versionID string) (*Entity, error)
+	FindNullObjectVersionByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) (*Entity, error)
+	FindLatestObjectByBucketNameAndKeyExcludingID(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, excludedObjectID ulid.ULID) (*Entity, error)
 	CountObjectsByBucketNameAndPrefixAndStartAfter(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) (*int, error)
+	CountObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarker(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, versionIDMarker string) (*int, error)
 	CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarker(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, uploadIdMarker string) (*int, error)
+	ClearLatestObjectByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) error
 	DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error)
 	DeleteObjectByIdAndOptimisticLockVersion(ctx context.Context, tx *sql.Tx, objectId ulid.ULID, optimisticLockVersion int64) (*bool, error)
 }
@@ -37,6 +43,9 @@ type Entity struct {
 	ChecksumSHA256        *string
 	ChecksumType          *string
 	Size                  int64
+	VersionID             *string
+	IsDeleteMarker        bool
+	IsLatest              bool
 	UploadStatus          string
 	UploadId              *storage.UploadId
 	OptimisticLockVersion int64

--- a/internal/storage/database/repository/storageoutboxentry/interface.go
+++ b/internal/storage/database/repository/storageoutboxentry/interface.go
@@ -27,6 +27,7 @@ type Entity struct {
 	Operation   string
 	Bucket      storage.BucketName
 	Key         string
+	VersionID   *string
 	ContentType *string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/storage/database/sqlite/migrations/19_bucket_versioning_and_object_versions.down.sql
+++ b/internal/storage/database/sqlite/migrations/19_bucket_versioning_and_object_versions.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS objects_completed_version_unique;
+DROP INDEX IF EXISTS objects_completed_latest_unique;
+
+CREATE UNIQUE INDEX objects_completed_unique ON objects (bucket_name, key, upload_status)
+WHERE upload_status = 'COMPLETED';

--- a/internal/storage/database/sqlite/migrations/19_bucket_versioning_and_object_versions.up.sql
+++ b/internal/storage/database/sqlite/migrations/19_bucket_versioning_and_object_versions.up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE buckets ADD COLUMN versioning_status TEXT;
+
+ALTER TABLE objects ADD COLUMN version_id TEXT;
+ALTER TABLE objects ADD COLUMN is_delete_marker INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE objects ADD COLUMN is_latest INTEGER NOT NULL DEFAULT 0;
+
+UPDATE objects
+SET version_id = 'null', is_delete_marker = 0, is_latest = 1
+WHERE upload_status = 'COMPLETED';
+
+DROP INDEX objects_completed_unique;
+
+CREATE UNIQUE INDEX objects_completed_latest_unique ON objects (bucket_name, key, upload_status, is_latest)
+WHERE upload_status = 'COMPLETED' AND is_latest = 1;
+
+CREATE UNIQUE INDEX objects_completed_version_unique ON objects (bucket_name, key, upload_status, version_id)
+WHERE upload_status = 'COMPLETED' AND version_id IS NOT NULL;

--- a/internal/storage/database/sqlite/migrations/20_storage_outbox_version_id.down.sql
+++ b/internal/storage/database/sqlite/migrations/20_storage_outbox_version_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE storage_outbox_entries DROP COLUMN version_id;

--- a/internal/storage/database/sqlite/migrations/20_storage_outbox_version_id.up.sql
+++ b/internal/storage/database/sqlite/migrations/20_storage_outbox_version_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE storage_outbox_entries ADD COLUMN version_id TEXT;

--- a/internal/storage/database/sqlite/repository/bucket/sqlite.go
+++ b/internal/storage/database/sqlite/repository/bucket/sqlite.go
@@ -14,10 +14,10 @@ type sqliteRepository struct {
 }
 
 const (
-	findAllBucketsStmt     = "SELECT id, name, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets"
-	findBucketByNameStmt   = "SELECT id, name, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets WHERE name = $1"
-	insertBucketStmt       = "INSERT INTO buckets (id, name, website_index_document_suffix, website_error_document_key, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6)"
-	updateBucketByIdStmt   = "UPDATE buckets SET name = $1, website_index_document_suffix = $2, website_error_document_key = $3, updated_at = $4 WHERE id = $5"
+	findAllBucketsStmt     = "SELECT id, name, versioning_status, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets"
+	findBucketByNameStmt   = "SELECT id, name, versioning_status, website_index_document_suffix, website_error_document_key, created_at, updated_at FROM buckets WHERE name = $1"
+	insertBucketStmt       = "INSERT INTO buckets (id, name, versioning_status, website_index_document_suffix, website_error_document_key, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
+	updateBucketByIdStmt   = "UPDATE buckets SET name = $1, versioning_status = $2, website_index_document_suffix = $3, website_error_document_key = $4, updated_at = $5 WHERE id = $6"
 	existsBucketByNameStmt = "SELECT id FROM buckets WHERE name = $1"
 	deleteBucketByNameStmt = "DELETE FROM buckets WHERE name = $1"
 )
@@ -29,11 +29,12 @@ func NewRepository() (bucket.Repository, error) {
 func convertRowToBucketEntity(bucketRows *sql.Rows) (*bucket.Entity, error) {
 	var id string
 	var name string
+	var versioningStatus *string
 	var websiteIndexDocumentSuffix *string
 	var websiteErrorDocumentKey *string
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := bucketRows.Scan(&id, &name, &websiteIndexDocumentSuffix, &websiteErrorDocumentKey, &createdAt, &updatedAt)
+	err := bucketRows.Scan(&id, &name, &versioningStatus, &websiteIndexDocumentSuffix, &websiteErrorDocumentKey, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -41,6 +42,7 @@ func convertRowToBucketEntity(bucketRows *sql.Rows) (*bucket.Entity, error) {
 	bucketEntity := bucket.Entity{
 		Id:                         &ulidId,
 		Name:                       storage.MustNewBucketName(name),
+		VersioningStatus:           versioningStatus,
 		WebsiteIndexDocumentSuffix: websiteIndexDocumentSuffix,
 		WebsiteErrorDocumentKey:    websiteErrorDocumentKey,
 		CreatedAt:                  createdAt,
@@ -88,11 +90,11 @@ func (br *sqliteRepository) SaveBucket(ctx context.Context, tx *sql.Tx, bucket *
 		bucket.Id = &id
 		bucket.CreatedAt = time.Now().UTC()
 		bucket.UpdatedAt = bucket.CreatedAt
-		_, err := tx.ExecContext(ctx, insertBucketStmt, bucket.Id.String(), bucket.Name.String(), bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.CreatedAt, bucket.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertBucketStmt, bucket.Id.String(), bucket.Name.String(), bucket.VersioningStatus, bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.CreatedAt, bucket.UpdatedAt)
 		return err
 	}
 	bucket.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateBucketByIdStmt, bucket.Name.String(), bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.UpdatedAt, bucket.Id.String())
+	_, err := tx.ExecContext(ctx, updateBucketByIdStmt, bucket.Name.String(), bucket.VersioningStatus, bucket.WebsiteIndexDocumentSuffix, bucket.WebsiteErrorDocumentKey, bucket.UpdatedAt, bucket.Id.String())
 	return err
 }
 

--- a/internal/storage/database/sqlite/repository/object/sqlite.go
+++ b/internal/storage/database/sqlite/repository/object/sqlite.go
@@ -15,19 +15,25 @@ type sqliteRepository struct {
 }
 
 const (
-	insertObjectStmt                                                                             = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)"
-	insertObjectIfAbsentStmt                                                                     = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT DO NOTHING"
-	updateObjectByIdStmt                                                                         = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15"
-	updateObjectByIdAndOptimisticLockVersionStmt                                                 = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, upload_status = $12, upload_id = $13, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $14 WHERE id = $15 AND optimistic_lock_version = $16"
-	containsBucketObjectsByBucketNameStmt                                                        = "SELECT id FROM objects WHERE bucket_name = $1"
-	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                               = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 ORDER BY key ASC"
-	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
-	findObjectByBucketNameAndKeyAndUploadIdStmt                                                  = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
-	findObjectByBucketNameAndKeyStmt                                                             = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3"
-	countObjectsByBucketNameAndPrefixAndStartAfterStmt                                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_status = $4"
-	countObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerStmt                           = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5"
-	deleteObjectByIdStmt                                                                         = "DELETE FROM objects WHERE id = $1"
-	deleteObjectByIdAndOptimisticLockVersionStmt                                                 = "DELETE FROM objects WHERE id = $1 AND optimistic_lock_version = $2"
+	insertObjectStmt                                                                                       = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)"
+	insertObjectIfAbsentStmt                                                                               = "INSERT INTO objects (id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) ON CONFLICT DO NOTHING"
+	updateObjectByIdStmt                                                                                   = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, version_id = $12, is_delete_marker = $13, is_latest = $14, upload_status = $15, upload_id = $16, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $17 WHERE id = $18"
+	updateObjectByIdAndOptimisticLockVersionStmt                                                           = "UPDATE objects SET bucket_name = $1, key = $2, content_type = $3, etag = $4, checksum_crc32 = $5, checksum_crc32c = $6, checksum_crc64nvme = $7, checksum_sha1 = $8, checksum_sha256 = $9, checksum_type = $10, size = $11, version_id = $12, is_delete_marker = $13, is_latest = $14, upload_status = $15, upload_id = $16, optimistic_lock_version = optimistic_lock_version + 1, updated_at = $17 WHERE id = $18 AND optimistic_lock_version = $19"
+	containsBucketObjectsByBucketNameStmt                                                                  = "SELECT id FROM objects WHERE bucket_name = $1"
+	findObjectsByBucketNameAndPrefixAndStartAfterOrderByKeyAscStmt                                         = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_status = $4 AND is_latest = 1 AND is_delete_marker = 0 ORDER BY key ASC"
+	findObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDescStmt = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND upload_status = $3 AND (key > $4 OR (key = $4 AND COALESCE(version_id, '') < $5)) ORDER BY key ASC, created_at DESC"
+	findObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerOrderByKeyAscAndUploadIdAscStmt           = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5 ORDER BY key ASC, upload_id ASC"
+	findObjectByBucketNameAndKeyAndUploadIdStmt                                                            = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_id = $3 AND upload_status = $4"
+	findObjectByBucketNameAndKeyStmt                                                                       = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3 AND is_latest = 1"
+	findObjectByBucketNameAndKeyAndVersionIDStmt                                                           = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND version_id = $3 AND upload_status = $4"
+	findNullObjectVersionByBucketNameAndKeyStmt                                                            = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND version_id = 'null' AND upload_status = $3"
+	findLatestObjectByBucketNameAndKeyExcludingIDStmt                                                      = "SELECT id, bucket_name, key, content_type, etag, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, checksum_type, size, version_id, is_delete_marker, is_latest, upload_status, upload_id, optimistic_lock_version, created_at, updated_at FROM objects WHERE bucket_name = $1 AND key = $2 AND upload_status = $3 AND id != $4 ORDER BY created_at DESC LIMIT 1"
+	countObjectsByBucketNameAndPrefixAndStartAfterStmt                                                     = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_status = $4 AND is_latest = 1 AND is_delete_marker = 0"
+	countObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerStmt                             = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND upload_status = $3 AND (key > $4 OR (key = $4 AND COALESCE(version_id, '') < $5))"
+	countObjectsByBucketNameAndPrefixAndKeyMarkerAndUploadIdMarkerStmt                                     = "SELECT COUNT(*) FROM objects WHERE bucket_name = $1 and key LIKE $2 || '%' AND key > $3 AND upload_id > $4 AND upload_status = $5"
+	clearLatestObjectByBucketNameAndKeyStmt                                                                = "UPDATE objects SET is_latest = 0, updated_at = $3 WHERE bucket_name = $1 AND key = $2 AND upload_status = $4 AND is_latest = 1"
+	deleteObjectByIdStmt                                                                                   = "DELETE FROM objects WHERE id = $1"
+	deleteObjectByIdAndOptimisticLockVersionStmt                                                           = "DELETE FROM objects WHERE id = $1 AND optimistic_lock_version = $2"
 )
 
 func NewRepository() (object.Repository, error) {
@@ -47,12 +53,15 @@ func convertRowToObjectEntity(objectRows *sql.Rows) (*object.Entity, error) {
 	var checksumSHA256 *string
 	var checksumType *string
 	var size int64
+	var versionID *string
+	var isDeleteMarker bool
+	var isLatest bool
 	var uploadStatus string
 	var uploadId *string
 	var optimisticLockVersion int64
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &uploadStatus, &uploadId, &optimisticLockVersion, &createdAt, &updatedAt)
+	err := objectRows.Scan(&id, &bucketName, &key, &contentType, &etag, &checksumCRC32, &checksumCRC32C, &checksumCRC64NVME, &checksumSHA1, &checksumSHA256, &checksumType, &size, &versionID, &isDeleteMarker, &isLatest, &uploadStatus, &uploadId, &optimisticLockVersion, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +79,9 @@ func convertRowToObjectEntity(objectRows *sql.Rows) (*object.Entity, error) {
 		ChecksumSHA256:        checksumSHA256,
 		ChecksumType:          checksumType,
 		Size:                  size,
+		VersionID:             versionID,
+		IsDeleteMarker:        isDeleteMarker,
+		IsLatest:              isLatest,
 		UploadStatus:          uploadStatus,
 		UploadId:              ptrutils.MapPtr(uploadId, storage.MustNewUploadId),
 		OptimisticLockVersion: optimisticLockVersion,
@@ -91,11 +103,11 @@ func (or *sqliteRepository) SaveObject(ctx context.Context, tx *sql.Tx, object *
 		if object.OptimisticLockVersion == 0 {
 			object.OptimisticLockVersion = 1
 		}
-		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertObjectStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 		return err
 	}
 	object.UpdatedAt = time.Now().UTC()
-	res, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
+	res, err := tx.ExecContext(ctx, updateObjectByIdStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String())
 	if err != nil {
 		return err
 	}
@@ -125,7 +137,7 @@ func (or *sqliteRepository) InsertObjectIfAbsent(ctx context.Context, tx *sql.Tx
 	}
 	object.UpdatedAt = object.CreatedAt
 
-	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
+	res, err := tx.ExecContext(ctx, insertObjectIfAbsentStmt, object.Id.String(), object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.OptimisticLockVersion, object.CreatedAt, object.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +155,7 @@ func (or *sqliteRepository) UpdateObjectByIdAndOptimisticLockVersion(ctx context
 		return uploadId.String()
 	}
 	object.UpdatedAt = time.Now().UTC()
-	res, err := tx.ExecContext(ctx, updateObjectByIdAndOptimisticLockVersionStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String(), optimisticLockVersion)
+	res, err := tx.ExecContext(ctx, updateObjectByIdAndOptimisticLockVersionStmt, object.BucketName.String(), object.Key.String(), object.ContentType, object.ETag, object.ChecksumCRC32, object.ChecksumCRC32C, object.ChecksumCRC64NVME, object.ChecksumSHA1, object.ChecksumSHA256, object.ChecksumType, object.Size, object.VersionID, object.IsDeleteMarker, object.IsLatest, object.UploadStatus, ptrutils.MapPtr(object.UploadId, mapUploadIdToString), object.UpdatedAt, object.Id.String(), optimisticLockVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -202,6 +214,23 @@ func (or *sqliteRepository) FindUploadsByBucketNameAndPrefixAndKeyMarkerAndUploa
 	return objects, nil
 }
 
+func (or *sqliteRepository) FindObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDesc(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, versionIDMarker string) ([]object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDescStmt, bucketName.String(), prefix, object.UploadStatusCompleted, keyMarker, versionIDMarker)
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	objects := []object.Entity{}
+	for objectRows.Next() {
+		objectEntity, err := convertRowToObjectEntity(objectRows)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, *objectEntity)
+	}
+	return objects, nil
+}
+
 func (or *sqliteRepository) FindObjectByBucketNameAndKeyAndUploadId(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) (*object.Entity, error) {
 	objectRows, err := tx.QueryContext(ctx, findObjectByBucketNameAndKeyAndUploadIdStmt, bucketName.String(), key.String(), uploadId.String(), object.UploadStatusPending)
 	if err != nil {
@@ -236,6 +265,42 @@ func (or *sqliteRepository) FindObjectByBucketNameAndKey(ctx context.Context, tx
 	return nil, nil
 }
 
+func (or *sqliteRepository) FindObjectByBucketNameAndKeyAndVersionID(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, versionID string) (*object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findObjectByBucketNameAndKeyAndVersionIDStmt, bucketName.String(), key.String(), versionID, object.UploadStatusCompleted)
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	if objectRows.Next() {
+		return convertRowToObjectEntity(objectRows)
+	}
+	return nil, nil
+}
+
+func (or *sqliteRepository) FindNullObjectVersionByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) (*object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findNullObjectVersionByBucketNameAndKeyStmt, bucketName.String(), key.String(), object.UploadStatusCompleted)
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	if objectRows.Next() {
+		return convertRowToObjectEntity(objectRows)
+	}
+	return nil, nil
+}
+
+func (or *sqliteRepository) FindLatestObjectByBucketNameAndKeyExcludingID(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey, excludedObjectID ulid.ULID) (*object.Entity, error) {
+	objectRows, err := tx.QueryContext(ctx, findLatestObjectByBucketNameAndKeyExcludingIDStmt, bucketName.String(), key.String(), object.UploadStatusCompleted, excludedObjectID.String())
+	if err != nil {
+		return nil, err
+	}
+	defer objectRows.Close()
+	if objectRows.Next() {
+		return convertRowToObjectEntity(objectRows)
+	}
+	return nil, nil
+}
+
 func (or *sqliteRepository) CountObjectsByBucketNameAndPrefixAndStartAfter(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, startAfter string) (*int, error) {
 	keyCountRow := tx.QueryRowContext(ctx, countObjectsByBucketNameAndPrefixAndStartAfterStmt, bucketName.String(), prefix, startAfter, object.UploadStatusCompleted)
 	var keyCount int
@@ -254,6 +319,21 @@ func (or *sqliteRepository) CountUploadsByBucketNameAndPrefixAndKeyMarkerAndUplo
 		return nil, err
 	}
 	return &keyCount, nil
+}
+
+func (or *sqliteRepository) CountObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarker(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, prefix string, keyMarker string, versionIDMarker string) (*int, error) {
+	keyCountRow := tx.QueryRowContext(ctx, countObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerStmt, bucketName.String(), prefix, object.UploadStatusCompleted, keyMarker, versionIDMarker)
+	var keyCount int
+	err := keyCountRow.Scan(&keyCount)
+	if err != nil {
+		return nil, err
+	}
+	return &keyCount, nil
+}
+
+func (or *sqliteRepository) ClearLatestObjectByBucketNameAndKey(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key storage.ObjectKey) error {
+	_, err := tx.ExecContext(ctx, clearLatestObjectByBucketNameAndKeyStmt, bucketName.String(), key.String(), time.Now().UTC(), object.UploadStatusCompleted)
+	return err
 }
 
 func (or *sqliteRepository) DeleteObjectById(ctx context.Context, tx *sql.Tx, objectId ulid.ULID) (*bool, error) {

--- a/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
@@ -15,13 +15,13 @@ type sqliteRepository struct {
 
 const (
 	countStorageOutboxEntriesStmt            = "SELECT COUNT(*) FROM storage_outbox_entries"
-	findFirstStorageOutboxEntryStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryStmt           = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
-	findFirstStorageOutboxEntryForBucketStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryForBucketStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryStmt          = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryStmt           = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketStmt = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketStmt  = "SELECT id, operation, bucket, key, version_id, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
 	findStorageOutboxEntryChunksByIdStmt     = "SELECT outbox_entry_id, chunk_index, content FROM storage_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
-	insertStorageOutboxEntryStmt             = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
-	updateStorageOutboxEntryByIdStmt         = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6"
+	insertStorageOutboxEntryStmt             = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, version_id, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8)"
+	updateStorageOutboxEntryByIdStmt         = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, version_id = $4, content_type = $5, updated_at = $6 WHERE id = $7"
 	upsertStorageOutboxContentChunkStmt      = "INSERT OR REPLACE INTO storage_outbox_contents (outbox_entry_id, chunk_index, content) VALUES($1, $2, $3)"
 	deleteStorageOutboxEntryByIdStmt         = "DELETE FROM storage_outbox_entries WHERE id = $1"
 )
@@ -44,10 +44,11 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 	var operation string
 	var bucket string
 	var key string
+	var versionID *string
 	var contentType *string
 	var createdAt time.Time
 	var updatedAt time.Time
-	err := storageOutboxRow.Scan(&id, &operation, &bucket, &key, &contentType, &createdAt, &updatedAt)
+	err := storageOutboxRow.Scan(&id, &operation, &bucket, &key, &versionID, &contentType, &createdAt, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -60,6 +61,7 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 		Operation:   operation,
 		Bucket:      storage.MustNewBucketName(bucket),
 		Key:         key,
+		VersionID:   versionID,
 		ContentType: contentType,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
@@ -137,12 +139,12 @@ func (sor *sqliteRepository) SaveStorageOutboxEntry(ctx context.Context, tx *sql
 		storageOutboxEntry.Id = &id
 		storageOutboxEntry.CreatedAt = time.Now().UTC()
 		storageOutboxEntry.UpdatedAt = storageOutboxEntry.CreatedAt
-		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.VersionID, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
 		return err
 	}
 
 	storageOutboxEntry.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String())
+	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.VersionID, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String())
 	return err
 }
 

--- a/internal/storage/database/sqlite/sqlite.go
+++ b/internal/storage/database/sqlite/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
@@ -19,6 +20,8 @@ import (
 
 //go:embed migrations/*.sql
 var migrationsFilesystem embed.FS
+
+var openDatabaseMu sync.Mutex
 
 // In auto-vacuum full mode freelist pages are moved to the end of the file
 // end the file is truncated
@@ -125,6 +128,9 @@ func (sdb *sqliteDatabase) GetDatabaseType() database.DatabaseType {
 }
 
 func OpenDatabase(dbPath string) (*sqliteDatabase, error) {
+	openDatabaseMu.Lock()
+	defer openDatabaseMu.Unlock()
+
 	storagePath := filepath.Dir(dbPath)
 	err := os.MkdirAll(storagePath, os.ModePerm)
 	if err != nil {

--- a/internal/storage/integrity/validator.go
+++ b/internal/storage/integrity/validator.go
@@ -111,7 +111,7 @@ func (v *Validator) ValidateAll(ctx context.Context) (*ValidationReport, error) 
 				report.FailedObjects++
 				if v.deleteCorrupted {
 					if v.confirmDeletion(result) {
-						err := v.storage.DeleteObject(ctx, bucket.Name, object.Key, nil)
+						_, err := v.storage.DeleteObject(ctx, bucket.Name, object.Key, nil)
 						if err != nil {
 							result.ActionTaken = fmt.Sprintf("Failed to delete: %v", err)
 						} else {

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -268,11 +268,62 @@ func (mbs *metadataPartStorage) DeleteBucketWebsiteConfiguration(ctx context.Con
 	return nil
 }
 
+func (mbs *metadataPartStorage) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.GetBucketVersioningConfiguration")
+	defer span.End()
+
+	tx, err := mbs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := mbs.metadataStore.GetBucketVersioningConfiguration(ctx, tx, bucketName)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	if config.Status == nil {
+		return &storage.BucketVersioningConfiguration{}, nil
+	}
+	status := storage.BucketVersioningStatus(*config.Status)
+	return &storage.BucketVersioningConfiguration{Status: &status}, nil
+}
+
+func (mbs *metadataPartStorage) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.PutBucketVersioningConfiguration")
+	defer span.End()
+
+	tx, err := mbs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return err
+	}
+
+	metaConfig := &metadatastore.BucketVersioningConfiguration{}
+	if config != nil && config.Status != nil {
+		status := metadatastore.BucketVersioningStatus(*config.Status)
+		metaConfig.Status = &status
+	}
+
+	err = mbs.metadataStore.PutBucketVersioningConfiguration(ctx, tx, bucketName, metaConfig)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
 func convertObject(mObject metadatastore.Object) storage.Object {
 	return storage.Object{
 		Key:               mObject.Key,
 		ContentType:       mObject.ContentType,
 		LastModified:      mObject.LastModified,
+		VersionID:         mObject.VersionID,
+		IsDeleteMarker:    mObject.IsDeleteMarker,
 		ETag:              mObject.ETag,
 		ChecksumCRC32:     mObject.ChecksumCRC32,
 		ChecksumCRC32C:    mObject.ChecksumCRC32C,
@@ -322,6 +373,43 @@ func (mbs *metadataPartStorage) ListObjects(ctx context.Context, bucketName stor
 	return &listBucketResult, nil
 }
 
+func (mbs *metadataPartStorage) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.ListObjectVersions")
+	defer span.End()
+
+	tx, err := mbs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+
+	metaResult, err := mbs.metadataStore.ListObjectVersions(ctx, tx, bucketName, metadatastore.ListObjectVersionsOptions{
+		Prefix:          opts.Prefix,
+		Delimiter:       opts.Delimiter,
+		KeyMarker:       opts.KeyMarker,
+		VersionIDMarker: opts.VersionIDMarker,
+		MaxKeys:         opts.MaxKeys,
+	})
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	versions := sliceutils.Map(func(v metadatastore.ObjectVersion) storage.ObjectVersion {
+		return storage.ObjectVersion{Key: v.Key, VersionID: v.VersionID, IsDeleteMarker: v.IsDeleteMarker, IsLatest: v.IsLatest, LastModified: v.LastModified, Size: v.Size, ETag: v.ETag}
+	}, metaResult.Versions)
+
+	return &storage.ListObjectVersionsResult{
+		Versions:            versions,
+		CommonPrefixes:      metaResult.CommonPrefixes,
+		IsTruncated:         metaResult.IsTruncated,
+		NextKeyMarker:       metaResult.NextKeyMarker,
+		NextVersionIDMarker: metaResult.NextVersionIDMarker,
+	}, nil
+}
+
 func (mbs *metadataPartStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.HeadObject")
 	defer span.End()
@@ -331,10 +419,27 @@ func (mbs *metadataPartStorage) HeadObject(ctx context.Context, bucketName stora
 		return nil, err
 	}
 
-	mObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	var mObject *metadatastore.Object
+	if opts != nil && opts.VersionID != nil {
+		mObject, err = mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, key, *opts.VersionID)
+	} else {
+		mObject, err = mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	}
 	if err != nil {
 		tx.Rollback()
 		return nil, err
+	}
+
+	if mObject.IsDeleteMarker {
+		tx.Rollback()
+		versionID := ""
+		if mObject.VersionID != nil {
+			versionID = *mObject.VersionID
+		}
+		if opts != nil && opts.VersionID != nil {
+			return nil, &storage.VersionDeleteMarkerMethodNotAllowedError{VersionID: versionID, LastModified: mObject.LastModified}
+		}
+		return nil, &storage.CurrentDeleteMarkerError{VersionID: versionID}
 	}
 
 	if opts != nil {
@@ -467,9 +572,25 @@ func (mbs *metadataPartStorage) GetObject(ctx context.Context, bucketName storag
 	}
 	defer tx.Rollback() // Safe to call multiple times
 
-	object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	var object *metadatastore.Object
+	if opts != nil && opts.VersionID != nil {
+		object, err = mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, key, *opts.VersionID)
+	} else {
+		object, err = mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	}
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if object.IsDeleteMarker {
+		versionID := ""
+		if object.VersionID != nil {
+			versionID = *object.VersionID
+		}
+		if opts != nil && opts.VersionID != nil {
+			return nil, nil, &storage.VersionDeleteMarkerMethodNotAllowedError{VersionID: versionID, LastModified: object.LastModified}
+		}
+		return nil, nil, &storage.CurrentDeleteMarkerError{VersionID: versionID}
 	}
 
 	if opts != nil {
@@ -533,19 +654,28 @@ func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storag
 	ifNoneMatchStar := opts != nil && opts.IfNoneMatchStar
 
 	if !ifNoneMatchStar {
-		// if we already have such an object,
-		// remove all previous parts
-		previousObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
-		if err != nil && err != storage.ErrNoSuchKey {
+		versioningConfig, err := mbs.metadataStore.GetBucketVersioningConfiguration(ctx, tx, bucketName)
+		if err != nil {
 			tx.Rollback()
 			return nil, err
 		}
-		if previousObject != nil {
-			for _, part := range previousObject.Parts {
-				err = mbs.partStore.DeletePart(ctx, tx, part.Id)
-				if err != nil {
-					tx.Rollback()
-					return nil, err
+		versioningEnabled := versioningConfig.Status != nil && *versioningConfig.Status == metadatastore.BucketVersioningStatusEnabled
+
+		if !versioningEnabled {
+			// In unversioned/suspended mode, writes overwrite the null version.
+			// Remove its part content before metadata replacement.
+			previousObject, err := mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, key, "null")
+			if err != nil && err != storage.ErrNoSuchKey {
+				tx.Rollback()
+				return nil, err
+			}
+			if previousObject != nil {
+				for _, part := range previousObject.Parts {
+					err = mbs.partStore.DeletePart(ctx, tx, part.Id)
+					if err != nil {
+						tx.Rollback()
+						return nil, err
+					}
 				}
 			}
 		}
@@ -613,6 +743,7 @@ func (mbs *metadataPartStorage) PutObject(ctx context.Context, bucketName storag
 	}
 
 	return &storage.PutObjectResult{
+		VersionID:         object.VersionID,
 		ETag:              &object.ETag,
 		ChecksumCRC32:     object.ChecksumCRC32,
 		ChecksumCRC32C:    object.ChecksumCRC32C,
@@ -761,7 +892,7 @@ func (mbs *metadataPartStorage) AppendObject(ctx context.Context, bucketName sto
 	}, nil
 }
 
-func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := mbs.tracer.Start(ctx, "MetadataPartStorage.DeleteObject")
 	defer span.End()
 
@@ -769,51 +900,89 @@ func (mbs *metadataPartStorage) DeleteObject(ctx context.Context, bucketName sto
 	defer unblockGC()
 	tx, err := mbs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	versioningConfig, err := mbs.metadataStore.GetBucketVersioningConfiguration(ctx, tx, bucketName)
 	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	versioningEnabled := versioningConfig.Status != nil && *versioningConfig.Status == metadatastore.BucketVersioningStatusEnabled
+	versioningSuspended := versioningConfig.Status != nil && *versioningConfig.Status == metadatastore.BucketVersioningStatusSuspended
+
+	object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	if opts != nil && opts.VersionID != nil {
+		object, err = mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, key, *opts.VersionID)
+	} else if versioningSuspended {
+		object, err = mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, key, "null")
+	}
+	if err != nil {
+		if err == storage.ErrNoSuchKey {
+			if opts == nil || opts.VersionID == nil {
+				if versioningEnabled {
+					object = nil
+					err = nil
+				} else if versioningSuspended {
+					// Suspended mode may have no null version; still create a delete marker.
+					object = nil
+					err = nil
+				}
+			}
+		}
 		if err == storage.ErrNoSuchKey {
 			tx.Rollback()
 			// Object does not exist.
 			if opts != nil && opts.IfMatchETag != nil {
 				// Conditional delete: object must exist.
-				return storage.ErrPreconditionFailed
+				return nil, storage.ErrPreconditionFailed
 			}
 			// No condition: silently succeed per S3 semantics.
-			return nil
+			return &storage.DeleteObjectResult{}, nil
 		}
 		tx.Rollback()
-		return err
+		return nil, err
 	}
 
-	for _, part := range object.Parts {
-		err = mbs.partStore.DeletePart(ctx, tx, part.Id)
-		if err != nil {
-			tx.Rollback()
-			return err
+	shouldDeleteParts := opts != nil && opts.VersionID != nil
+	if opts == nil || opts.VersionID == nil {
+		if versioningSuspended {
+			shouldDeleteParts = true // null version hard-delete on suspended key-only delete
+		} else if !versioningEnabled {
+			shouldDeleteParts = true // unversioned hard delete
+		}
+	}
+
+	if shouldDeleteParts && object != nil && !object.IsDeleteMarker {
+		for _, part := range object.Parts {
+			err = mbs.partStore.DeletePart(ctx, tx, part.Id)
+			if err != nil {
+				tx.Rollback()
+				return nil, err
+			}
 		}
 	}
 
 	var metaOpts *metadatastore.DeleteObjectOptions
 	if opts != nil {
 		metaOpts = &metadatastore.DeleteObjectOptions{
+			VersionID:   opts.VersionID,
 			IfMatchETag: opts.IfMatchETag,
 		}
 	}
-	err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, key, metaOpts)
+	metaResult, err := mbs.metadataStore.DeleteObject(ctx, tx, bucketName, key, metaOpts)
 	if err != nil {
 		tx.Rollback()
-		return err
+		return nil, err
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &storage.DeleteObjectResult{VersionID: metaResult.VersionID, IsDeleteMarker: metaResult.IsDeleteMarker}, nil
 }
 
 func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
@@ -831,8 +1000,21 @@ func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName st
 		Entries: make([]storage.DeleteObjectsEntry, 0, len(entries)),
 	}
 
+	versioningConfig, err := mbs.metadataStore.GetBucketVersioningConfiguration(ctx, tx, bucketName)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	versioningEnabled := versioningConfig.Status != nil && *versioningConfig.Status == metadatastore.BucketVersioningStatusEnabled
+	versioningSuspended := versioningConfig.Status != nil && *versioningConfig.Status == metadatastore.BucketVersioningStatusSuspended
+
 	for _, entry := range entries {
 		object, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, entry.Key)
+		if entry.VersionID != nil {
+			object, err = mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, entry.Key, *entry.VersionID)
+		} else if versioningSuspended {
+			object, err = mbs.metadataStore.HeadObjectVersion(ctx, tx, bucketName, entry.Key, "null")
+		}
 		if err != nil {
 			if err == storage.ErrNoSuchKey {
 				if entry.IfMatchETag != nil {
@@ -843,13 +1025,16 @@ func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName st
 						ErrCode: "PreconditionFailed",
 						ErrMsg:  "At least one of the pre-conditions you specified did not hold",
 					})
-				} else {
+				} else if !(entry.VersionID == nil && (versioningEnabled || versioningSuspended)) {
 					result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: entry.Key, Deleted: true})
+					continue
 				}
-				continue
+				object = nil
+				err = nil
+			} else {
+				tx.Rollback()
+				return nil, err
 			}
-			tx.Rollback()
-			return nil, err
 		}
 
 		// Object exists — check conditional ETag if specified.
@@ -863,7 +1048,16 @@ func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName st
 			continue
 		}
 
-		if object != nil {
+		shouldDeleteParts := entry.VersionID != nil
+		if entry.VersionID == nil {
+			if versioningSuspended {
+				shouldDeleteParts = true
+			} else if !versioningEnabled {
+				shouldDeleteParts = true
+			}
+		}
+
+		if shouldDeleteParts && object != nil && !object.IsDeleteMarker {
 			for _, part := range object.Parts {
 				err = mbs.partStore.DeletePart(ctx, tx, part.Id)
 				if err != nil {
@@ -874,16 +1068,16 @@ func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName st
 		}
 
 		var metaOpts *metadatastore.DeleteObjectOptions
-		if entry.IfMatchETag != nil {
-			metaOpts = &metadatastore.DeleteObjectOptions{IfMatchETag: entry.IfMatchETag}
+		if entry.IfMatchETag != nil || entry.VersionID != nil {
+			metaOpts = &metadatastore.DeleteObjectOptions{VersionID: entry.VersionID, IfMatchETag: entry.IfMatchETag}
 		}
-		err = mbs.metadataStore.DeleteObject(ctx, tx, bucketName, entry.Key, metaOpts)
+		metaResult, err := mbs.metadataStore.DeleteObject(ctx, tx, bucketName, entry.Key, metaOpts)
 		if err != nil {
 			tx.Rollback()
 			return nil, err
 		}
 
-		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: entry.Key, Deleted: true})
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: entry.Key, VersionID: metaResult.VersionID, DeleteMarker: &metaResult.IsDeleteMarker, Deleted: true})
 	}
 
 	err = tx.Commit()

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -1180,6 +1180,7 @@ func (mbs *metadataPartStorage) UploadPart(ctx context.Context, bucketName stora
 func convertCompleteMultipartUploadResult(result metadatastore.CompleteMultipartUploadResult) storage.CompleteMultipartUploadResult {
 	return storage.CompleteMultipartUploadResult{
 		Location:          result.Location,
+		VersionID:         result.VersionID,
 		ETag:              result.ETag,
 		ChecksumCRC32:     result.ChecksumCRC32,
 		ChecksumCRC32C:    result.ChecksumCRC32C,

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -1127,7 +1127,13 @@ func (mbs *metadataPartStorage) DeleteObjects(ctx context.Context, bucketName st
 			return nil, err
 		}
 
-		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: entry.Key, VersionID: metaResult.VersionID, DeleteMarker: &metaResult.IsDeleteMarker, Deleted: true})
+		resultEntry := storage.DeleteObjectsEntry{Key: entry.Key, DeleteMarker: &metaResult.IsDeleteMarker, Deleted: true}
+		if metaResult.IsDeleteMarker && entry.VersionID == nil {
+			resultEntry.DeleteMarkerVersionID = metaResult.VersionID
+		} else {
+			resultEntry.VersionID = metaResult.VersionID
+		}
+		result.Entries = append(result.Entries, resultEntry)
 	}
 
 	err = tx.Commit()

--- a/internal/storage/metadatapart/metadatapart.go
+++ b/internal/storage/metadatapart/metadatapart.go
@@ -3,6 +3,7 @@ package metadatapart
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"log/slog"
 	"time"
@@ -764,11 +765,22 @@ func (mbs *metadataPartStorage) AppendObject(ctx context.Context, bucketName sto
 		return nil, err
 	}
 
-	// Fetch the existing object (if any).
-	existingObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
-	if err != nil && err != storage.ErrNoSuchKey {
+	versioningConfig, err := mbs.metadataStore.GetBucketVersioningConfiguration(ctx, tx, bucketName)
+	if err != nil {
 		tx.Rollback()
 		return nil, err
+	}
+	versioningEnabled := versioningConfig.Status != nil && *versioningConfig.Status == metadatastore.BucketVersioningStatusEnabled
+
+	// Fetch the existing object (if any).
+	existingObject, err := mbs.metadataStore.HeadObject(ctx, tx, bucketName, key)
+	var currentDeleteMarkerErr *storage.CurrentDeleteMarkerError
+	if err != nil && !errors.As(err, &currentDeleteMarkerErr) && err != storage.ErrNoSuchKey {
+		tx.Rollback()
+		return nil, err
+	}
+	if currentDeleteMarkerErr != nil {
+		existingObject = nil
 	}
 
 	// Validate WriteOffset condition.
@@ -824,15 +836,53 @@ func (mbs *metadataPartStorage) AppendObject(ctx context.Context, bucketName sto
 	var allParts []metadatastore.Part
 	var totalSize int64
 	if existingObject != nil {
-		allParts = append(allParts, existingObject.Parts...)
 		totalSize = existingObject.Size
 	}
 
 	// S3 enforces a maximum of 10,000 parts per object.
 	const maxAppendParts = 10_000
-	if len(allParts)+1 > maxAppendParts {
+	existingPartCount := 0
+	if existingObject != nil {
+		existingPartCount = len(existingObject.Parts)
+	}
+	if existingPartCount+1 > maxAppendParts {
 		tx.Rollback()
 		return nil, storage.ErrTooManyParts
+	}
+
+	if existingObject != nil {
+		if versioningEnabled {
+			// Versioned append creates a new object version, so existing parts need
+			// fresh IDs instead of being reused in the new version metadata.
+			allParts = make([]metadatastore.Part, 0, len(existingObject.Parts)+1)
+			for _, existingPart := range existingObject.Parts {
+				existingPartReader, partErr := mbs.partStore.GetPart(ctx, tx, existingPart.Id)
+				if partErr != nil {
+					tx.Rollback()
+					return nil, partErr
+				}
+
+				newExistingPartID, partErr := partstore.NewRandomPartId()
+				if partErr != nil {
+					existingPartReader.Close()
+					tx.Rollback()
+					return nil, partErr
+				}
+
+				partErr = mbs.partStore.PutPart(ctx, tx, *newExistingPartID, existingPartReader)
+				existingPartReader.Close()
+				if partErr != nil {
+					tx.Rollback()
+					return nil, partErr
+				}
+
+				clonedPart := existingPart
+				clonedPart.Id = *newExistingPartID
+				allParts = append(allParts, clonedPart)
+			}
+		} else {
+			allParts = append(allParts, existingObject.Parts...)
+		}
 	}
 
 	allParts = append(allParts, newPart)

--- a/internal/storage/metadatapart/metadatapart_test.go
+++ b/internal/storage/metadatapart/metadatapart_test.go
@@ -209,7 +209,7 @@ func TestConditionalDeleteObject_MatchingETag(t *testing.T) {
 	etag := *result.ETag
 
 	// Delete with correct ETag — should succeed.
-	err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(etag)})
+	_, err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(etag)})
 	require.NoError(t, err)
 
 	// Object should be gone.
@@ -231,7 +231,7 @@ func TestConditionalDeleteObject_WrongETag(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete with wrong ETag — should return PreconditionFailed.
-	err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr("wrong-etag")})
+	_, err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr("wrong-etag")})
 	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
 
 	// Object should still exist.
@@ -250,7 +250,7 @@ func TestConditionalDeleteObject_NoObjectWithCondition(t *testing.T) {
 	require.NoError(t, st.CreateBucket(ctx, bucket))
 
 	// Delete non-existent object with ETag condition — should return PreconditionFailed.
-	err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr("any-etag")})
+	_, err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr("any-etag")})
 	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
 }
 
@@ -265,7 +265,7 @@ func TestConditionalDeleteObject_NoObjectNoCondition(t *testing.T) {
 	require.NoError(t, st.CreateBucket(ctx, bucket))
 
 	// Delete non-existent object without condition — should silently succeed (S3 semantics).
-	err := st.DeleteObject(ctx, bucket, key, nil)
+	_, err := st.DeleteObject(ctx, bucket, key, nil)
 	require.NoError(t, err)
 }
 
@@ -335,7 +335,7 @@ func TestConditionalDeleteObject_WildcardMatchExistingObject(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete with If-Match: * on an existing object — should succeed.
-	err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
+	_, err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
 	require.NoError(t, err)
 
 	// Object should be gone.
@@ -354,7 +354,7 @@ func TestConditionalDeleteObject_WildcardMatchMissingObject(t *testing.T) {
 	require.NoError(t, st.CreateBucket(ctx, bucket))
 
 	// Delete with If-Match: * on a non-existent object — should return PreconditionFailed.
-	err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
+	_, err := st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{IfMatchETag: ptrutils.ToPtr(storage.ETagWildcard)})
 	assert.ErrorIs(t, err, storage.ErrPreconditionFailed)
 }
 

--- a/internal/storage/metadatapart/metadatapart_test.go
+++ b/internal/storage/metadatapart/metadatapart_test.go
@@ -194,6 +194,45 @@ func newTestStorage(t *testing.T) (*metadataPartStorage, func()) {
 	return mps, cleanup
 }
 
+func readObjectContent(t *testing.T, st *metadataPartStorage, bucket storage.BucketName, key storage.ObjectKey, versionID *string) string {
+	t.Helper()
+
+	var opts *storage.GetObjectOptions
+	if versionID != nil {
+		opts = &storage.GetObjectOptions{VersionID: versionID}
+	}
+
+	_, readers, err := st.GetObject(context.Background(), bucket, key, nil, opts)
+	require.NoError(t, err)
+	require.Len(t, readers, 1)
+	defer readers[0].Close()
+
+	content, err := io.ReadAll(readers[0])
+	require.NoError(t, err)
+	return string(content)
+}
+
+func versionIDsForKey(t *testing.T, st *metadataPartStorage, bucket storage.BucketName, key storage.ObjectKey) (latestVersionID string, olderVersionIDs []string) {
+	t.Helper()
+
+	versions, err := st.ListObjectVersions(context.Background(), bucket, storage.ListObjectVersionsOptions{MaxKeys: 1000})
+	require.NoError(t, err)
+
+	for _, version := range versions.Versions {
+		if !version.Key.Equals(key) || version.IsDeleteMarker {
+			continue
+		}
+		if version.IsLatest {
+			latestVersionID = version.VersionID
+			continue
+		}
+		olderVersionIDs = append(olderVersionIDs, version.VersionID)
+	}
+
+	require.NotEmpty(t, latestVersionID)
+	return latestVersionID, olderVersionIDs
+}
+
 func TestConditionalDeleteObject_MatchingETag(t *testing.T) {
 	testutils.SkipIfIntegration(t)
 	ctx := context.Background()
@@ -503,6 +542,154 @@ func TestAppendObject_WriteOffsetNonZeroOnMissing(t *testing.T) {
 	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil,
 		&storage.AppendObjectOptions{WriteOffset: &nonZero})
 	assert.ErrorIs(t, err, storage.ErrInvalidWriteOffset)
+}
+
+func TestAppendObject_CreatesNewVersionWhenVersioningEnabled(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	status := storage.BucketVersioningStatusEnabled
+	require.NoError(t, st.PutBucketVersioningConfiguration(ctx, bucket, &storage.BucketVersioningConfiguration{Status: &status}))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	result, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(11), result.Size)
+
+	latestVersionID, olderVersionIDs := versionIDsForKey(t, st, bucket, key)
+	require.Len(t, olderVersionIDs, 1)
+	assert.NotEqual(t, "null", latestVersionID)
+	assert.NotEqual(t, "null", olderVersionIDs[0])
+	assert.NotEqual(t, latestVersionID, olderVersionIDs[0])
+
+	assert.Equal(t, "hello world", readObjectContent(t, st, bucket, key, nil))
+	assert.Equal(t, "hello world", readObjectContent(t, st, bucket, key, &latestVersionID))
+	assert.Equal(t, "hello", readObjectContent(t, st, bucket, key, &olderVersionIDs[0]))
+}
+
+func TestAppendObject_CreatesNewVersionAfterDeleteMarkerWhenVersioningEnabled(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	status := storage.BucketVersioningStatusEnabled
+	require.NoError(t, st.PutBucketVersioningConfiguration(ctx, bucket, &storage.BucketVersioningConfiguration{Status: &status}))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+	_, err = st.DeleteObject(ctx, bucket, key, nil)
+	require.NoError(t, err)
+	_, err = st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("world")), nil, nil)
+	require.NoError(t, err)
+
+	latestVersionID, olderVersionIDs := versionIDsForKey(t, st, bucket, key)
+	require.Len(t, olderVersionIDs, 1)
+	assert.NotEqual(t, latestVersionID, olderVersionIDs[0])
+	assert.Equal(t, "world", readObjectContent(t, st, bucket, key, nil))
+	assert.Equal(t, "world", readObjectContent(t, st, bucket, key, &latestVersionID))
+	assert.Equal(t, "hello", readObjectContent(t, st, bucket, key, &olderVersionIDs[0]))
+}
+
+func TestAppendObject_DeleteObjectVersionPreservesOlderVersion(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	status := storage.BucketVersioningStatusEnabled
+	require.NoError(t, st.PutBucketVersioningConfiguration(ctx, bucket, &storage.BucketVersioningConfiguration{Status: &status}))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+	_, err = st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil, nil)
+	require.NoError(t, err)
+
+	latestVersionID, olderVersionIDs := versionIDsForKey(t, st, bucket, key)
+	require.Len(t, olderVersionIDs, 1)
+
+	_, err = st.DeleteObject(ctx, bucket, key, &storage.DeleteObjectOptions{VersionID: &latestVersionID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", readObjectContent(t, st, bucket, key, nil))
+	assert.Equal(t, "hello", readObjectContent(t, st, bucket, key, &olderVersionIDs[0]))
+
+	_, err = st.HeadObject(ctx, bucket, key, &storage.HeadObjectOptions{VersionID: &latestVersionID})
+	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
+}
+
+func TestAppendObject_DeleteObjectsVersionPreservesOlderVersion(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	status := storage.BucketVersioningStatusEnabled
+	require.NoError(t, st.PutBucketVersioningConfiguration(ctx, bucket, &storage.BucketVersioningConfiguration{Status: &status}))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+	_, err = st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil, nil)
+	require.NoError(t, err)
+
+	latestVersionID, olderVersionIDs := versionIDsForKey(t, st, bucket, key)
+	require.Len(t, olderVersionIDs, 1)
+
+	deleteResult, err := st.DeleteObjects(ctx, bucket, []storage.DeleteObjectsInputEntry{{Key: key, VersionID: &latestVersionID}})
+	require.NoError(t, err)
+	require.Len(t, deleteResult.Entries, 1)
+	assert.True(t, deleteResult.Entries[0].Deleted)
+
+	assert.Equal(t, "hello", readObjectContent(t, st, bucket, key, nil))
+	assert.Equal(t, "hello", readObjectContent(t, st, bucket, key, &olderVersionIDs[0]))
+
+	_, err = st.HeadObject(ctx, bucket, key, &storage.HeadObjectOptions{VersionID: &latestVersionID})
+	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
+}
+
+func TestAppendObject_SuspendedBucketReusesNullVersion(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	status := storage.BucketVersioningStatusSuspended
+	require.NoError(t, st.PutBucketVersioningConfiguration(ctx, bucket, &storage.BucketVersioningConfiguration{Status: &status}))
+
+	_, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+	result, err := st.AppendObject(ctx, bucket, key, bytes.NewReader([]byte(" world")), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(11), result.Size)
+
+	latestVersionID, olderVersionIDs := versionIDsForKey(t, st, bucket, key)
+	assert.Equal(t, "null", latestVersionID)
+	assert.Empty(t, olderVersionIDs)
+	assert.Equal(t, "hello world", readObjectContent(t, st, bucket, key, nil))
 }
 
 func TestAppendObject_NoSuchBucket(t *testing.T) {

--- a/internal/storage/metadatapart/metadatapart_test.go
+++ b/internal/storage/metadatapart/metadatapart_test.go
@@ -360,6 +360,41 @@ func TestConditionalDeleteObjects_MixedConditions(t *testing.T) {
 	assert.ErrorIs(t, err, storage.ErrNoSuchKey)
 }
 
+func TestDeleteObjects_KeyOnlyDeleteReturnsDeleteMarkerVersionID(t *testing.T) {
+	testutils.SkipIfIntegration(t)
+	ctx := context.Background()
+	st, cleanup := newTestStorage(t)
+	defer cleanup()
+
+	bucket := storage.MustNewBucketName("bucket")
+	key := storage.MustNewObjectKey("obj")
+	require.NoError(t, st.CreateBucket(ctx, bucket))
+
+	status := storage.BucketVersioningStatusEnabled
+	require.NoError(t, st.PutBucketVersioningConfiguration(ctx, bucket, &storage.BucketVersioningConfiguration{Status: &status}))
+
+	_, err := st.PutObject(ctx, bucket, key, nil, bytes.NewReader([]byte("hello")), nil, nil)
+	require.NoError(t, err)
+
+	deleteResult, err := st.DeleteObjects(ctx, bucket, []storage.DeleteObjectsInputEntry{{Key: key}})
+	require.NoError(t, err)
+	require.Len(t, deleteResult.Entries, 1)
+
+	entry := deleteResult.Entries[0]
+	assert.True(t, entry.Deleted)
+	require.NotNil(t, entry.DeleteMarker)
+	assert.True(t, *entry.DeleteMarker)
+	assert.Nil(t, entry.VersionID)
+	require.NotNil(t, entry.DeleteMarkerVersionID)
+	assert.NotEmpty(t, *entry.DeleteMarkerVersionID)
+
+	_, err = st.HeadObject(ctx, bucket, key, nil)
+	var currentDeleteMarkerErr *storage.CurrentDeleteMarkerError
+	assert.ErrorAs(t, err, &currentDeleteMarkerErr)
+	require.NotNil(t, currentDeleteMarkerErr)
+	assert.Equal(t, *entry.DeleteMarkerVersionID, currentDeleteMarkerErr.VersionID)
+}
+
 func TestConditionalDeleteObject_WildcardMatchExistingObject(t *testing.T) {
 	testutils.SkipIfIntegration(t)
 	ctx := context.Background()

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -70,6 +70,7 @@ type InitiateMultipartUploadResult struct {
 type CompleteMultipartUploadResult struct {
 	DeletedParts      []Part
 	Location          string
+	VersionID         *string
 	ETag              string
 	ChecksumCRC32     *string
 	ChecksumCRC32C    *string

--- a/internal/storage/metadatapart/metadatastore/metadatastore.go
+++ b/internal/storage/metadatapart/metadatastore/metadatastore.go
@@ -18,10 +18,23 @@ type Bucket struct {
 	CreationDate time.Time
 }
 
+type BucketVersioningStatus string
+
+const (
+	BucketVersioningStatusEnabled   BucketVersioningStatus = "Enabled"
+	BucketVersioningStatusSuspended BucketVersioningStatus = "Suspended"
+)
+
+type BucketVersioningConfiguration struct {
+	Status *BucketVersioningStatus
+}
+
 type Object struct {
 	Key               ObjectKey
 	ContentType       *string // only set in HeadObject and PutObject
 	LastModified      time.Time
+	VersionID         *string
+	IsDeleteMarker    bool
 	ETag              string
 	ChecksumCRC32     *string
 	ChecksumCRC32C    *string
@@ -227,11 +240,43 @@ type AppendObjectOptions struct {
 }
 
 type DeleteObjectOptions struct {
+	VersionID *string
 	// IfMatchETag, when non-nil, requires the stored object's ETag to equal this
 	// value before deleting; otherwise ErrPreconditionFailed is returned.
 	// The special value "*" matches any existing object (i.e. HTTP If-Match: *),
 	// returning ErrPreconditionFailed only when the object does not exist.
 	IfMatchETag *string
+}
+
+type DeleteObjectResult struct {
+	VersionID      *string
+	IsDeleteMarker bool
+}
+
+type ObjectVersion struct {
+	Key            ObjectKey
+	VersionID      string
+	IsDeleteMarker bool
+	IsLatest       bool
+	LastModified   time.Time
+	Size           int64
+	ETag           *string
+}
+
+type ListObjectVersionsOptions struct {
+	Prefix          *string
+	Delimiter       *string
+	KeyMarker       *string
+	VersionIDMarker *string
+	MaxKeys         int32
+}
+
+type ListObjectVersionsResult struct {
+	Versions            []ObjectVersion
+	CommonPrefixes      []string
+	IsTruncated         bool
+	NextKeyMarker       *string
+	NextVersionIDMarker *string
 }
 
 // CompleteMultipartUploadOptions holds conditional request options for CompleteMultipartUpload.
@@ -257,6 +302,8 @@ type BucketStore interface {
 	DeleteBucket(ctx context.Context, tx *sql.Tx, bucketName BucketName) error
 	ListBuckets(ctx context.Context, tx *sql.Tx) ([]Bucket, error)
 	HeadBucket(ctx context.Context, tx *sql.Tx, bucketName BucketName) (*Bucket, error)
+	GetBucketVersioningConfiguration(ctx context.Context, tx *sql.Tx, bucketName BucketName) (*BucketVersioningConfiguration, error)
+	PutBucketVersioningConfiguration(ctx context.Context, tx *sql.Tx, bucketName BucketName, config *BucketVersioningConfiguration) error
 }
 
 type WebsiteConfiguration struct {
@@ -272,7 +319,9 @@ type BucketWebsiteStore interface {
 
 type ObjectStore interface {
 	ListObjects(ctx context.Context, tx *sql.Tx, bucketName BucketName, opts ListObjectsOptions) (*ListBucketResult, error)
+	ListObjectVersions(ctx context.Context, tx *sql.Tx, bucketName BucketName, opts ListObjectVersionsOptions) (*ListObjectVersionsResult, error)
 	HeadObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey) (*Object, error)
+	HeadObjectVersion(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, versionID string) (*Object, error)
 	PutObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object, opts *PutObjectOptions) error
 	// AppendObject appends a new part to an existing object's part list. The caller
 	// must supply the updated object metadata (including new ETag, size, and the
@@ -280,7 +329,7 @@ type ObjectStore interface {
 	// created. If WriteOffset is set in opts and does not match the current object
 	// size, ErrInvalidWriteOffset is returned.
 	AppendObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, object *Object, opts *AppendObjectOptions) error
-	DeleteObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
+	DeleteObject(ctx context.Context, tx *sql.Tx, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) (*DeleteObjectResult, error)
 }
 
 type MultipartStore interface {
@@ -415,7 +464,7 @@ func Tester(metadataStore MetadataStore, db database.Database) error {
 	if err != nil {
 		return err
 	}
-	err = metadataStore.DeleteObject(ctx, tx, bucketName, key, nil)
+	_, err = metadataStore.DeleteObject(ctx, tx, bucketName, key, nil)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -468,7 +517,7 @@ func Tester(metadataStore MetadataStore, db database.Database) error {
 	if err != nil {
 		return err
 	}
-	err = metadataStore.DeleteObject(ctx, tx, bucketName, key, nil)
+	_, err = metadataStore.DeleteObject(ctx, tx, bucketName, key, nil)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -218,6 +218,48 @@ func (sms *sqlMetadataStore) DeleteBucketWebsiteConfiguration(ctx context.Contex
 	return sms.bucketRepository.SaveBucket(ctx, tx, bucketEntity)
 }
 
+func (sms *sqlMetadataStore) GetBucketVersioningConfiguration(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName) (*metadatastore.BucketVersioningConfiguration, error) {
+	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.GetBucketVersioningConfiguration")
+	defer span.End()
+
+	bucketEntity, err := sms.bucketRepository.FindBucketByName(ctx, tx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+	if bucketEntity == nil {
+		return nil, metadatastore.ErrNoSuchBucket
+	}
+
+	if bucketEntity.VersioningStatus == nil {
+		return &metadatastore.BucketVersioningConfiguration{}, nil
+	}
+
+	status := metadatastore.BucketVersioningStatus(*bucketEntity.VersioningStatus)
+	return &metadatastore.BucketVersioningConfiguration{Status: &status}, nil
+}
+
+func (sms *sqlMetadataStore) PutBucketVersioningConfiguration(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, config *metadatastore.BucketVersioningConfiguration) error {
+	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.PutBucketVersioningConfiguration")
+	defer span.End()
+
+	bucketEntity, err := sms.bucketRepository.FindBucketByName(ctx, tx, bucketName)
+	if err != nil {
+		return err
+	}
+	if bucketEntity == nil {
+		return metadatastore.ErrNoSuchBucket
+	}
+
+	if config == nil || config.Status == nil {
+		bucketEntity.VersioningStatus = nil
+	} else {
+		status := string(*config.Status)
+		bucketEntity.VersioningStatus = &status
+	}
+
+	return sms.bucketRepository.SaveBucket(ctx, tx, bucketEntity)
+}
+
 func determineCommonPrefix(prefix, key, delimiter string) *string {
 	prefixSegments := strings.Split(prefix, delimiter)
 	keySegments := strings.Split(key, delimiter)
@@ -291,6 +333,8 @@ func (sms *sqlMetadataStore) listObjects(ctx context.Context, tx *sql.Tx, bucket
 				objects = append(objects, metadatastore.Object{
 					Key:               objectEntity.Key,
 					LastModified:      objectEntity.UpdatedAt,
+					VersionID:         objectEntity.VersionID,
+					IsDeleteMarker:    objectEntity.IsDeleteMarker,
 					ETag:              objectEntity.ETag,
 					ChecksumCRC32:     objectEntity.ChecksumCRC32,
 					ChecksumCRC32C:    objectEntity.ChecksumCRC32C,
@@ -326,6 +370,120 @@ func (sms *sqlMetadataStore) ListObjects(ctx context.Context, tx *sql.Tx, bucket
 	}
 
 	return sms.listObjects(ctx, tx, bucketName, opts)
+}
+
+func (sms *sqlMetadataStore) ListObjectVersions(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, opts metadatastore.ListObjectVersionsOptions) (*metadatastore.ListObjectVersionsResult, error) {
+	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.ListObjectVersions")
+	defer span.End()
+
+	exists, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+	if !*exists {
+		return nil, metadatastore.ErrNoSuchBucket
+	}
+
+	prefix := ""
+	if opts.Prefix != nil {
+		prefix = *opts.Prefix
+	}
+	delimiter := ""
+	if opts.Delimiter != nil {
+		delimiter = *opts.Delimiter
+	}
+	keyMarker := ""
+	if opts.KeyMarker != nil {
+		keyMarker = *opts.KeyMarker
+	}
+	versionIDMarker := ""
+	if opts.VersionIDMarker != nil {
+		versionIDMarker = *opts.VersionIDMarker
+	}
+
+	entities, err := sms.objectRepository.FindObjectVersionsByBucketNameAndPrefixAndKeyMarkerAndVersionIDMarkerOrderByKeyAscAndVersionIDDesc(ctx, tx, bucketName, prefix, keyMarker, versionIDMarker)
+	if err != nil {
+		return nil, err
+	}
+
+	maxKeys := opts.MaxKeys
+	if maxKeys <= 0 {
+		maxKeys = 1000
+	}
+
+	commonPrefixes := []string{}
+	commonPrefixSet := map[string]struct{}{}
+	versions := []metadatastore.ObjectVersion{}
+	isTruncated := false
+	emittedCount := int32(0)
+	var lastReturnedKey *string
+	var lastReturnedVersionID *string
+	var nextKeyMarker *string
+	var nextVersionIDMarker *string
+
+	for _, entity := range entities {
+		if delimiter != "" {
+			commonPrefix := determineCommonPrefix(prefix, entity.Key.String(), delimiter)
+			if commonPrefix != nil {
+				if _, exists := commonPrefixSet[*commonPrefix]; exists {
+					continue
+				}
+				if emittedCount >= maxKeys {
+					isTruncated = true
+					break
+				}
+				commonPrefixSet[*commonPrefix] = struct{}{}
+				commonPrefixes = append(commonPrefixes, *commonPrefix)
+				emittedCount++
+				k := entity.Key.String()
+				lastReturnedKey = &k
+				lastReturnedVersionID = entity.VersionID
+				continue
+			}
+		}
+
+		if emittedCount >= maxKeys {
+			isTruncated = true
+			break
+		}
+
+		keyWithoutPrefix := strings.TrimPrefix(entity.Key.String(), prefix)
+		if delimiter == "" || !strings.Contains(keyWithoutPrefix, delimiter) {
+			versionID := ""
+			if entity.VersionID != nil {
+				versionID = *entity.VersionID
+			}
+			versions = append(versions, metadatastore.ObjectVersion{
+				Key:            entity.Key,
+				VersionID:      versionID,
+				IsDeleteMarker: entity.IsDeleteMarker,
+				IsLatest:       entity.IsLatest,
+				LastModified:   entity.UpdatedAt,
+				Size:           entity.Size,
+				ETag:           &entity.ETag,
+			})
+			emittedCount++
+			nextKey := entity.Key.String()
+			lastReturnedKey = &nextKey
+			lastReturnedVersionID = entity.VersionID
+		}
+	}
+
+	if !isTruncated && emittedCount >= maxKeys && int(emittedCount) < len(entities) {
+		isTruncated = true
+	}
+	if isTruncated {
+		nextKeyMarker = lastReturnedKey
+		nextVersionIDMarker = lastReturnedVersionID
+	}
+
+	return &metadatastore.ListObjectVersionsResult{
+		Versions:            versions,
+		CommonPrefixes:      commonPrefixes,
+		IsTruncated:         isTruncated,
+		NextKeyMarker:       nextKeyMarker,
+		NextVersionIDMarker: nextVersionIDMarker,
+	}, nil
 }
 
 func (sms *sqlMetadataStore) HeadObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey) (*metadatastore.Object, error) {
@@ -368,6 +526,8 @@ func (sms *sqlMetadataStore) HeadObject(ctx context.Context, tx *sql.Tx, bucketN
 		Key:               key,
 		ContentType:       objectEntity.ContentType,
 		LastModified:      objectEntity.UpdatedAt,
+		VersionID:         objectEntity.VersionID,
+		IsDeleteMarker:    objectEntity.IsDeleteMarker,
 		ETag:              objectEntity.ETag,
 		ChecksumCRC32:     objectEntity.ChecksumCRC32,
 		ChecksumCRC32C:    objectEntity.ChecksumCRC32C,
@@ -380,16 +540,83 @@ func (sms *sqlMetadataStore) HeadObject(ctx context.Context, tx *sql.Tx, bucketN
 	}, nil
 }
 
+func (sms *sqlMetadataStore) HeadObjectVersion(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, versionID string) (*metadatastore.Object, error) {
+	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.HeadObjectVersion")
+	defer span.End()
+
+	exists, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+	if !*exists {
+		return nil, metadatastore.ErrNoSuchBucket
+	}
+
+	objectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKeyAndVersionID(ctx, tx, bucketName, key, versionID)
+	if err != nil {
+		return nil, err
+	}
+	if objectEntity == nil {
+		return nil, metadatastore.ErrNoSuchKey
+	}
+
+	parts := []metadatastore.Part{}
+	if !objectEntity.IsDeleteMarker {
+		partEntities, err := sms.partRepository.FindPartsByObjectIdOrderBySequenceNumberAsc(ctx, tx, *objectEntity.Id)
+		if err != nil {
+			return nil, err
+		}
+		parts = sliceutils.Map(func(partEntity part.Entity) metadatastore.Part {
+			return metadatastore.Part{Id: partEntity.PartId, ETag: partEntity.ETag, ChecksumCRC32: partEntity.ChecksumCRC32, ChecksumCRC32C: partEntity.ChecksumCRC32C, ChecksumCRC64NVME: partEntity.ChecksumCRC64NVME, ChecksumSHA1: partEntity.ChecksumSHA1, ChecksumSHA256: partEntity.ChecksumSHA256, Size: partEntity.Size}
+		}, partEntities)
+	}
+
+	return &metadatastore.Object{Key: key, ContentType: objectEntity.ContentType, LastModified: objectEntity.UpdatedAt, VersionID: objectEntity.VersionID, IsDeleteMarker: objectEntity.IsDeleteMarker, ETag: objectEntity.ETag, ChecksumCRC32: objectEntity.ChecksumCRC32, ChecksumCRC32C: objectEntity.ChecksumCRC32C, ChecksumCRC64NVME: objectEntity.ChecksumCRC64NVME, ChecksumSHA1: objectEntity.ChecksumSHA1, ChecksumSHA256: objectEntity.ChecksumSHA256, ChecksumType: objectEntity.ChecksumType, Size: objectEntity.Size, Parts: parts}, nil
+}
+
 func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, obj *metadatastore.Object, opts *metadatastore.PutObjectOptions) error {
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.PutObject")
 	defer span.End()
 
-	existsBucket, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	bucketEntity, err := sms.bucketRepository.FindBucketByName(ctx, tx, bucketName)
 	if err != nil {
 		return err
 	}
-	if !*existsBucket {
+	if bucketEntity == nil {
 		return metadatastore.ErrNoSuchBucket
+	}
+
+	versioningEnabled := bucketEntity.VersioningStatus != nil && *bucketEntity.VersioningStatus == string(metadatastore.BucketVersioningStatusEnabled)
+
+	latestObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
+	if err != nil {
+		return err
+	}
+
+	objectExists := latestObjectEntity != nil && !latestObjectEntity.IsDeleteMarker
+	if opts != nil && opts.IfMatchETag != nil {
+		if *opts.IfMatchETag == metadatastore.ETagWildcard {
+			if !objectExists {
+				return metadatastore.ErrPreconditionFailed
+			}
+		} else if !objectExists || latestObjectEntity.ETag != *opts.IfMatchETag {
+			return metadatastore.ErrPreconditionFailed
+		}
+	}
+	if opts != nil && opts.IfNoneMatchStar && objectExists {
+		return metadatastore.ErrPreconditionFailed
+	}
+
+	if opts != nil && opts.IfMatchETag != nil && latestObjectEntity != nil {
+		lockedObjectEntity := *latestObjectEntity
+		locked, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, latestObjectEntity.OptimisticLockVersion)
+		if err != nil {
+			return err
+		}
+		if !*locked {
+			return metadatastore.ErrPreconditionFailed
+		}
+		latestObjectEntity = &lockedObjectEntity
 	}
 
 	objectEntity := object.Entity{
@@ -404,56 +631,61 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		ChecksumSHA256:    obj.ChecksumSHA256,
 		ChecksumType:      obj.ChecksumType,
 		Size:              obj.Size,
+		IsDeleteMarker:    false,
+		IsLatest:          true,
 		UploadStatus:      object.UploadStatusCompleted,
 	}
 
-	oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
-	if err != nil {
-		return err
-	}
-
-	if opts != nil && opts.IfMatchETag != nil {
-		if oldObjectEntity == nil || oldObjectEntity.ETag != *opts.IfMatchETag {
-			return metadatastore.ErrPreconditionFailed
+	if versioningEnabled {
+		versionID := metadatastore.NewRandomUploadId().String()
+		objectEntity.VersionID = &versionID
+		if latestObjectEntity != nil {
+			latestObjectEntity.IsLatest = false
+			if err := sms.objectRepository.SaveObject(ctx, tx, latestObjectEntity); err != nil {
+				return err
+			}
 		}
-
-		objectEntity.Id = oldObjectEntity.Id
-		updated, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &objectEntity, oldObjectEntity.OptimisticLockVersion)
-		if err != nil {
-			return err
-		}
-		if !*updated {
-			return metadatastore.ErrPreconditionFailed
-		}
-
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
-		if err != nil {
-			return err
-		}
-	} else if opts != nil && opts.IfNoneMatchStar {
-		inserted, err := sms.objectRepository.InsertObjectIfAbsent(ctx, tx, &objectEntity)
-		if err != nil {
-			return err
-		}
-		if !*inserted {
-			return metadatastore.ErrPreconditionFailed
-		}
-	} else if oldObjectEntity != nil {
-		objectEntity.Id = oldObjectEntity.Id
-		objectEntity.OptimisticLockVersion = oldObjectEntity.OptimisticLockVersion
-		err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
-		if err != nil {
-			return err
-		}
-
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
-		if err != nil {
+		if err := sms.objectRepository.SaveObject(ctx, tx, &objectEntity); err != nil {
+			if opts != nil && opts.IfNoneMatchStar && isUniqueConstraintViolation(err) {
+				return metadatastore.ErrPreconditionFailed
+			}
 			return err
 		}
 	} else {
-		err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
+		nullVersionEntity, err := sms.objectRepository.FindNullObjectVersionByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
 		if err != nil {
 			return err
+		}
+		nullVersion := "null"
+		objectEntity.VersionID = &nullVersion
+
+		if latestObjectEntity != nil {
+			latestObjectEntity.IsLatest = false
+			if err := sms.objectRepository.SaveObject(ctx, tx, latestObjectEntity); err != nil {
+				return err
+			}
+		}
+
+		if nullVersionEntity != nil {
+			objectEntity.Id = nullVersionEntity.Id
+			objectEntity.OptimisticLockVersion = nullVersionEntity.OptimisticLockVersion
+			if err := sms.objectRepository.SaveObject(ctx, tx, &objectEntity); err != nil {
+				if opts != nil && opts.IfNoneMatchStar && isUniqueConstraintViolation(err) {
+					return metadatastore.ErrPreconditionFailed
+				}
+				return err
+			}
+			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
+			if err != nil {
+				return err
+			}
+		} else {
+			if err := sms.objectRepository.SaveObject(ctx, tx, &objectEntity); err != nil {
+				if opts != nil && opts.IfNoneMatchStar && isUniqueConstraintViolation(err) {
+					return metadatastore.ErrPreconditionFailed
+				}
+				return err
+			}
 		}
 	}
 
@@ -479,6 +711,8 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		sequenceNumber += 1
 	}
 
+	obj.VersionID = objectEntity.VersionID
+
 	return nil
 }
 
@@ -502,14 +736,17 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 
 	if oldObjectEntity != nil {
 		updatedEntity := object.Entity{
-			Id:           oldObjectEntity.Id,
-			BucketName:   bucketName,
-			Key:          obj.Key,
-			ContentType:  oldObjectEntity.ContentType,
-			ETag:         obj.ETag,
-			ChecksumType: obj.ChecksumType,
-			Size:         obj.Size,
-			UploadStatus: object.UploadStatusCompleted,
+			Id:             oldObjectEntity.Id,
+			BucketName:     bucketName,
+			Key:            obj.Key,
+			ContentType:    oldObjectEntity.ContentType,
+			ETag:           obj.ETag,
+			ChecksumType:   obj.ChecksumType,
+			Size:           obj.Size,
+			VersionID:      oldObjectEntity.VersionID,
+			IsLatest:       true,
+			IsDeleteMarker: false,
+			UploadStatus:   object.UploadStatusCompleted,
 		}
 		updated, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &updatedEntity, oldObjectEntity.OptimisticLockVersion)
 		if err != nil {
@@ -549,13 +786,16 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 
 	// No existing object — create a new one (same semantics as PutObject).
 	newEntity := object.Entity{
-		BucketName:   bucketName,
-		Key:          obj.Key,
-		ContentType:  obj.ContentType,
-		ETag:         obj.ETag,
-		ChecksumType: obj.ChecksumType,
-		Size:         obj.Size,
-		UploadStatus: object.UploadStatusCompleted,
+		BucketName:     bucketName,
+		Key:            obj.Key,
+		ContentType:    obj.ContentType,
+		ETag:           obj.ETag,
+		ChecksumType:   obj.ChecksumType,
+		Size:           obj.Size,
+		VersionID:      ptrutils.ToPtr("null"),
+		IsLatest:       true,
+		IsDeleteMarker: false,
+		UploadStatus:   object.UploadStatusCompleted,
 	}
 	err = sms.objectRepository.SaveObject(ctx, tx, &newEntity)
 	if err != nil {
@@ -585,74 +825,163 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 	return nil
 }
 
-func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, opts *metadatastore.DeleteObjectOptions) error {
+func (sms *sqlMetadataStore) DeleteObject(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, opts *metadatastore.DeleteObjectOptions) (*metadatastore.DeleteObjectResult, error) {
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.DeleteObject")
 	defer span.End()
 
-	exists, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	bucketEntity, err := sms.bucketRepository.FindBucketByName(ctx, tx, bucketName)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if !*exists {
-		return metadatastore.ErrNoSuchBucket
+	if bucketEntity == nil {
+		return nil, metadatastore.ErrNoSuchBucket
 	}
 
-	objectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, key)
+	versioningStatus := ""
+	if bucketEntity.VersioningStatus != nil {
+		versioningStatus = *bucketEntity.VersioningStatus
+	}
+
+	currentEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, key)
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	if opts != nil && opts.VersionID != nil {
+		versionEntity, err := sms.objectRepository.FindObjectByBucketNameAndKeyAndVersionID(ctx, tx, bucketName, key, *opts.VersionID)
+		if err != nil {
+			return nil, err
+		}
+		if versionEntity == nil {
+			return &metadatastore.DeleteObjectResult{VersionID: opts.VersionID}, nil
+		}
+
+		if opts.IfMatchETag != nil {
+			if *opts.IfMatchETag == metadatastore.ETagWildcard {
+				// any existing version matches
+			} else if versionEntity.IsDeleteMarker || versionEntity.ETag != *opts.IfMatchETag {
+				return nil, metadatastore.ErrPreconditionFailed
+			}
+		}
+
+		if !versionEntity.IsDeleteMarker {
+			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *versionEntity.Id)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *versionEntity.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		if versionEntity.IsLatest {
+			nextLatest, err := sms.objectRepository.FindLatestObjectByBucketNameAndKeyExcludingID(ctx, tx, bucketName, key, *versionEntity.Id)
+			if err != nil {
+				return nil, err
+			}
+			if nextLatest != nil {
+				nextLatest.IsLatest = true
+				if err := sms.objectRepository.SaveObject(ctx, tx, nextLatest); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		return &metadatastore.DeleteObjectResult{VersionID: versionEntity.VersionID, IsDeleteMarker: versionEntity.IsDeleteMarker}, nil
 	}
 
 	if opts != nil && opts.IfMatchETag != nil {
 		if *opts.IfMatchETag == metadatastore.ETagWildcard {
-			// If-Match: * — object must exist (any ETag); 412 if absent.
-			if objectEntity == nil {
-				return metadatastore.ErrPreconditionFailed
+			if currentEntity == nil || currentEntity.IsDeleteMarker {
+				return nil, metadatastore.ErrPreconditionFailed
 			}
 		} else {
-			// Conditional delete: object must exist and ETag must match exactly.
-			if objectEntity == nil || objectEntity.ETag != *opts.IfMatchETag {
-				return metadatastore.ErrPreconditionFailed
+			if currentEntity == nil || currentEntity.IsDeleteMarker || currentEntity.ETag != *opts.IfMatchETag {
+				return nil, metadatastore.ErrPreconditionFailed
 			}
 		}
 	}
 
-	if objectEntity != nil {
-		if opts != nil && opts.IfMatchETag != nil {
-			lockedObjectEntity := *objectEntity
-			locked, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, objectEntity.OptimisticLockVersion)
+	if versioningStatus == string(metadatastore.BucketVersioningStatusEnabled) || versioningStatus == string(metadatastore.BucketVersioningStatusSuspended) {
+		if versioningStatus == string(metadatastore.BucketVersioningStatusSuspended) {
+			nullVersionEntity, err := sms.objectRepository.FindNullObjectVersionByBucketNameAndKey(ctx, tx, bucketName, key)
 			if err != nil {
-				return err
+				return nil, err
+			}
+			if nullVersionEntity != nil {
+				_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *nullVersionEntity.Id)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if currentEntity != nil {
+			currentEntity.IsLatest = false
+			if err := sms.objectRepository.SaveObject(ctx, tx, currentEntity); err != nil {
+				return nil, err
+			}
+		}
+		deleteMarkerVersionID := metadatastore.NewRandomUploadId().String()
+		deleteMarker := object.Entity{
+			BucketName:     bucketName,
+			Key:            key,
+			ETag:           "",
+			Size:           0,
+			VersionID:      &deleteMarkerVersionID,
+			IsDeleteMarker: true,
+			IsLatest:       true,
+			UploadStatus:   object.UploadStatusCompleted,
+		}
+		if err := sms.objectRepository.SaveObject(ctx, tx, &deleteMarker); err != nil {
+			return nil, err
+		}
+		return &metadatastore.DeleteObjectResult{VersionID: deleteMarker.VersionID, IsDeleteMarker: true}, nil
+	}
+
+	if currentEntity != nil {
+		if opts != nil && opts.IfMatchETag != nil {
+			lockedObjectEntity := *currentEntity
+			locked, lockErr := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, currentEntity.OptimisticLockVersion)
+			if lockErr != nil {
+				return nil, lockErr
 			}
 			if !*locked {
-				return metadatastore.ErrPreconditionFailed
+				return nil, metadatastore.ErrPreconditionFailed
 			}
 
-			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *lockedObjectEntity.Id)
-			if err != nil {
-				return err
+			if !lockedObjectEntity.IsDeleteMarker {
+				err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *lockedObjectEntity.Id)
+				if err != nil {
+					return nil, err
+				}
 			}
 
-			deleted, err := sms.objectRepository.DeleteObjectByIdAndOptimisticLockVersion(ctx, tx, *lockedObjectEntity.Id, lockedObjectEntity.OptimisticLockVersion)
-			if err != nil {
-				return err
+			deleted, deleteErr := sms.objectRepository.DeleteObjectByIdAndOptimisticLockVersion(ctx, tx, *lockedObjectEntity.Id, lockedObjectEntity.OptimisticLockVersion)
+			if deleteErr != nil {
+				return nil, deleteErr
 			}
 			if !*deleted {
-				return metadatastore.ErrPreconditionFailed
+				return nil, metadatastore.ErrPreconditionFailed
 			}
 		} else {
-			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *objectEntity.Id)
-			if err != nil {
-				return err
+			if !currentEntity.IsDeleteMarker {
+				err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *currentEntity.Id)
+				if err != nil {
+					return nil, err
+				}
 			}
 
-			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *objectEntity.Id)
+			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *currentEntity.Id)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
-	return nil
+	return &metadatastore.DeleteObjectResult{}, nil
 }
 
 func (sms *sqlMetadataStore) CreateMultipartUpload(ctx context.Context, tx *sql.Tx, bucketName metadatastore.BucketName, key metadatastore.ObjectKey, contentType *string, checksumType *string) (*metadatastore.InitiateMultipartUploadResult, error) {
@@ -672,14 +1001,16 @@ func (sms *sqlMetadataStore) CreateMultipartUpload(ctx context.Context, tx *sql.
 	}
 
 	objectEntity := object.Entity{
-		BucketName:   bucketName,
-		Key:          key,
-		ContentType:  contentType,
-		ETag:         "",
-		ChecksumType: checksumType,
-		Size:         -1,
-		UploadId:     ptrutils.ToPtr(metadatastore.NewRandomUploadId()),
-		UploadStatus: object.UploadStatusPending,
+		BucketName:     bucketName,
+		Key:            key,
+		ContentType:    contentType,
+		ETag:           "",
+		ChecksumType:   checksumType,
+		Size:           -1,
+		IsLatest:       false,
+		IsDeleteMarker: false,
+		UploadId:       ptrutils.ToPtr(metadatastore.NewRandomUploadId()),
+		UploadStatus:   object.UploadStatusPending,
 	}
 	err = sms.objectRepository.SaveObject(ctx, tx, &objectEntity)
 	if err != nil {
@@ -735,11 +1066,11 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.CompleteMultipartUpload")
 	defer span.End()
 
-	exists, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	bucketEntity, err := sms.bucketRepository.FindBucketByName(ctx, tx, bucketName)
 	if err != nil {
 		return nil, err
 	}
-	if !*exists {
+	if bucketEntity == nil {
 		return nil, metadatastore.ErrNoSuchBucket
 	}
 
@@ -794,79 +1125,106 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 
 	deletedParts := []metadatastore.Part{}
 
-	// Remove old objects
-	oldObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, key)
+	versioningEnabled := bucketEntity.VersioningStatus != nil && *bucketEntity.VersioningStatus == string(metadatastore.BucketVersioningStatusEnabled)
+
+	latestObjectEntity, err := sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}
+	objectExists := latestObjectEntity != nil && !latestObjectEntity.IsDeleteMarker
 
 	// Evaluate conditional headers (AWS S3 compatible behaviour):
 	//   If-Match:      the current object's ETag must match the supplied value.
 	//   If-None-Match: "*" means the operation must fail when any object exists.
 	if opts != nil {
 		if opts.IfMatchETag != nil {
-			// If-Match: * — any existing object satisfies the condition; fail when absent.
+			// If-Match: * — any existing non-delete-marker object satisfies the condition; fail when absent.
 			// If-Match: <etag> — existing ETag must match exactly; fail otherwise.
 			if *opts.IfMatchETag == metadatastore.ETagWildcard {
-				if oldObjectEntity == nil {
+				if !objectExists {
 					return nil, metadatastore.ErrPreconditionFailed
 				}
 			} else {
-				if oldObjectEntity == nil || oldObjectEntity.ETag != *opts.IfMatchETag {
+				if !objectExists || latestObjectEntity.ETag != *opts.IfMatchETag {
 					return nil, metadatastore.ErrPreconditionFailed
 				}
 			}
 		}
 		if opts.IfNoneMatchStar {
-			// If-None-Match: * — fail when any object currently exists at the key.
-			if oldObjectEntity != nil {
+			// If-None-Match: * — fail when any existing non-delete-marker object currently exists at the key.
+			if objectExists {
 				return nil, metadatastore.ErrPreconditionFailed
 			}
 		}
 	}
 
-	if oldObjectEntity != nil {
-		oldPartEntities, err := sms.partRepository.FindPartsByObjectIdOrderBySequenceNumberAsc(ctx, tx, *oldObjectEntity.Id)
+	if opts != nil && opts.IfMatchETag != nil && latestObjectEntity != nil {
+		lockedObjectEntity := *latestObjectEntity
+		locked, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, latestObjectEntity.OptimisticLockVersion)
 		if err != nil {
 			return nil, err
 		}
+		if !*locked {
+			return nil, metadatastore.ErrPreconditionFailed
+		}
+		latestObjectEntity = &lockedObjectEntity
+	}
 
-		err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *oldObjectEntity.Id)
+	if versioningEnabled {
+		newVersionID := metadatastore.NewRandomUploadId().String()
+		objectEntity.VersionID = &newVersionID
+	} else {
+		nullVersionEntity, err := sms.objectRepository.FindNullObjectVersionByBucketNameAndKey(ctx, tx, bucketName, key)
 		if err != nil {
 			return nil, err
 		}
-
-		deletedParts = sliceutils.Map(func(partEntity part.Entity) metadatastore.Part {
-			return metadatastore.Part{
-				Id:                partEntity.PartId,
-				ETag:              partEntity.ETag,
-				ChecksumCRC32:     partEntity.ChecksumCRC32,
-				ChecksumCRC32C:    partEntity.ChecksumCRC32C,
-				ChecksumCRC64NVME: partEntity.ChecksumCRC64NVME,
-				ChecksumSHA1:      partEntity.ChecksumSHA1,
-				ChecksumSHA256:    partEntity.ChecksumSHA256,
-				Size:              partEntity.Size,
-			}
-		}, oldPartEntities)
-
-		if opts != nil && opts.IfMatchETag != nil {
-			deleted, err := sms.objectRepository.DeleteObjectByIdAndOptimisticLockVersion(ctx, tx, *oldObjectEntity.Id, oldObjectEntity.OptimisticLockVersion)
+		if nullVersionEntity != nil {
+			oldPartEntities, err := sms.partRepository.FindPartsByObjectIdOrderBySequenceNumberAsc(ctx, tx, *nullVersionEntity.Id)
 			if err != nil {
 				return nil, err
 			}
-			if !*deleted {
-				return nil, metadatastore.ErrPreconditionFailed
-			}
-		} else {
-			_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *oldObjectEntity.Id)
+
+			err = sms.partRepository.DeletePartsByObjectId(ctx, tx, *nullVersionEntity.Id)
 			if err != nil {
 				return nil, err
 			}
+
+			deletedParts = append(deletedParts, sliceutils.Map(func(partEntity part.Entity) metadatastore.Part {
+				return metadatastore.Part{Id: partEntity.PartId, ETag: partEntity.ETag, ChecksumCRC32: partEntity.ChecksumCRC32, ChecksumCRC32C: partEntity.ChecksumCRC32C, ChecksumCRC64NVME: partEntity.ChecksumCRC64NVME, ChecksumSHA1: partEntity.ChecksumSHA1, ChecksumSHA256: partEntity.ChecksumSHA256, Size: partEntity.Size}
+			}, oldPartEntities)...)
+
+			if opts != nil && opts.IfMatchETag != nil && latestObjectEntity != nil && latestObjectEntity.Id != nil && nullVersionEntity.Id != nil && *latestObjectEntity.Id == *nullVersionEntity.Id {
+				deleted, deleteErr := sms.objectRepository.DeleteObjectByIdAndOptimisticLockVersion(ctx, tx, *nullVersionEntity.Id, latestObjectEntity.OptimisticLockVersion)
+				if deleteErr != nil {
+					return nil, deleteErr
+				}
+				if !*deleted {
+					return nil, metadatastore.ErrPreconditionFailed
+				}
+			} else {
+				_, err = sms.objectRepository.DeleteObjectById(ctx, tx, *nullVersionEntity.Id)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		nullVersion := "null"
+		objectEntity.VersionID = &nullVersion
+	}
+
+	if latestObjectEntity != nil {
+		latestObjectEntity.IsLatest = false
+		err = sms.objectRepository.SaveObject(ctx, tx, latestObjectEntity)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	objectEntity.UploadStatus = object.UploadStatusCompleted
 	objectEntity.UploadId = nil
+	objectEntity.IsDeleteMarker = false
+	objectEntity.IsLatest = true
 	objectEntity.Size = totalSize
 	objectEntity.ETag = *calculatedChecksums.ETag
 	objectEntity.ChecksumCRC32 = calculatedChecksums.ChecksumCRC32

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -665,6 +665,9 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 		if err != nil {
 			return err
 		}
+		if opts != nil && opts.IfNoneMatchStar && nullVersionEntity != nil {
+			return metadatastore.ErrPreconditionFailed
+		}
 		nullVersion := "null"
 		objectEntity.VersionID = &nullVersion
 
@@ -1200,6 +1203,9 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 		nullVersionEntity, err := sms.objectRepository.FindNullObjectVersionByBucketNameAndKey(ctx, tx, bucketName, key)
 		if err != nil {
 			return nil, err
+		}
+		if opts != nil && opts.IfNoneMatchStar && nullVersionEntity != nil {
+			return nil, metadatastore.ErrPreconditionFailed
 		}
 		if nullVersionEntity != nil {
 			oldPartEntities, err := sms.partRepository.FindPartsByObjectIdOrderBySequenceNumberAsc(ctx, tx, *nullVersionEntity.Id)

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -1166,8 +1166,17 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 			}
 		}
 	}
+	if opts != nil && opts.IfNoneMatchStar {
+		latestObjectEntity, err = sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, key)
+		if err != nil {
+			return nil, err
+		}
+		if latestObjectEntity != nil && !latestObjectEntity.IsDeleteMarker {
+			return nil, metadatastore.ErrPreconditionFailed
+		}
+	}
 
-	if opts != nil && opts.IfMatchETag != nil && latestObjectEntity != nil {
+	if opts != nil && (opts.IfMatchETag != nil || opts.IfNoneMatchStar) && latestObjectEntity != nil {
 		lockedObjectEntity := *latestObjectEntity
 		locked, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, latestObjectEntity.OptimisticLockVersion)
 		if err != nil {

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -606,8 +606,17 @@ func (sms *sqlMetadataStore) PutObject(ctx context.Context, tx *sql.Tx, bucketNa
 	if opts != nil && opts.IfNoneMatchStar && objectExists {
 		return metadatastore.ErrPreconditionFailed
 	}
+	if opts != nil && opts.IfNoneMatchStar {
+		latestObjectEntity, err = sms.objectRepository.FindObjectByBucketNameAndKey(ctx, tx, bucketName, obj.Key)
+		if err != nil {
+			return err
+		}
+		if latestObjectEntity != nil && !latestObjectEntity.IsDeleteMarker {
+			return metadatastore.ErrPreconditionFailed
+		}
+	}
 
-	if opts != nil && opts.IfMatchETag != nil && latestObjectEntity != nil {
+	if opts != nil && (opts.IfMatchETag != nil || opts.IfNoneMatchStar) && latestObjectEntity != nil {
 		lockedObjectEntity := *latestObjectEntity
 		locked, err := sms.objectRepository.UpdateObjectByIdAndOptimisticLockVersion(ctx, tx, &lockedObjectEntity, latestObjectEntity.OptimisticLockVersion)
 		if err != nil {

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -729,12 +729,17 @@ func (sms *sqlMetadataStore) AppendObject(ctx context.Context, tx *sql.Tx, bucke
 	ctx, span := sms.tracer.Start(ctx, "SqlMetadataStore.AppendObject")
 	defer span.End()
 
-	existsBucket, err := sms.bucketRepository.ExistsBucketByName(ctx, tx, bucketName)
+	bucketEntity, err := sms.bucketRepository.FindBucketByName(ctx, tx, bucketName)
 	if err != nil {
 		return err
 	}
-	if !*existsBucket {
+	if bucketEntity == nil {
 		return metadatastore.ErrNoSuchBucket
+	}
+
+	versioningEnabled := bucketEntity.VersioningStatus != nil && *bucketEntity.VersioningStatus == string(metadatastore.BucketVersioningStatusEnabled)
+	if versioningEnabled {
+		return sms.PutObject(ctx, tx, bucketName, obj, nil)
 	}
 
 	// Check whether an object already exists at this key.

--- a/internal/storage/metadatapart/metadatastore/sql/sql.go
+++ b/internal/storage/metadatapart/metadatastore/sql/sql.go
@@ -1263,6 +1263,7 @@ func (sms *sqlMetadataStore) CompleteMultipartUpload(ctx context.Context, tx *sq
 	return &metadatastore.CompleteMultipartUploadResult{
 		DeletedParts:      deletedParts,
 		ETag:              objectEntity.ETag,
+		VersionID:         objectEntity.VersionID,
 		ChecksumCRC32:     objectEntity.ChecksumCRC32,
 		ChecksumCRC32C:    objectEntity.ChecksumCRC32C,
 		ChecksumCRC64NVME: objectEntity.ChecksumCRC64NVME,

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -229,6 +229,20 @@ func (m *AuditLogMiddleware) HeadBucket(ctx context.Context, bucketName storage.
 	return bucket, err
 }
 
+func (m *AuditLogMiddleware) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	start := time.Now()
+	config, err := m.next.GetBucketVersioningConfiguration(ctx, bucketName)
+	m.log(ctx, "GetBucketVersioning", auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
+	return config, err
+}
+
+func (m *AuditLogMiddleware) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	start := time.Now()
+	err := m.next.PutBucketVersioningConfiguration(ctx, bucketName, config)
+	m.log(ctx, "PutBucketVersioning", auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
+	return err
+}
+
 func (m *AuditLogMiddleware) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
 	start := time.Now()
 	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
@@ -258,6 +272,13 @@ func (m *AuditLogMiddleware) ListObjects(ctx context.Context, bucketName storage
 	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
 	res, err := m.next.ListObjects(ctx, bucketName, opts)
 	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
+	return res, err
+}
+
+func (m *AuditLogMiddleware) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	start := time.Now()
+	res, err := m.next.ListObjectVersions(ctx, bucketName, opts)
+	m.log(ctx, "ListObjectVersions", auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return res, err
 }
 
@@ -293,12 +314,12 @@ func (m *AuditLogMiddleware) AppendObject(ctx context.Context, bucketName storag
 	return res, err
 }
 
-func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	start := time.Now()
 	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	err := m.next.DeleteObject(ctx, bucketName, key, opts)
+	res, err := m.next.DeleteObject(ctx, bucketName, key, opts)
 	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return res, err
 }
 
 func (m *AuditLogMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -123,12 +123,36 @@ func (csm *conditionalStorageMiddleware) HeadBucket(ctx context.Context, bucketN
 	return storage.HeadBucket(ctx, bucketName)
 }
 
+func (csm *conditionalStorageMiddleware) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.GetBucketVersioningConfiguration")
+	defer span.End()
+
+	s := csm.lookupStorage(bucketName)
+	return s.GetBucketVersioningConfiguration(ctx, bucketName)
+}
+
+func (csm *conditionalStorageMiddleware) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.PutBucketVersioningConfiguration")
+	defer span.End()
+
+	s := csm.lookupStorage(bucketName)
+	return s.PutBucketVersioningConfiguration(ctx, bucketName, config)
+}
+
 func (csm *conditionalStorageMiddleware) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.ListObjects")
 	defer span.End()
 
 	storage := csm.lookupStorage(bucketName)
 	return storage.ListObjects(ctx, bucketName, opts)
+}
+
+func (csm *conditionalStorageMiddleware) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.ListObjectVersions")
+	defer span.End()
+
+	s := csm.lookupStorage(bucketName)
+	return s.ListObjectVersions(ctx, bucketName, opts)
 }
 
 func (csm *conditionalStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
@@ -163,7 +187,7 @@ func (csm *conditionalStorageMiddleware) AppendObject(ctx context.Context, bucke
 	return s.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
 }
 
-func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (csm *conditionalStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := csm.tracer.Start(ctx, "ConditionalStorageMiddleware.DeleteObject")
 	defer span.End()
 

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -275,6 +275,32 @@ func (psm *prometheusStorageMiddleware) HeadBucket(ctx context.Context, bucketNa
 	return mBucket, err
 }
 
+func (psm *prometheusStorageMiddleware) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.GetBucketVersioningConfiguration")
+	defer span.End()
+
+	config, err := psm.innerStorage.GetBucketVersioningConfiguration(ctx, bucketName)
+	if err != nil {
+		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "GetBucketVersioning"}).Inc()
+		return nil, err
+	}
+	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "GetBucketVersioning"}).Inc()
+	return config, nil
+}
+
+func (psm *prometheusStorageMiddleware) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.PutBucketVersioningConfiguration")
+	defer span.End()
+
+	err := psm.innerStorage.PutBucketVersioningConfiguration(ctx, bucketName, config)
+	if err != nil {
+		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "PutBucketVersioning"}).Inc()
+		return err
+	}
+	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "PutBucketVersioning"}).Inc()
+	return nil
+}
+
 func (psm *prometheusStorageMiddleware) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.GetBucketWebsiteConfiguration")
 	defer span.End()
@@ -333,6 +359,19 @@ func (psm *prometheusStorageMiddleware) ListObjects(ctx context.Context, bucketN
 	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "ListObjects"}).Inc()
 
 	return mListBucketResult, nil
+}
+
+func (psm *prometheusStorageMiddleware) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.ListObjectVersions")
+	defer span.End()
+
+	res, err := psm.innerStorage.ListObjectVersions(ctx, bucketName, opts)
+	if err != nil {
+		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "ListObjectVersions"}).Inc()
+		return nil, err
+	}
+	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "ListObjectVersions"}).Inc()
+	return res, nil
 }
 
 func (psm *prometheusStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
@@ -410,19 +449,19 @@ func (psm *prometheusStorageMiddleware) AppendObject(ctx context.Context, bucket
 	return appendObjectResult, nil
 }
 
-func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObject")
 	defer span.End()
 
-	err := psm.innerStorage.DeleteObject(ctx, bucketName, key, opts)
+	result, err := psm.innerStorage.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteObject"}).Inc()
-		return err
+		return nil, err
 	}
 
 	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "DeleteObject"}).Inc()
 
-	return nil
+	return result, nil
 }
 
 func (psm *prometheusStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jdillenkofer/pithos/internal/checksumutils"
+	"github.com/jdillenkofer/pithos/internal/ioutils"
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/storage"
 	"github.com/jdillenkofer/pithos/internal/storage/database"
@@ -29,6 +30,8 @@ type outboxMetrics struct {
 	processingDuration prometheus.Histogram
 	errorsCounter      prometheus.Counter
 }
+
+const maxOutboxReplayMemoryCacheSize = 32 * 1024 * 1024 // 32MB
 
 func newOutboxMetrics(registerer prometheus.Registerer) *outboxMetrics {
 	m := &outboxMetrics{
@@ -185,7 +188,15 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			for i, chunk := range chunks {
 				readers[i] = bytes.NewReader(chunk.Content)
 			}
-			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(readers...), nil, nil)
+			readSeekCloser, err := ioutils.NewSmartCachedReadSeekCloser(io.MultiReader(readers...), maxOutboxReplayMemoryCacheSize)
+			if err != nil {
+				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
+				time.Sleep(5 * time.Second)
+				return
+			}
+			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, readSeekCloser, nil, nil)
+			readSeekCloser.Close()
 			if err != nil {
 				tx.Rollback()
 				os.metrics.errorsCounter.Inc()

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -193,7 +193,13 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 				return
 			}
 		case storageOutboxEntry.DeleteObjectStorageOperation:
-			_, err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
+			deleteOpts := &storage.DeleteObjectOptions{}
+			if entry.VersionID != nil {
+				deleteOpts.VersionID = entry.VersionID
+			} else {
+				deleteOpts = nil
+			}
+			_, err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), deleteOpts)
 			if err != nil {
 				tx.Rollback()
 				os.metrics.errorsCounter.Inc()
@@ -268,11 +274,12 @@ func (os *outboxStorage) Stop(ctx context.Context) error {
 	return os.innerStorage.Stop(ctx)
 }
 
-func (os *outboxStorage) storeStorageOutboxEntry(ctx context.Context, tx *sql.Tx, operation string, bucketName storage.BucketName, key string) (*ulid.ULID, error) {
+func (os *outboxStorage) storeStorageOutboxEntry(ctx context.Context, tx *sql.Tx, operation string, bucketName storage.BucketName, key string, versionID *string) (*ulid.ULID, error) {
 	entry := storageOutboxEntry.Entity{
 		Operation: operation,
 		Bucket:    bucketName,
 		Key:       key,
+		VersionID: versionID,
 	}
 	err := os.storageOutboxEntryRepository.SaveStorageOutboxEntry(ctx, tx, &entry)
 	if err != nil {
@@ -296,7 +303,7 @@ func (os *outboxStorage) CreateBucket(ctx context.Context, bucketName storage.Bu
 	if err != nil {
 		return err
 	}
-	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.CreateBucketStorageOperation, bucketName, "")
+	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.CreateBucketStorageOperation, bucketName, "", nil)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -316,7 +323,7 @@ func (os *outboxStorage) DeleteBucket(ctx context.Context, bucketName storage.Bu
 	if err != nil {
 		return err
 	}
-	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteBucketStorageOperation, bucketName, "")
+	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteBucketStorageOperation, bucketName, "", nil)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -518,7 +525,16 @@ func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.Bucke
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.PutObject")
 	defer span.End()
 
-	if opts != nil && (opts.IfNoneMatchStar || opts.IfMatchETag != nil) {
+	putMustBeSynchronous := opts != nil && (opts.IfNoneMatchStar || opts.IfMatchETag != nil)
+	if !putMustBeSynchronous {
+		versioningConfig, err := os.innerStorage.GetBucketVersioningConfiguration(ctx, bucketName)
+		if err != nil {
+			return nil, err
+		}
+		putMustBeSynchronous = versioningConfig.Status != nil && *versioningConfig.Status == storage.BucketVersioningStatusEnabled
+	}
+
+	if putMustBeSynchronous {
 		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
 		if err != nil {
 			return nil, err
@@ -531,7 +547,7 @@ func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.Bucke
 		return nil, err
 	}
 	_, calculatedChecksums, err := checksumutils.CalculateChecksumsStreaming(ctx, reader, func(reader io.Reader) error {
-		entryId, err := os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.PutObjectStorageOperation, bucketName, key.String())
+		entryId, err := os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.PutObjectStorageOperation, bucketName, key.String(), nil)
 		if err != nil {
 			return err
 		}
@@ -607,9 +623,8 @@ func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.Bu
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObject")
 	defer span.End()
 
-	// Version-specific / conditional deletes must execute synchronously to
-	// preserve exact semantics because outbox entries currently only persist key.
-	if opts != nil && (opts.VersionID != nil || opts.IfMatchETag != nil) {
+	// ETag-conditional deletes must execute synchronously.
+	if opts != nil && opts.IfMatchETag != nil {
 		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
 		if err != nil {
 			return nil, err
@@ -621,7 +636,11 @@ func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.Bu
 	if err != nil {
 		return nil, err
 	}
-	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, key.String())
+	var versionID *string
+	if opts != nil {
+		versionID = opts.VersionID
+	}
+	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, key.String(), versionID)
 	if err != nil {
 		tx.Rollback()
 		return nil, err
@@ -630,21 +649,21 @@ func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.Bu
 	if err != nil {
 		return nil, err
 	}
-	return &storage.DeleteObjectResult{}, nil
+	return &storage.DeleteObjectResult{VersionID: versionID}, nil
 }
 
 func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObjects")
 	defer span.End()
 
-	hasVersionOrCondition := false
+	hasETagCondition := false
 	for _, entry := range entries {
-		if entry.VersionID != nil || entry.IfMatchETag != nil {
-			hasVersionOrCondition = true
+		if entry.IfMatchETag != nil {
+			hasETagCondition = true
 			break
 		}
 	}
-	if hasVersionOrCondition {
+	if hasETagCondition {
 		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
 		if err != nil {
 			return nil, err
@@ -658,7 +677,7 @@ func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.B
 	}
 
 	for _, entry := range entries {
-		_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, entry.Key.String())
+		_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, entry.Key.String(), entry.VersionID)
 		if err != nil {
 			tx.Rollback()
 			return nil, err
@@ -674,7 +693,7 @@ func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.B
 		Entries: make([]storage.DeleteObjectsEntry, len(entries)),
 	}
 	for i, entry := range entries {
-		result.Entries[i] = storage.DeleteObjectsEntry{Key: entry.Key, Deleted: true}
+		result.Entries[i] = storage.DeleteObjectsEntry{Key: entry.Key, VersionID: entry.VersionID, Deleted: true}
 	}
 	return result, nil
 }

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -539,10 +540,12 @@ func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.Bucke
 	putMustBeSynchronous := opts != nil && (opts.IfNoneMatchStar || opts.IfMatchETag != nil)
 	if !putMustBeSynchronous {
 		versioningConfig, err := os.innerStorage.GetBucketVersioningConfiguration(ctx, bucketName)
-		if err != nil {
+		if err != nil && !errors.Is(err, storage.ErrNoSuchBucket) {
 			return nil, err
 		}
-		putMustBeSynchronous = versioningConfig.Status != nil && *versioningConfig.Status == storage.BucketVersioningStatusEnabled
+		if err == nil {
+			putMustBeSynchronous = versioningConfig.Status != nil && *versioningConfig.Status == storage.BucketVersioningStatusEnabled
+		}
 	}
 
 	if putMustBeSynchronous {

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -193,7 +193,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 				return
 			}
 		case storageOutboxEntry.DeleteObjectStorageOperation:
-			err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
+			_, err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
 			if err != nil {
 				tx.Rollback()
 				os.metrics.errorsCounter.Inc()
@@ -440,6 +440,30 @@ func (os *outboxStorage) HeadBucket(ctx context.Context, bucketName storage.Buck
 	return os.innerStorage.HeadBucket(ctx, bucketName)
 }
 
+func (os *outboxStorage) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := os.tracer.Start(ctx, "OutboxStorage.GetBucketVersioningConfiguration")
+	defer span.End()
+
+	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.innerStorage.GetBucketVersioningConfiguration(ctx, bucketName)
+}
+
+func (os *outboxStorage) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := os.tracer.Start(ctx, "OutboxStorage.PutBucketVersioningConfiguration")
+	defer span.End()
+
+	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	if err != nil {
+		return err
+	}
+
+	return os.innerStorage.PutBucketVersioningConfiguration(ctx, bucketName, config)
+}
+
 func (os *outboxStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.ListObjects")
 	defer span.End()
@@ -450,6 +474,18 @@ func (os *outboxStorage) ListObjects(ctx context.Context, bucketName storage.Buc
 	}
 
 	return os.innerStorage.ListObjects(ctx, bucketName, opts)
+}
+
+func (os *outboxStorage) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := os.tracer.Start(ctx, "OutboxStorage.ListObjectVersions")
+	defer span.End()
+
+	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.innerStorage.ListObjectVersions(ctx, bucketName, opts)
 }
 
 func (os *outboxStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
@@ -567,29 +603,54 @@ func (os *outboxStorage) AppendObject(ctx context.Context, bucketName storage.Bu
 	return os.innerStorage.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
 }
 
-func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (os *outboxStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObject")
 	defer span.End()
 
+	// Version-specific / conditional deletes must execute synchronously to
+	// preserve exact semantics because outbox entries currently only persist key.
+	if opts != nil && (opts.VersionID != nil || opts.IfMatchETag != nil) {
+		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+		if err != nil {
+			return nil, err
+		}
+		return os.innerStorage.DeleteObject(ctx, bucketName, key, opts)
+	}
+
 	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	_, err = os.storeStorageOutboxEntry(ctx, tx, storageOutboxEntry.DeleteObjectStorageOperation, bucketName, key.String())
 	if err != nil {
 		tx.Rollback()
-		return err
+		return nil, err
 	}
 	err = tx.Commit()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return &storage.DeleteObjectResult{}, nil
 }
 
 func (os *outboxStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.DeleteObjects")
 	defer span.End()
+
+	hasVersionOrCondition := false
+	for _, entry := range entries {
+		if entry.VersionID != nil || entry.IfMatchETag != nil {
+			hasVersionOrCondition = true
+			break
+		}
+	}
+	if hasVersionOrCondition {
+		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+		if err != nil {
+			return nil, err
+		}
+		return os.innerStorage.DeleteObjects(ctx, bucketName, entries)
+	}
 
 	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
 	if err != nil {

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -124,11 +124,37 @@ func (rs *replicationStorage) HeadBucket(ctx context.Context, bucketName storage
 	return rs.primaryStorage.HeadBucket(ctx, bucketName)
 }
 
+func (rs *replicationStorage) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.GetBucketVersioningConfiguration")
+	defer span.End()
+	return rs.primaryStorage.GetBucketVersioningConfiguration(ctx, bucketName)
+}
+
+func (rs *replicationStorage) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.PutBucketVersioningConfiguration")
+	defer span.End()
+	if err := rs.primaryStorage.PutBucketVersioningConfiguration(ctx, bucketName, config); err != nil {
+		return err
+	}
+	for _, secondaryStorage := range rs.secondaryStorages {
+		if err := secondaryStorage.PutBucketVersioningConfiguration(ctx, bucketName, config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (rs *replicationStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.ListObjects")
 	defer span.End()
 
 	return rs.primaryStorage.ListObjects(ctx, bucketName, opts)
+}
+
+func (rs *replicationStorage) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.ListObjectVersions")
+	defer span.End()
+	return rs.primaryStorage.ListObjectVersions(ctx, bucketName, opts)
 }
 
 func (rs *replicationStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
@@ -207,21 +233,21 @@ func (rs *replicationStorage) AppendObject(ctx context.Context, bucketName stora
 	return appendObjectResult, nil
 }
 
-func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObject")
 	defer span.End()
 
-	err := rs.primaryStorage.DeleteObject(ctx, bucketName, key, opts)
+	result, err := rs.primaryStorage.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, secondaryStorage := range rs.secondaryStorages {
-		err = secondaryStorage.DeleteObject(ctx, bucketName, key, opts)
+		_, err = secondaryStorage.DeleteObject(ctx, bucketName, key, opts)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return result, nil
 }
 
 func (rs *replicationStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -522,6 +522,7 @@ func (rs *s3ClientStorage) CompleteMultipartUpload(ctx context.Context, bucketNa
 	}
 	return &storage.CompleteMultipartUploadResult{
 		Location:          *completeMultipartUploadResult.Location,
+		VersionID:         completeMultipartUploadResult.VersionId,
 		ETag:              *completeMultipartUploadResult.ETag,
 		ChecksumCRC32:     completeMultipartUploadResult.ChecksumCRC32,
 		ChecksumCRC32C:    completeMultipartUploadResult.ChecksumCRC32C,

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -123,6 +123,33 @@ func (rs *s3ClientStorage) HeadBucket(ctx context.Context, bucketName storage.Bu
 	}, nil
 }
 
+func (rs *s3ClientStorage) GetBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.BucketVersioningConfiguration, error) {
+	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.GetBucketVersioningConfiguration")
+	defer span.End()
+
+	result, err := rs.s3Client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(bucketName.String())})
+	if err != nil {
+		return nil, err
+	}
+	if result.Status == "" {
+		return &storage.BucketVersioningConfiguration{}, nil
+	}
+	status := storage.BucketVersioningStatus(result.Status)
+	return &storage.BucketVersioningConfiguration{Status: &status}, nil
+}
+
+func (rs *s3ClientStorage) PutBucketVersioningConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.BucketVersioningConfiguration) error {
+	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.PutBucketVersioningConfiguration")
+	defer span.End()
+
+	status := types.BucketVersioningStatusSuspended
+	if config != nil && config.Status != nil && *config.Status == storage.BucketVersioningStatusEnabled {
+		status = types.BucketVersioningStatusEnabled
+	}
+	_, err := rs.s3Client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{Bucket: aws.String(bucketName.String()), VersioningConfiguration: &types.VersioningConfiguration{Status: status}})
+	return err
+}
+
 func (rs *s3ClientStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.ListObjects")
 	defer span.End()
@@ -160,6 +187,39 @@ func (rs *s3ClientStorage) ListObjects(ctx context.Context, bucketName storage.B
 	}, nil
 }
 
+func (rs *s3ClientStorage) ListObjectVersions(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectVersionsOptions) (*storage.ListObjectVersionsResult, error) {
+	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.ListObjectVersions")
+	defer span.End()
+
+	result, err := rs.s3Client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+		Bucket:          aws.String(bucketName.String()),
+		Prefix:          opts.Prefix,
+		Delimiter:       opts.Delimiter,
+		KeyMarker:       opts.KeyMarker,
+		VersionIdMarker: opts.VersionIDMarker,
+		MaxKeys:         aws.Int32(opts.MaxKeys),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	versions := []storage.ObjectVersion{}
+	for _, version := range result.Versions {
+		if version.Key == nil || version.VersionId == nil || version.LastModified == nil {
+			continue
+		}
+		versions = append(versions, storage.ObjectVersion{Key: storage.MustNewObjectKey(*version.Key), VersionID: *version.VersionId, IsDeleteMarker: false, IsLatest: aws.ToBool(version.IsLatest), LastModified: *version.LastModified, Size: aws.ToInt64(version.Size), ETag: version.ETag})
+	}
+	for _, marker := range result.DeleteMarkers {
+		if marker.Key == nil || marker.VersionId == nil || marker.LastModified == nil {
+			continue
+		}
+		versions = append(versions, storage.ObjectVersion{Key: storage.MustNewObjectKey(*marker.Key), VersionID: *marker.VersionId, IsDeleteMarker: true, IsLatest: aws.ToBool(marker.IsLatest), LastModified: *marker.LastModified})
+	}
+
+	return &storage.ListObjectVersionsResult{Versions: versions, IsTruncated: aws.ToBool(result.IsTruncated), NextKeyMarker: result.NextKeyMarker, NextVersionIDMarker: result.NextVersionIdMarker}, nil
+}
+
 func (rs *s3ClientStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.HeadObject")
 	defer span.End()
@@ -167,6 +227,12 @@ func (rs *s3ClientStorage) HeadObject(ctx context.Context, bucketName storage.Bu
 	headObjectResult, err := rs.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(bucketName.String()),
 		Key:    aws.String(key.String()),
+		VersionId: func() *string {
+			if opts != nil {
+				return opts.VersionID
+			}
+			return nil
+		}(),
 	})
 	var notFoundError *types.NotFound
 	if err != nil && errors.As(err, &notFoundError) {
@@ -178,6 +244,8 @@ func (rs *s3ClientStorage) HeadObject(ctx context.Context, bucketName storage.Bu
 	return &storage.Object{
 		Key:               key,
 		LastModified:      *headObjectResult.LastModified,
+		VersionID:         headObjectResult.VersionId,
+		IsDeleteMarker:    aws.ToBool(headObjectResult.DeleteMarker),
 		ETag:              *headObjectResult.ETag,
 		ChecksumCRC32:     headObjectResult.ChecksumCRC32,
 		ChecksumCRC32C:    headObjectResult.ChecksumCRC32C,
@@ -225,6 +293,12 @@ func (rs *s3ClientStorage) GetObject(ctx context.Context, bucketName storage.Buc
 			Bucket: aws.String(bucketName.String()),
 			Key:    aws.String(key.String()),
 			Range:  awsRange,
+			VersionId: func() *string {
+				if opts != nil {
+					return opts.VersionID
+				}
+				return nil
+			}(),
 		})
 		var notFoundError *types.NotFound
 		if err != nil && errors.As(err, &notFoundError) {
@@ -296,7 +370,7 @@ func (rs *s3ClientStorage) AppendObject(_ context.Context, _ storage.BucketName,
 	return nil, storage.ErrNotImplemented
 }
 
-func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) (*storage.DeleteObjectResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "S3ClientStorage.DeleteObject")
 	defer span.End()
 
@@ -307,15 +381,18 @@ func (rs *s3ClientStorage) DeleteObject(ctx context.Context, bucketName storage.
 	if opts != nil && opts.IfMatchETag != nil {
 		input.IfMatch = opts.IfMatchETag
 	}
-	_, err := rs.s3Client.DeleteObject(ctx, input)
+	if opts != nil && opts.VersionID != nil {
+		input.VersionId = opts.VersionID
+	}
+	result, err := rs.s3Client.DeleteObject(ctx, input)
 	var notFoundError *types.NotFound
 	if err != nil && errors.As(err, &notFoundError) {
-		return storage.ErrNoSuchBucket
+		return nil, storage.ErrNoSuchBucket
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return &storage.DeleteObjectResult{VersionID: result.VersionId, IsDeleteMarker: aws.ToBool(result.DeleteMarker)}, nil
 }
 
 func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
@@ -325,7 +402,7 @@ func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage
 	identifiers := make([]types.ObjectIdentifier, len(entries))
 	for i, entry := range entries {
 		k := entry.Key.String()
-		identifiers[i] = types.ObjectIdentifier{Key: &k}
+		identifiers[i] = types.ObjectIdentifier{Key: &k, VersionId: entry.VersionID}
 	}
 
 	deleteResult, err := rs.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
@@ -353,7 +430,7 @@ func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage
 
 	for _, deleted := range deleteResult.Deleted {
 		key := storage.MustNewObjectKey(*deleted.Key)
-		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: true})
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, VersionID: deleted.VersionId, DeleteMarkerVersionID: deleted.DeleteMarkerVersionId, DeleteMarker: deleted.DeleteMarker, Deleted: true})
 	}
 	for _, errEntry := range deleteResult.Errors {
 		key := storage.MustNewObjectKey(*errEntry.Key)
@@ -365,7 +442,7 @@ func (rs *s3ClientStorage) DeleteObjects(ctx context.Context, bucketName storage
 		if errEntry.Message != nil {
 			msg = *errEntry.Message
 		}
-		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, Deleted: false, ErrCode: code, ErrMsg: msg})
+		result.Entries = append(result.Entries, storage.DeleteObjectsEntry{Key: key, VersionID: errEntry.VersionId, Deleted: false, ErrCode: code, ErrMsg: msg})
 	}
 
 	return result, nil

--- a/internal/storage/s3client/s3client.go
+++ b/internal/storage/s3client/s3client.go
@@ -128,6 +128,12 @@ func (rs *s3ClientStorage) GetBucketVersioningConfiguration(ctx context.Context,
 	defer span.End()
 
 	result, err := rs.s3Client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(bucketName.String())})
+	var notFoundError *types.NotFound
+	var noSuchBucketError *types.NoSuchBucket
+	var apiErr smithy.APIError
+	if err != nil && (errors.As(err, &notFoundError) || errors.As(err, &noSuchBucketError) || (errors.As(err, &apiErr) && (apiErr.ErrorCode() == "NoSuchBucket" || apiErr.ErrorCode() == "NotFound"))) {
+		return nil, storage.ErrNoSuchBucket
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -18,10 +18,23 @@ type Bucket struct {
 	CreationDate time.Time
 }
 
+type BucketVersioningStatus string
+
+const (
+	BucketVersioningStatusEnabled   BucketVersioningStatus = "Enabled"
+	BucketVersioningStatusSuspended BucketVersioningStatus = "Suspended"
+)
+
+type BucketVersioningConfiguration struct {
+	Status *BucketVersioningStatus
+}
+
 type Object struct {
 	Key               ObjectKey
 	ContentType       *string
 	LastModified      time.Time
+	VersionID         *string
+	IsDeleteMarker    bool
 	ETag              string
 	ChecksumCRC32     *string
 	ChecksumCRC32C    *string
@@ -52,6 +65,7 @@ type ListBucketResult struct {
 }
 
 type PutObjectResult struct {
+	VersionID         *string
 	ETag              *string
 	ChecksumCRC32     *string
 	ChecksumCRC32C    *string
@@ -87,6 +101,7 @@ const ChecksumTypeFullObject = metadatastore.ChecksumTypeFullObject
 const ChecksumTypeComposite = metadatastore.ChecksumTypeComposite
 
 type DeleteObjectOptions struct {
+	VersionID *string
 	// IfMatchETag, when non-nil, requires the stored object's ETag to equal this
 	// value before deleting; otherwise ErrPreconditionFailed is returned.
 	// The special value "*" matches any existing object (i.e. HTTP If-Match: *),
@@ -94,9 +109,15 @@ type DeleteObjectOptions struct {
 	IfMatchETag *string
 }
 
+type DeleteObjectResult struct {
+	VersionID      *string
+	IsDeleteMarker bool
+}
+
 // HeadObjectOptions holds conditional request options for HeadObject.
 // ETag values must be bare hex strings (without surrounding quotes).
 type HeadObjectOptions struct {
+	VersionID *string
 	// IfMatchETag, when non-nil, requires the stored object's ETag to match;
 	// otherwise ErrPreconditionFailed is returned.
 	// The special value "*" matches any existing object.
@@ -110,6 +131,7 @@ type HeadObjectOptions struct {
 // GetObjectOptions holds conditional request options for GetObject.
 // ETag values must be bare hex strings (without surrounding quotes).
 type GetObjectOptions struct {
+	VersionID *string
 	// IfMatchETag, when non-nil, requires the stored object's ETag to match;
 	// otherwise ErrPreconditionFailed is returned.
 	// The special value "*" matches any existing object.
@@ -189,10 +211,13 @@ type ListPartsResult struct {
 
 // DeleteObjectsEntry represents the result for a single key in a DeleteObjects operation.
 type DeleteObjectsEntry struct {
-	Key     ObjectKey
-	Deleted bool
-	ErrCode string
-	ErrMsg  string
+	VersionID             *string
+	DeleteMarker          *bool
+	DeleteMarkerVersionID *string
+	Key                   ObjectKey
+	Deleted               bool
+	ErrCode               string
+	ErrMsg                string
 }
 
 // DeleteObjectsResult is the per-key result of a bulk DeleteObjects operation.
@@ -203,7 +228,34 @@ type DeleteObjectsResult struct {
 // DeleteObjectsInputEntry represents a single entry in a bulk DeleteObjects request, optionally with a conditional ETag.
 type DeleteObjectsInputEntry struct {
 	Key         ObjectKey
+	VersionID   *string
 	IfMatchETag *string
+}
+
+type ObjectVersion struct {
+	Key            ObjectKey
+	VersionID      string
+	IsDeleteMarker bool
+	IsLatest       bool
+	LastModified   time.Time
+	Size           int64
+	ETag           *string
+}
+
+type ListObjectVersionsOptions struct {
+	Prefix          *string
+	Delimiter       *string
+	KeyMarker       *string
+	VersionIDMarker *string
+	MaxKeys         int32
+}
+
+type ListObjectVersionsResult struct {
+	Versions            []ObjectVersion
+	CommonPrefixes      []string
+	IsTruncated         bool
+	NextKeyMarker       *string
+	NextVersionIDMarker *string
 }
 
 type ChecksumInput = metadatastore.ChecksumInput
@@ -242,6 +294,23 @@ var ErrNoSuchWebsiteConfiguration error = metadatastore.ErrNoSuchWebsiteConfigur
 var ErrTooManyParts error = metadatastore.ErrTooManyParts
 var ErrInvalidWriteOffset error = metadatastore.ErrInvalidWriteOffset
 var ErrCASFailure error = metadatastore.ErrCASFailure
+
+type CurrentDeleteMarkerError struct {
+	VersionID string
+}
+
+func (e *CurrentDeleteMarkerError) Error() string {
+	return ErrNoSuchKey.Error()
+}
+
+type VersionDeleteMarkerMethodNotAllowedError struct {
+	VersionID    string
+	LastModified time.Time
+}
+
+func (e *VersionDeleteMarkerMethodNotAllowedError) Error() string {
+	return "MethodNotAllowed"
+}
 
 var MaxEntitySize int64 = 5 * 1000 * 1000 * 1000 // 5 GB
 
@@ -285,6 +354,8 @@ type BucketManager interface {
 	DeleteBucket(ctx context.Context, bucketName BucketName) error
 	ListBuckets(ctx context.Context) ([]Bucket, error)
 	HeadBucket(ctx context.Context, bucketName BucketName) (*Bucket, error)
+	GetBucketVersioningConfiguration(ctx context.Context, bucketName BucketName) (*BucketVersioningConfiguration, error)
+	PutBucketVersioningConfiguration(ctx context.Context, bucketName BucketName, config *BucketVersioningConfiguration) error
 }
 
 type WebsiteConfiguration = metadatastore.WebsiteConfiguration
@@ -298,6 +369,7 @@ type BucketWebsiteManager interface {
 // ObjectManager manages object operations
 type ObjectManager interface {
 	ListObjects(ctx context.Context, bucketName BucketName, opts ListObjectsOptions) (*ListBucketResult, error)
+	ListObjectVersions(ctx context.Context, bucketName BucketName, opts ListObjectVersionsOptions) (*ListObjectVersionsResult, error)
 	HeadObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *HeadObjectOptions) (*Object, error)
 	// GetObject retrieves an object with optional byte ranges.
 	// If ranges is empty or nil, returns the entire object as a single reader.
@@ -309,7 +381,7 @@ type ObjectManager interface {
 	// it behaves like PutObject and creates a new object with the provided data.
 	// The ETag in the result reflects the new whole-object ETag after the append.
 	AppendObject(ctx context.Context, bucketName BucketName, key ObjectKey, data io.Reader, checksumInput *ChecksumInput, opts *AppendObjectOptions) (*AppendObjectResult, error)
-	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) error
+	DeleteObject(ctx context.Context, bucketName BucketName, key ObjectKey, opts *DeleteObjectOptions) (*DeleteObjectResult, error)
 	DeleteObjects(ctx context.Context, bucketName BucketName, entries []DeleteObjectsInputEntry) (*DeleteObjectsResult, error)
 }
 
@@ -420,7 +492,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return errors.New("invalid object key")
 		}
 
-		err = storage.DeleteObject(ctx, bucketName, key, nil)
+		_, err = storage.DeleteObject(ctx, bucketName, key, nil)
 		if err != nil {
 			return err
 		}
@@ -445,7 +517,7 @@ func Tester(storage Storage, bucketNames []BucketName, content []byte) error {
 			return err
 		}
 
-		err = storage.DeleteObject(ctx, bucketName, key, nil)
+		_, err = storage.DeleteObject(ctx, bucketName, key, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -157,6 +157,7 @@ type UploadPartResult struct {
 
 type CompleteMultipartUploadResult struct {
 	Location          string
+	VersionID         *string
 	ETag              string
 	ChecksumCRC32     *string
 	ChecksumCRC32C    *string


### PR DESCRIPTION
Add bucket/object versioning control and data model support, wire version-aware object operations, and align delete-marker, multipart, and listing semantics so clients can use AWS-compatible versioning flows end-to-end.