### PR TITLE
refactor(storage): centralize middleware delegation and reduce boilerplate

### DIFF
--- a/internal/storage/cache/cachestorage.go
+++ b/internal/storage/cache/cachestorage.go
@@ -11,27 +11,27 @@ import (
 	"github.com/jdillenkofer/pithos/internal/ioutils"
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/storage"
+	"github.com/jdillenkofer/pithos/internal/storage/middlewares/delegator"
 )
 
 type CacheStorage struct {
 	*lifecycle.ValidatedLifecycle
-	cache        Cache
-	innerStorage storage.Storage
-	tracer       trace.Tracer
+	delegator.DelegatingStorage
+	cache  Cache
+	tracer trace.Tracer
 }
 
-// Compile-time check to ensure CacheStorage implements storage.Storage
 var _ storage.Storage = (*CacheStorage)(nil)
 
 func New(cache Cache, innerStorage storage.Storage) (storage.Storage, error) {
-	lifecycle, err := lifecycle.NewValidatedLifecycle("CacheStorage")
+	lc, err := lifecycle.NewValidatedLifecycle("CacheStorage")
 	if err != nil {
 		return nil, err
 	}
 	return &CacheStorage{
-		ValidatedLifecycle: lifecycle,
+		ValidatedLifecycle: lc,
+		DelegatingStorage:  delegator.Wrap(innerStorage),
 		cache:              cache,
-		innerStorage:       innerStorage,
 		tracer:             otel.Tracer("internal/storage/cache"),
 	}, nil
 }
@@ -44,93 +44,25 @@ func (cs *CacheStorage) Start(ctx context.Context) error {
 	if err := cs.ValidatedLifecycle.Start(ctx); err != nil {
 		return err
 	}
-	return cs.innerStorage.Start(ctx)
+	return cs.Next.Start(ctx)
 }
 
 func (cs *CacheStorage) Stop(ctx context.Context) error {
 	if err := cs.ValidatedLifecycle.Stop(ctx); err != nil {
 		return err
 	}
-	return cs.innerStorage.Stop(ctx)
-}
-
-func (cs *CacheStorage) CreateBucket(ctx context.Context, bucketName storage.BucketName) error {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.CreateBucket")
-	defer span.End()
-
-	err := cs.innerStorage.CreateBucket(ctx, bucketName)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (cs *CacheStorage) DeleteBucket(ctx context.Context, bucketName storage.BucketName) error {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteBucket")
-	defer span.End()
-
-	err := cs.innerStorage.DeleteBucket(ctx, bucketName)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (cs *CacheStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.ListBuckets")
-	defer span.End()
-
-	buckets, err := cs.innerStorage.ListBuckets(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return buckets, nil
-}
-
-func (cs *CacheStorage) HeadBucket(ctx context.Context, bucketName storage.BucketName) (*storage.Bucket, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.HeadBucket")
-	defer span.End()
-
-	bucket, err := cs.innerStorage.HeadBucket(ctx, bucketName)
-	if err != nil {
-		return nil, err
-	}
-	return bucket, nil
-}
-
-func (cs *CacheStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.ListObjects")
-	defer span.End()
-
-	objects, err := cs.innerStorage.ListObjects(ctx, bucketName, opts)
-	if err != nil {
-		return nil, err
-	}
-	return objects, nil
-}
-
-func (cs *CacheStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.HeadObject")
-	defer span.End()
-
-	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key, opts)
-	if err != nil {
-		return nil, err
-	}
-	return object, nil
+	return cs.Next.Stop(ctx)
 }
 
 func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.GetObject")
 	defer span.End()
 
-	// If no ranges specified, get the entire object
 	if len(ranges) == 0 {
 		ranges = []storage.ByteRange{{Start: nil, End: nil}}
 	}
 
-	// Get object metadata
-	object, err := cs.innerStorage.HeadObject(ctx, bucketName, key, nil)
+	object, err := cs.Next.HeadObject(ctx, bucketName, key, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,8 +74,7 @@ func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.Bucket
 	}
 
 	if err == ErrCacheMiss {
-		// @TODO: only cache byteRange that was requested
-		_, readers, err := cs.innerStorage.GetObject(ctx, bucketName, key, nil, opts)
+		_, readers, err := cs.Next.GetObject(ctx, bucketName, key, nil, opts)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -164,23 +95,18 @@ func (cs *CacheStorage) GetObject(ctx context.Context, bucketName storage.Bucket
 		}
 	}
 
-	// Create readers for each range
 	readers := []io.ReadCloser{}
 	for _, byteRange := range ranges {
 		startByte := byteRange.Start
 		endByte := byteRange.End
 
 		var reader io.ReadCloser = ioutils.NewByteReadSeekCloser(data)
-
-		// We need to apply the LimitedEndReadSeekCloser first, otherwise we need to recalculate the end offset
-		// because the LimitedStartSeekCloser changes the offsets
 		if endByte != nil {
 			reader = ioutils.NewLimitedEndReadCloser(reader, *endByte)
 		}
 		if startByte != nil {
 			_, err := ioutils.SkipNBytes(reader, *startByte)
 			if err != nil {
-				// Close any readers we've already opened
 				for _, r := range readers {
 					r.Close()
 				}
@@ -203,7 +129,7 @@ func (cs *CacheStorage) PutObject(ctx context.Context, bucketName storage.Bucket
 	}
 	byteReadSeekCloser := ioutils.NewByteReadSeekCloser(data)
 
-	putObjectResult, err := cs.innerStorage.PutObject(ctx, bucketName, key, contentType, byteReadSeekCloser, checksumInput, opts)
+	putObjectResult, err := cs.Next.PutObject(ctx, bucketName, key, contentType, byteReadSeekCloser, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -221,12 +147,11 @@ func (cs *CacheStorage) AppendObject(ctx context.Context, bucketName storage.Buc
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.AppendObject")
 	defer span.End()
 
-	appendObjectResult, err := cs.innerStorage.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
+	appendObjectResult, err := cs.Next.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	// Invalidate the cached object so subsequent reads see the new content.
 	cacheKey := getObjectCacheKeyForBucketAndKey(bucketName, key)
 	_ = cs.cache.Remove(cacheKey)
 
@@ -237,7 +162,7 @@ func (cs *CacheStorage) DeleteObject(ctx context.Context, bucketName storage.Buc
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObject")
 	defer span.End()
 
-	err := cs.innerStorage.DeleteObject(ctx, bucketName, key, opts)
+	err := cs.Next.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
 		return err
 	}
@@ -254,7 +179,7 @@ func (cs *CacheStorage) DeleteObjects(ctx context.Context, bucketName storage.Bu
 	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteObjects")
 	defer span.End()
 
-	result, err := cs.innerStorage.DeleteObjects(ctx, bucketName, entries)
+	result, err := cs.Next.DeleteObjects(ctx, bucketName, entries)
 	if err != nil {
 		return nil, err
 	}
@@ -262,96 +187,9 @@ func (cs *CacheStorage) DeleteObjects(ctx context.Context, bucketName storage.Bu
 	for _, entry := range result.Entries {
 		if entry.Deleted {
 			cacheKey := getObjectCacheKeyForBucketAndKey(bucketName, entry.Key)
-			_ = cs.cache.Remove(cacheKey) // best-effort cache eviction
+			_ = cs.cache.Remove(cacheKey)
 		}
 	}
 
 	return result, nil
-}
-
-func (cs *CacheStorage) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.CreateMultipartUpload")
-	defer span.End()
-
-	initiateMultipartUploadResult, err := cs.innerStorage.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
-	if err != nil {
-		return nil, err
-	}
-	return initiateMultipartUploadResult, nil
-}
-
-func (cs *CacheStorage) UploadPart(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, partNumber int32, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.UploadPartResult, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.UploadPart")
-	defer span.End()
-
-	uploadPartResult, err := cs.innerStorage.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
-	if err != nil {
-		return nil, err
-	}
-	return uploadPartResult, nil
-}
-
-func (cs *CacheStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.CompleteMultipartUpload")
-	defer span.End()
-
-	completeMultipartUploadResult, err := cs.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
-	if err != nil {
-		return nil, err
-	}
-	return completeMultipartUploadResult, nil
-}
-
-func (cs *CacheStorage) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.AbortMultipartUpload")
-	defer span.End()
-
-	err := cs.innerStorage.AbortMultipartUpload(ctx, bucketName, key, uploadId)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (cs *CacheStorage) ListMultipartUploads(ctx context.Context, bucketName storage.BucketName, opts storage.ListMultipartUploadsOptions) (*storage.ListMultipartUploadsResult, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.ListMultipartUploads")
-	defer span.End()
-
-	listMultipartUploadsResult, err := cs.innerStorage.ListMultipartUploads(ctx, bucketName, opts)
-	if err != nil {
-		return nil, err
-	}
-	return listMultipartUploadsResult, nil
-}
-
-func (cs *CacheStorage) ListParts(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, opts storage.ListPartsOptions) (*storage.ListPartsResult, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.ListParts")
-	defer span.End()
-
-	listPartsResult, err := cs.innerStorage.ListParts(ctx, bucketName, key, uploadId, opts)
-	if err != nil {
-		return nil, err
-	}
-	return listPartsResult, nil
-}
-
-func (cs *CacheStorage) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.GetBucketWebsiteConfiguration")
-	defer span.End()
-
-	return cs.innerStorage.GetBucketWebsiteConfiguration(ctx, bucketName)
-}
-
-func (cs *CacheStorage) PutBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.WebsiteConfiguration) error {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.PutBucketWebsiteConfiguration")
-	defer span.End()
-
-	return cs.innerStorage.PutBucketWebsiteConfiguration(ctx, bucketName, config)
-}
-
-func (cs *CacheStorage) DeleteBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) error {
-	ctx, span := cs.tracer.Start(ctx, "CacheStorage.DeleteBucketWebsiteConfiguration")
-	defer span.End()
-
-	return cs.innerStorage.DeleteBucketWebsiteConfiguration(ctx, bucketName)
 }

--- a/internal/storage/middlewares/audit/audit.go
+++ b/internal/storage/middlewares/audit/audit.go
@@ -14,11 +14,12 @@ import (
 	"github.com/jdillenkofer/pithos/internal/http/server/authentication"
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/storage"
+	"github.com/jdillenkofer/pithos/internal/storage/middlewares/delegator"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type AuditLogMiddleware struct {
-	next        storage.Storage
+	delegator.DelegatingStorage
 	sink        sink.Sink
 	signer      signing.Signer
 	mlDsaSigner signing.Signer
@@ -27,9 +28,24 @@ type AuditLogMiddleware struct {
 	mu          sync.Mutex
 }
 
+type auditResource struct {
+	bucket     string
+	key        string
+	uploadID   string
+	partNumber int32
+}
+
+func (m *AuditLogMiddleware) run(ctx context.Context, op auditlog.Operation, resource auditResource, fn func(context.Context) error) error {
+	start := time.Now()
+	m.log(ctx, op, auditlog.PhaseStart, resource.bucket, resource.key, resource.uploadID, resource.partNumber, nil, 0, 0)
+	err := fn(ctx)
+	m.log(ctx, op, auditlog.PhaseComplete, resource.bucket, resource.key, resource.uploadID, resource.partNumber, err, statusCodeFromError(err), time.Since(start).Milliseconds())
+	return err
+}
+
 func NewAuditLogMiddleware(next storage.Storage, sink sink.Sink, signer signing.Signer, mlDsaSigner signing.Signer, lastHash []byte, initialHashBuffer [][]byte) *AuditLogMiddleware {
 	m := &AuditLogMiddleware{
-		next:        next,
+		DelegatingStorage: delegator.Wrap(next),
 		sink:        sink,
 		signer:      signer,
 		mlDsaSigner: mlDsaSigner,
@@ -189,130 +205,136 @@ func (m *AuditLogMiddleware) emitGrounding() {
 }
 
 func (m *AuditLogMiddleware) Start(ctx context.Context) error {
-	return m.next.Start(ctx)
+	return m.Next.Start(ctx)
 }
 
 func (m *AuditLogMiddleware) Stop(ctx context.Context) error {
 	_ = m.sink.Close()
-	return m.next.Stop(ctx)
+	return m.Next.Stop(ctx)
 }
 
 func (m *AuditLogMiddleware) CreateBucket(ctx context.Context, bucketName storage.BucketName) error {
-	start := time.Now()
-	m.log(ctx, auditlog.OpCreateBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	err := m.next.CreateBucket(ctx, bucketName)
-	m.log(ctx, auditlog.OpCreateBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return m.run(ctx, auditlog.OpCreateBucket, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		return m.Next.CreateBucket(ctx, bucketName)
+	})
 }
 
 func (m *AuditLogMiddleware) DeleteBucket(ctx context.Context, bucketName storage.BucketName) error {
-	start := time.Now()
-	m.log(ctx, auditlog.OpDeleteBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	err := m.next.DeleteBucket(ctx, bucketName)
-	m.log(ctx, auditlog.OpDeleteBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return m.run(ctx, auditlog.OpDeleteBucket, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		return m.Next.DeleteBucket(ctx, bucketName)
+	})
 }
 
 func (m *AuditLogMiddleware) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpListBuckets, auditlog.PhaseStart, "", "", "", 0, nil, 0, 0)
-	buckets, err := m.next.ListBuckets(ctx)
-	m.log(ctx, auditlog.OpListBuckets, auditlog.PhaseComplete, "", "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return buckets, err
+	var result []storage.Bucket
+	err := m.run(ctx, auditlog.OpListBuckets, auditResource{}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.ListBuckets(ctx)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) HeadBucket(ctx context.Context, bucketName storage.BucketName) (*storage.Bucket, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpHeadBucket, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	bucket, err := m.next.HeadBucket(ctx, bucketName)
-	m.log(ctx, auditlog.OpHeadBucket, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return bucket, err
+	var result *storage.Bucket
+	err := m.run(ctx, auditlog.OpHeadBucket, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.HeadBucket(ctx, bucketName)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	config, err := m.next.GetBucketWebsiteConfiguration(ctx, bucketName)
-	m.log(ctx, auditlog.OpGetBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return config, err
+	var result *storage.WebsiteConfiguration
+	err := m.run(ctx, auditlog.OpGetBucketWebsite, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.GetBucketWebsiteConfiguration(ctx, bucketName)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) PutBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.WebsiteConfiguration) error {
-	start := time.Now()
-	m.log(ctx, auditlog.OpPutBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	err := m.next.PutBucketWebsiteConfiguration(ctx, bucketName, config)
-	m.log(ctx, auditlog.OpPutBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return m.run(ctx, auditlog.OpPutBucketWebsite, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		return m.Next.PutBucketWebsiteConfiguration(ctx, bucketName, config)
+	})
 }
 
 func (m *AuditLogMiddleware) DeleteBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) error {
-	start := time.Now()
-	m.log(ctx, auditlog.OpDeleteBucketWebsite, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	err := m.next.DeleteBucketWebsiteConfiguration(ctx, bucketName)
-	m.log(ctx, auditlog.OpDeleteBucketWebsite, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return m.run(ctx, auditlog.OpDeleteBucketWebsite, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		return m.Next.DeleteBucketWebsiteConfiguration(ctx, bucketName)
+	})
 }
 
 func (m *AuditLogMiddleware) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	res, err := m.next.ListObjects(ctx, bucketName, opts)
-	m.log(ctx, auditlog.OpListObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.ListBucketResult
+	err := m.run(ctx, auditlog.OpListObjects, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.ListObjects(ctx, bucketName, opts)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	obj, err := m.next.HeadObject(ctx, bucketName, key, opts)
-	m.log(ctx, auditlog.OpHeadObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return obj, err
+	var result *storage.Object
+	err := m.run(ctx, auditlog.OpHeadObject, auditResource{bucket: bucketName.String(), key: key.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.HeadObject(ctx, bucketName, key, opts)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	start := time.Now()
 	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	obj, readers, err := m.next.GetObject(ctx, bucketName, key, ranges, opts)
+	obj, readers, err := m.Next.GetObject(ctx, bucketName, key, ranges, opts)
 	m.log(ctx, auditlog.OpGetObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
 	return obj, readers, err
 }
 
 func (m *AuditLogMiddleware) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	res, err := m.next.PutObject(ctx, bucketName, key, contentType, data, checksumInput, opts)
-	m.log(ctx, auditlog.OpPutObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.PutObjectResult
+	err := m.run(ctx, auditlog.OpPutObject, auditResource{bucket: bucketName.String(), key: key.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.PutObject(ctx, bucketName, key, contentType, data, checksumInput, opts)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	res, err := m.next.AppendObject(ctx, bucketName, key, data, checksumInput, opts)
-	m.log(ctx, auditlog.OpAppendObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.AppendObjectResult
+	err := m.run(ctx, auditlog.OpAppendObject, auditResource{bucket: bucketName.String(), key: key.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.AppendObject(ctx, bucketName, key, data, checksumInput, opts)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
-	start := time.Now()
-	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	err := m.next.DeleteObject(ctx, bucketName, key, opts)
-	m.log(ctx, auditlog.OpDeleteObject, auditlog.PhaseComplete, bucketName.String(), key.String(), "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return m.run(ctx, auditlog.OpDeleteObject, auditResource{bucket: bucketName.String(), key: key.String()}, func(ctx context.Context) error {
+		return m.Next.DeleteObject(ctx, bucketName, key, opts)
+	})
 }
 
 func (m *AuditLogMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	result, err := m.next.DeleteObjects(ctx, bucketName, entries)
-	m.log(ctx, auditlog.OpDeleteObjects, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
+	var result *storage.DeleteObjectsResult
+	err := m.run(ctx, auditlog.OpDeleteObjects, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.DeleteObjects(ctx, bucketName, entries)
+		return err
+	})
 	return result, err
 }
 
 func (m *AuditLogMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
 	start := time.Now()
 	m.log(ctx, auditlog.OpCreateMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), "", 0, nil, 0, 0)
-	res, err := m.next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
+	res, err := m.Next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
 	uid := ""
 	if res != nil {
 		uid = res.UploadId.String()
@@ -322,43 +344,49 @@ func (m *AuditLogMiddleware) CreateMultipartUpload(ctx context.Context, bucketNa
 }
 
 func (m *AuditLogMiddleware) UploadPart(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, partNumber int32, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.UploadPartResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpUploadPart, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), partNumber, nil, 0, 0)
-	res, err := m.next.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
-	m.log(ctx, auditlog.OpUploadPart, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), partNumber, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.UploadPartResult
+	err := m.run(ctx, auditlog.OpUploadPart, auditResource{bucket: bucketName.String(), key: key.String(), uploadID: uploadId.String(), partNumber: partNumber}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil, 0, 0)
-	res, err := m.next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
-	m.log(ctx, auditlog.OpCompleteMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.CompleteMultipartUploadResult
+	err := m.run(ctx, auditlog.OpCompleteMultipartUpload, auditResource{bucket: bucketName.String(), key: key.String(), uploadID: uploadId.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {
-	start := time.Now()
-	m.log(ctx, auditlog.OpAbortMultipartUpload, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil, 0, 0)
-	err := m.next.AbortMultipartUpload(ctx, bucketName, key, uploadId)
-	m.log(ctx, auditlog.OpAbortMultipartUpload, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return err
+	return m.run(ctx, auditlog.OpAbortMultipartUpload, auditResource{bucket: bucketName.String(), key: key.String(), uploadID: uploadId.String()}, func(ctx context.Context) error {
+		return m.Next.AbortMultipartUpload(ctx, bucketName, key, uploadId)
+	})
 }
 
 func (m *AuditLogMiddleware) ListMultipartUploads(ctx context.Context, bucketName storage.BucketName, opts storage.ListMultipartUploadsOptions) (*storage.ListMultipartUploadsResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpListMultipartUploads, auditlog.PhaseStart, bucketName.String(), "", "", 0, nil, 0, 0)
-	res, err := m.next.ListMultipartUploads(ctx, bucketName, opts)
-	m.log(ctx, auditlog.OpListMultipartUploads, auditlog.PhaseComplete, bucketName.String(), "", "", 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.ListMultipartUploadsResult
+	err := m.run(ctx, auditlog.OpListMultipartUploads, auditResource{bucket: bucketName.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.ListMultipartUploads(ctx, bucketName, opts)
+		return err
+	})
+	return result, err
 }
 
 func (m *AuditLogMiddleware) ListParts(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, opts storage.ListPartsOptions) (*storage.ListPartsResult, error) {
-	start := time.Now()
-	m.log(ctx, auditlog.OpListParts, auditlog.PhaseStart, bucketName.String(), key.String(), uploadId.String(), 0, nil, 0, 0)
-	res, err := m.next.ListParts(ctx, bucketName, key, uploadId, opts)
-	m.log(ctx, auditlog.OpListParts, auditlog.PhaseComplete, bucketName.String(), key.String(), uploadId.String(), 0, err, statusCodeFromError(err), time.Since(start).Milliseconds())
-	return res, err
+	var result *storage.ListPartsResult
+	err := m.run(ctx, auditlog.OpListParts, auditResource{bucket: bucketName.String(), key: key.String(), uploadID: uploadId.String()}, func(ctx context.Context) error {
+		var err error
+		result, err = m.Next.ListParts(ctx, bucketName, key, uploadId, opts)
+		return err
+	})
+	return result, err
 }
 
 func statusCodeFromError(err error) int32 {

--- a/internal/storage/middlewares/conditional/conditional.go
+++ b/internal/storage/middlewares/conditional/conditional.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/storage"
+	"github.com/jdillenkofer/pithos/internal/storage/middlewares/delegator"
 )
 
 type conditionalStorageMiddleware struct {
 	*lifecycle.ValidatedLifecycle
+	delegator.DelegatingStorage
 	bucketToStorageMap map[string]storage.Storage
-	defaultStorage     storage.Storage
 	tracer             trace.Tracer
 }
 
@@ -31,8 +32,8 @@ func NewStorageMiddleware(bucketToStorageMap map[string]storage.Storage, default
 
 	return &conditionalStorageMiddleware{
 		ValidatedLifecycle: lifecycle,
+		DelegatingStorage:  delegator.Wrap(defaultStorage),
 		bucketToStorageMap: bucketToStorageMap,
-		defaultStorage:     defaultStorage,
 		tracer:             otel.Tracer("internal/storage/middlewares/conditional"),
 	}, nil
 }
@@ -48,7 +49,7 @@ func (csm *conditionalStorageMiddleware) Start(ctx context.Context) error {
 		}
 	}
 
-	return csm.defaultStorage.Start(ctx)
+	return csm.Next.Start(ctx)
 }
 
 func (csm *conditionalStorageMiddleware) Stop(ctx context.Context) error {
@@ -62,7 +63,7 @@ func (csm *conditionalStorageMiddleware) Stop(ctx context.Context) error {
 		}
 	}
 
-	return csm.defaultStorage.Stop(ctx)
+	return csm.Next.Stop(ctx)
 }
 
 func (csm *conditionalStorageMiddleware) lookupStorage(bucketName storage.BucketName) storage.Storage {
@@ -70,7 +71,7 @@ func (csm *conditionalStorageMiddleware) lookupStorage(bucketName storage.Bucket
 	if ok {
 		return storage
 	}
-	return csm.defaultStorage
+	return csm.Next
 }
 
 func (csm *conditionalStorageMiddleware) CreateBucket(ctx context.Context, bucketName storage.BucketName) error {
@@ -105,7 +106,7 @@ func (csm *conditionalStorageMiddleware) ListBuckets(ctx context.Context) ([]sto
 	}
 
 	// Include buckets from default storage
-	buckets, err := csm.defaultStorage.ListBuckets(ctx)
+	buckets, err := csm.Next.ListBuckets(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/middlewares/delegator/delegator.go
+++ b/internal/storage/middlewares/delegator/delegator.go
@@ -1,0 +1,106 @@
+package delegator
+
+import (
+	"context"
+	"io"
+
+	"github.com/jdillenkofer/pithos/internal/storage"
+)
+
+type DelegatingStorage struct {
+	Next storage.Storage
+}
+
+func Wrap(next storage.Storage) DelegatingStorage {
+	return DelegatingStorage{Next: next}
+}
+
+var _ storage.Storage = (*DelegatingStorage)(nil)
+
+func (d *DelegatingStorage) Start(ctx context.Context) error {
+	return d.Next.Start(ctx)
+}
+
+func (d *DelegatingStorage) Stop(ctx context.Context) error {
+	return d.Next.Stop(ctx)
+}
+
+func (d *DelegatingStorage) CreateBucket(ctx context.Context, bucketName storage.BucketName) error {
+	return d.Next.CreateBucket(ctx, bucketName)
+}
+
+func (d *DelegatingStorage) DeleteBucket(ctx context.Context, bucketName storage.BucketName) error {
+	return d.Next.DeleteBucket(ctx, bucketName)
+}
+
+func (d *DelegatingStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
+	return d.Next.ListBuckets(ctx)
+}
+
+func (d *DelegatingStorage) HeadBucket(ctx context.Context, bucketName storage.BucketName) (*storage.Bucket, error) {
+	return d.Next.HeadBucket(ctx, bucketName)
+}
+
+func (d *DelegatingStorage) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
+	return d.Next.GetBucketWebsiteConfiguration(ctx, bucketName)
+}
+
+func (d *DelegatingStorage) PutBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.WebsiteConfiguration) error {
+	return d.Next.PutBucketWebsiteConfiguration(ctx, bucketName, config)
+}
+
+func (d *DelegatingStorage) DeleteBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) error {
+	return d.Next.DeleteBucketWebsiteConfiguration(ctx, bucketName)
+}
+
+func (d *DelegatingStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
+	return d.Next.ListObjects(ctx, bucketName, opts)
+}
+
+func (d *DelegatingStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
+	return d.Next.HeadObject(ctx, bucketName, key, opts)
+}
+
+func (d *DelegatingStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
+	return d.Next.GetObject(ctx, bucketName, key, ranges, opts)
+}
+
+func (d *DelegatingStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
+	return d.Next.PutObject(ctx, bucketName, key, contentType, data, checksumInput, opts)
+}
+
+func (d *DelegatingStorage) AppendObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, data io.Reader, checksumInput *storage.ChecksumInput, opts *storage.AppendObjectOptions) (*storage.AppendObjectResult, error) {
+	return d.Next.AppendObject(ctx, bucketName, key, data, checksumInput, opts)
+}
+
+func (d *DelegatingStorage) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
+	return d.Next.DeleteObject(ctx, bucketName, key, opts)
+}
+
+func (d *DelegatingStorage) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
+	return d.Next.DeleteObjects(ctx, bucketName, entries)
+}
+
+func (d *DelegatingStorage) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
+	return d.Next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
+}
+
+func (d *DelegatingStorage) UploadPart(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, partNumber int32, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.UploadPartResult, error) {
+	return d.Next.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
+}
+
+func (d *DelegatingStorage) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
+	return d.Next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
+}
+
+func (d *DelegatingStorage) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {
+	return d.Next.AbortMultipartUpload(ctx, bucketName, key, uploadId)
+}
+
+func (d *DelegatingStorage) ListMultipartUploads(ctx context.Context, bucketName storage.BucketName, opts storage.ListMultipartUploadsOptions) (*storage.ListMultipartUploadsResult, error) {
+	return d.Next.ListMultipartUploads(ctx, bucketName, opts)
+}
+
+func (d *DelegatingStorage) ListParts(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, opts storage.ListPartsOptions) (*storage.ListPartsResult, error) {
+	return d.Next.ListParts(ctx, bucketName, key, uploadId, opts)
+}

--- a/internal/storage/middlewares/prometheus/prometheus.go
+++ b/internal/storage/middlewares/prometheus/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/ptrutils"
 	"github.com/jdillenkofer/pithos/internal/storage"
+	"github.com/jdillenkofer/pithos/internal/storage/middlewares/delegator"
 	"github.com/jdillenkofer/pithos/internal/task"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
@@ -19,6 +20,7 @@ import (
 
 type prometheusStorageMiddleware struct {
 	*lifecycle.ValidatedLifecycle
+	delegator.DelegatingStorage
 	registerer                   prometheus.Registerer
 	failedApiOpsCounter          *prometheus.CounterVec
 	successfulApiOpsCounter      *prometheus.CounterVec
@@ -26,8 +28,20 @@ type prometheusStorageMiddleware struct {
 	totalBytesUploadedByBucket   *prometheus.CounterVec
 	totalBytesDownloadedByBucket *prometheus.CounterVec
 	metricsMeasuringTaskHandle   *task.TaskHandle
-	innerStorage                 storage.Storage
 	tracer                       trace.Tracer
+}
+
+func (psm *prometheusStorageMiddleware) run(ctx context.Context, spanName string, opType string, fn func(context.Context) error) error {
+	ctx, span := psm.tracer.Start(ctx, spanName)
+	defer span.End()
+
+	err := fn(ctx)
+	if err != nil {
+		psm.failedApiOpsCounter.With(prometheus.Labels{"type": opType}).Inc()
+		return err
+	}
+	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": opType}).Inc()
+	return nil
 }
 
 // Compile-time check to ensure prometheusStorageMiddleware implements storage.Storage
@@ -91,19 +105,19 @@ func NewStorageMiddleware(innerStorage storage.Storage, registerer prometheus.Re
 
 	return &prometheusStorageMiddleware{
 		ValidatedLifecycle:           lifecycle,
+		DelegatingStorage:            delegator.Wrap(innerStorage),
 		registerer:                   registerer,
 		failedApiOpsCounter:          failedApiOpsCounter,
 		successfulApiOpsCounter:      successfulApiOpsCounter,
 		totalSizeByBucket:            totalSizeByBucket,
 		totalBytesUploadedByBucket:   totalBytesUploadedByBucket,
 		totalBytesDownloadedByBucket: totalBytesDownloadedByBucket,
-		innerStorage:                 innerStorage,
 		tracer:                       otel.Tracer("internal/storage/middlewares/prometheus"),
 	}, nil
 }
 
 func (psm *prometheusStorageMiddleware) measureMetrics(ctx context.Context) {
-	buckets, err := psm.innerStorage.ListBuckets(ctx)
+	buckets, err := psm.Next.ListBuckets(ctx)
 	if err != nil {
 		return
 	}
@@ -122,7 +136,7 @@ func (psm *prometheusStorageMiddleware) getTotalSizeByBucket(ctx context.Context
 	truncated := true
 
 	for truncated {
-		listBucketResult, err := psm.innerStorage.ListObjects(ctx, bucket.Name, storage.ListObjectsOptions{
+		listBucketResult, err := psm.Next.ListObjects(ctx, bucket.Name, storage.ListObjectsOptions{
 			StartAfter: startAfter,
 			MaxKeys:    1000,
 		})
@@ -187,7 +201,7 @@ func (psm *prometheusStorageMiddleware) Start(ctx context.Context) error {
 		psm.measureMetricsLoop(cancelTask)
 	})
 
-	return psm.innerStorage.Start(ctx)
+	return psm.Next.Start(ctx)
 }
 
 func (psm *prometheusStorageMiddleware) Stop(ctx context.Context) error {
@@ -211,150 +225,88 @@ func (psm *prometheusStorageMiddleware) Stop(ctx context.Context) error {
 		}
 	}
 
-	return psm.innerStorage.Stop(ctx)
+	return psm.Next.Stop(ctx)
 }
 
 func (psm *prometheusStorageMiddleware) CreateBucket(ctx context.Context, bucketName storage.BucketName) error {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.CreateBucket")
-	defer span.End()
-
-	err := psm.innerStorage.CreateBucket(ctx, bucketName)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "CreateBucket"}).Inc()
-
-		return err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "CreateBucket"}).Inc()
-
-	return nil
+	return psm.run(ctx, "PrometheusStorageMiddleware.CreateBucket", "CreateBucket", func(ctx context.Context) error {
+		return psm.Next.CreateBucket(ctx, bucketName)
+	})
 }
 
 func (psm *prometheusStorageMiddleware) DeleteBucket(ctx context.Context, bucketName storage.BucketName) error {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteBucket")
-	defer span.End()
-
-	err := psm.innerStorage.DeleteBucket(ctx, bucketName)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteBucket"}).Inc()
-		return err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "DeleteBucket"}).Inc()
-
-	return nil
+	return psm.run(ctx, "PrometheusStorageMiddleware.DeleteBucket", "DeleteBucket", func(ctx context.Context) error {
+		return psm.Next.DeleteBucket(ctx, bucketName)
+	})
 }
 
 func (psm *prometheusStorageMiddleware) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.ListBuckets")
-	defer span.End()
-
-	mBuckets, err := psm.innerStorage.ListBuckets(ctx)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "ListBuckets"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "ListBuckets"}).Inc()
-
-	return mBuckets, nil
+	var result []storage.Bucket
+	err := psm.run(ctx, "PrometheusStorageMiddleware.ListBuckets", "ListBuckets", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.ListBuckets(ctx)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) HeadBucket(ctx context.Context, bucketName storage.BucketName) (*storage.Bucket, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.HeadBucket")
-	defer span.End()
-
-	mBucket, err := psm.innerStorage.HeadBucket(ctx, bucketName)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "HeadBucket"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "HeadBucket"}).Inc()
-
-	return mBucket, err
+	var result *storage.Bucket
+	err := psm.run(ctx, "PrometheusStorageMiddleware.HeadBucket", "HeadBucket", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.HeadBucket(ctx, bucketName)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.GetBucketWebsiteConfiguration")
-	defer span.End()
-
-	config, err := psm.innerStorage.GetBucketWebsiteConfiguration(ctx, bucketName)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "GetBucketWebsite"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "GetBucketWebsite"}).Inc()
-
-	return config, nil
+	var result *storage.WebsiteConfiguration
+	err := psm.run(ctx, "PrometheusStorageMiddleware.GetBucketWebsiteConfiguration", "GetBucketWebsite", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.GetBucketWebsiteConfiguration(ctx, bucketName)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) PutBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.WebsiteConfiguration) error {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.PutBucketWebsiteConfiguration")
-	defer span.End()
-
-	err := psm.innerStorage.PutBucketWebsiteConfiguration(ctx, bucketName, config)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "PutBucketWebsite"}).Inc()
-		return err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "PutBucketWebsite"}).Inc()
-
-	return nil
+	return psm.run(ctx, "PrometheusStorageMiddleware.PutBucketWebsiteConfiguration", "PutBucketWebsite", func(ctx context.Context) error {
+		return psm.Next.PutBucketWebsiteConfiguration(ctx, bucketName, config)
+	})
 }
 
 func (psm *prometheusStorageMiddleware) DeleteBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) error {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteBucketWebsiteConfiguration")
-	defer span.End()
-
-	err := psm.innerStorage.DeleteBucketWebsiteConfiguration(ctx, bucketName)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteBucketWebsite"}).Inc()
-		return err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "DeleteBucketWebsite"}).Inc()
-
-	return nil
+	return psm.run(ctx, "PrometheusStorageMiddleware.DeleteBucketWebsiteConfiguration", "DeleteBucketWebsite", func(ctx context.Context) error {
+		return psm.Next.DeleteBucketWebsiteConfiguration(ctx, bucketName)
+	})
 }
 
 func (psm *prometheusStorageMiddleware) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.ListObjects")
-	defer span.End()
-
-	mListBucketResult, err := psm.innerStorage.ListObjects(ctx, bucketName, opts)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "ListObjects"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "ListObjects"}).Inc()
-
-	return mListBucketResult, nil
+	var result *storage.ListBucketResult
+	err := psm.run(ctx, "PrometheusStorageMiddleware.ListObjects", "ListObjects", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.ListObjects(ctx, bucketName, opts)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.HeadObject")
-	defer span.End()
-
-	mObject, err := psm.innerStorage.HeadObject(ctx, bucketName, key, opts)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "HeadObject"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "HeadObject"}).Inc()
-
-	return mObject, nil
+	var result *storage.Object
+	err := psm.run(ctx, "PrometheusStorageMiddleware.HeadObject", "HeadObject", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.HeadObject(ctx, bucketName, key, opts)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
 	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.GetObject")
 	defer span.End()
 
-	object, readers, err := psm.innerStorage.GetObject(ctx, bucketName, key, ranges, opts)
+	object, readers, err := psm.Next.GetObject(ctx, bucketName, key, ranges, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "GetObject"}).Inc()
 		return nil, nil, err
@@ -380,7 +332,7 @@ func (psm *prometheusStorageMiddleware) PutObject(ctx context.Context, bucketNam
 		psm.totalBytesUploadedByBucket.With(prometheus.Labels{"bucket": bucketName.String()}).Add(float64(n))
 	})
 
-	putObjectResult, err := psm.innerStorage.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
+	putObjectResult, err := psm.Next.PutObject(ctx, bucketName, key, contentType, reader, checksumInput, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "PutObject"}).Inc()
 		return nil, err
@@ -399,7 +351,7 @@ func (psm *prometheusStorageMiddleware) AppendObject(ctx context.Context, bucket
 		psm.totalBytesUploadedByBucket.With(prometheus.Labels{"bucket": bucketName.String()}).Add(float64(n))
 	})
 
-	appendObjectResult, err := psm.innerStorage.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
+	appendObjectResult, err := psm.Next.AppendObject(ctx, bucketName, key, reader, checksumInput, opts)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "AppendObject"}).Inc()
 		return nil, err
@@ -411,48 +363,29 @@ func (psm *prometheusStorageMiddleware) AppendObject(ctx context.Context, bucket
 }
 
 func (psm *prometheusStorageMiddleware) DeleteObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.DeleteObjectOptions) error {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObject")
-	defer span.End()
-
-	err := psm.innerStorage.DeleteObject(ctx, bucketName, key, opts)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteObject"}).Inc()
-		return err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "DeleteObject"}).Inc()
-
-	return nil
+	return psm.run(ctx, "PrometheusStorageMiddleware.DeleteObject", "DeleteObject", func(ctx context.Context) error {
+		return psm.Next.DeleteObject(ctx, bucketName, key, opts)
+	})
 }
 
 func (psm *prometheusStorageMiddleware) DeleteObjects(ctx context.Context, bucketName storage.BucketName, entries []storage.DeleteObjectsInputEntry) (*storage.DeleteObjectsResult, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.DeleteObjects")
-	defer span.End()
-
-	result, err := psm.innerStorage.DeleteObjects(ctx, bucketName, entries)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "DeleteObjects"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "DeleteObjects"}).Inc()
-
-	return result, nil
+	var result *storage.DeleteObjectsResult
+	err := psm.run(ctx, "PrometheusStorageMiddleware.DeleteObjects", "DeleteObjects", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.DeleteObjects(ctx, bucketName, entries)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) CreateMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, checksumType *string) (*storage.InitiateMultipartUploadResult, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.CreateMultipartUpload")
-	defer span.End()
-
-	initiateMultipartUploadResult, err := psm.innerStorage.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "CreateMultipartUpload"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "CreateMultipartUpload"}).Inc()
-
-	return initiateMultipartUploadResult, nil
+	var result *storage.InitiateMultipartUploadResult
+	err := psm.run(ctx, "PrometheusStorageMiddleware.CreateMultipartUpload", "CreateMultipartUpload", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) UploadPart(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, partNumber int32, data io.Reader, checksumInput *storage.ChecksumInput) (*storage.UploadPartResult, error) {
@@ -464,7 +397,7 @@ func (psm *prometheusStorageMiddleware) UploadPart(ctx context.Context, bucketNa
 		bytesUploaded += n
 	})
 
-	uploadPartResult, err := psm.innerStorage.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
+	uploadPartResult, err := psm.Next.UploadPart(ctx, bucketName, key, uploadId, partNumber, data, checksumInput)
 	if err != nil {
 		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "UploadPart"}).Inc()
 		return nil, err
@@ -477,59 +410,37 @@ func (psm *prometheusStorageMiddleware) UploadPart(ctx context.Context, bucketNa
 }
 
 func (psm *prometheusStorageMiddleware) CompleteMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, checksumInput *storage.ChecksumInput, opts *storage.CompleteMultipartUploadOptions) (*storage.CompleteMultipartUploadResult, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.CompleteMultipartUpload")
-	defer span.End()
-
-	completeMultipartUploadResult, err := psm.innerStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "CompleteMultipartUpload"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "CompleteMultipartUpload"}).Inc()
-
-	return completeMultipartUploadResult, nil
+	var result *storage.CompleteMultipartUploadResult
+	err := psm.run(ctx, "PrometheusStorageMiddleware.CompleteMultipartUpload", "CompleteMultipartUpload", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) AbortMultipartUpload(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId) error {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.AbortMultipartUpload")
-	defer span.End()
-
-	err := psm.innerStorage.AbortMultipartUpload(ctx, bucketName, key, uploadId)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "AbortMultipartUpload"}).Inc()
-		return err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "AbortMultipartUpload"}).Inc()
-
-	return nil
+	return psm.run(ctx, "PrometheusStorageMiddleware.AbortMultipartUpload", "AbortMultipartUpload", func(ctx context.Context) error {
+		return psm.Next.AbortMultipartUpload(ctx, bucketName, key, uploadId)
+	})
 }
 
 func (psm *prometheusStorageMiddleware) ListMultipartUploads(ctx context.Context, bucketName storage.BucketName, opts storage.ListMultipartUploadsOptions) (*storage.ListMultipartUploadsResult, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.ListMultipartUploads")
-	defer span.End()
-
-	listMultipartUploadsResult, err := psm.innerStorage.ListMultipartUploads(ctx, bucketName, opts)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "ListMultipartUploads"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "ListMultipartUploads"}).Inc()
-	return listMultipartUploadsResult, nil
+	var result *storage.ListMultipartUploadsResult
+	err := psm.run(ctx, "PrometheusStorageMiddleware.ListMultipartUploads", "ListMultipartUploads", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.ListMultipartUploads(ctx, bucketName, opts)
+		return err
+	})
+	return result, err
 }
 
 func (psm *prometheusStorageMiddleware) ListParts(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, opts storage.ListPartsOptions) (*storage.ListPartsResult, error) {
-	ctx, span := psm.tracer.Start(ctx, "PrometheusStorageMiddleware.ListParts")
-	defer span.End()
-
-	listPartsResult, err := psm.innerStorage.ListParts(ctx, bucketName, key, uploadId, opts)
-	if err != nil {
-		psm.failedApiOpsCounter.With(prometheus.Labels{"type": "ListParts"}).Inc()
-		return nil, err
-	}
-
-	psm.successfulApiOpsCounter.With(prometheus.Labels{"type": "ListParts"}).Inc()
-	return listPartsResult, nil
+	var result *storage.ListPartsResult
+	err := psm.run(ctx, "PrometheusStorageMiddleware.ListParts", "ListParts", func(ctx context.Context) error {
+		var err error
+		result, err = psm.Next.ListParts(ctx, bucketName, key, uploadId, opts)
+		return err
+	})
+	return result, err
 }

--- a/internal/storage/replication/replication.go
+++ b/internal/storage/replication/replication.go
@@ -8,39 +8,35 @@ import (
 	"github.com/jdillenkofer/pithos/internal/ioutils"
 	"github.com/jdillenkofer/pithos/internal/lifecycle"
 	"github.com/jdillenkofer/pithos/internal/storage"
+	"github.com/jdillenkofer/pithos/internal/storage/middlewares/delegator"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// maxMemoryCacheSize is the maximum size of a payload that will be cached in memory
-// before switching to a disk-based cache.
 const maxMemoryCacheSize = 10 * 1000 * 1000
 
 type replicationStorage struct {
 	*lifecycle.ValidatedLifecycle
-	primaryStorage                      storage.Storage
+	delegator.DelegatingStorage
 	secondaryStorages                   []storage.Storage
 	primaryUploadIdToSecondaryUploadIds map[storage.UploadId][]storage.UploadId
 	mapMutex                            sync.Mutex
 	tracer                              trace.Tracer
 }
 
-// Compile-time check to ensure replicationStorage implements storage.Storage
 var _ storage.Storage = (*replicationStorage)(nil)
 
 func NewStorage(primaryStorage storage.Storage, secondaryStorages ...storage.Storage) (storage.Storage, error) {
-	primaryUploadIdToSecondaryUploadIds := make(map[storage.UploadId][]storage.UploadId)
-
-	lifecycle, err := lifecycle.NewValidatedLifecycle("ReplicationStorage")
+	lc, err := lifecycle.NewValidatedLifecycle("ReplicationStorage")
 	if err != nil {
 		return nil, err
 	}
 
 	return &replicationStorage{
-		ValidatedLifecycle:                  lifecycle,
-		primaryStorage:                      primaryStorage,
+		ValidatedLifecycle:                  lc,
+		DelegatingStorage:                   delegator.Wrap(primaryStorage),
 		secondaryStorages:                   secondaryStorages,
-		primaryUploadIdToSecondaryUploadIds: primaryUploadIdToSecondaryUploadIds,
+		primaryUploadIdToSecondaryUploadIds: make(map[storage.UploadId][]storage.UploadId),
 		mapMutex:                            sync.Mutex{},
 		tracer:                              otel.Tracer("internal/storage/replication"),
 	}, nil
@@ -50,7 +46,7 @@ func (rs *replicationStorage) Start(ctx context.Context) error {
 	if err := rs.ValidatedLifecycle.Start(ctx); err != nil {
 		return err
 	}
-	if err := rs.primaryStorage.Start(ctx); err != nil {
+	if err := rs.Next.Start(ctx); err != nil {
 		return err
 	}
 	for _, secondaryStorage := range rs.secondaryStorages {
@@ -65,7 +61,7 @@ func (rs *replicationStorage) Stop(ctx context.Context) error {
 	if err := rs.ValidatedLifecycle.Stop(ctx); err != nil {
 		return err
 	}
-	if err := rs.primaryStorage.Stop(ctx); err != nil {
+	if err := rs.Next.Stop(ctx); err != nil {
 		return err
 	}
 	for _, secondaryStorage := range rs.secondaryStorages {
@@ -80,7 +76,7 @@ func (rs *replicationStorage) CreateBucket(ctx context.Context, bucketName stora
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.CreateBucket")
 	defer span.End()
 
-	err := rs.primaryStorage.CreateBucket(ctx, bucketName)
+	err := rs.Next.CreateBucket(ctx, bucketName)
 	if err != nil {
 		return err
 	}
@@ -97,7 +93,7 @@ func (rs *replicationStorage) DeleteBucket(ctx context.Context, bucketName stora
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteBucket")
 	defer span.End()
 
-	err := rs.primaryStorage.DeleteBucket(ctx, bucketName)
+	err := rs.Next.DeleteBucket(ctx, bucketName)
 	if err != nil {
 		return err
 	}
@@ -110,53 +106,17 @@ func (rs *replicationStorage) DeleteBucket(ctx context.Context, bucketName stora
 	return nil
 }
 
-func (rs *replicationStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.ListBuckets")
-	defer span.End()
-
-	return rs.primaryStorage.ListBuckets(ctx)
-}
-
-func (rs *replicationStorage) HeadBucket(ctx context.Context, bucketName storage.BucketName) (*storage.Bucket, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.HeadBucket")
-	defer span.End()
-
-	return rs.primaryStorage.HeadBucket(ctx, bucketName)
-}
-
-func (rs *replicationStorage) ListObjects(ctx context.Context, bucketName storage.BucketName, opts storage.ListObjectsOptions) (*storage.ListBucketResult, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.ListObjects")
-	defer span.End()
-
-	return rs.primaryStorage.ListObjects(ctx, bucketName, opts)
-}
-
-func (rs *replicationStorage) HeadObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, opts *storage.HeadObjectOptions) (*storage.Object, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.HeadObject")
-	defer span.End()
-
-	return rs.primaryStorage.HeadObject(ctx, bucketName, key, opts)
-}
-
-func (rs *replicationStorage) GetObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, ranges []storage.ByteRange, opts *storage.GetObjectOptions) (*storage.Object, []io.ReadCloser, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.GetObject")
-	defer span.End()
-
-	return rs.primaryStorage.GetObject(ctx, bucketName, key, ranges, opts)
-}
-
 func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, contentType *string, reader io.Reader, checksumInput *storage.ChecksumInput, opts *storage.PutObjectOptions) (*storage.PutObjectResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.PutObject")
 	defer span.End()
 
-	// Use smart cache (memory up to maxMemoryCacheSize, then disk)
 	readSeekCloser, err := ioutils.NewSmartCachedReadSeekCloser(reader, maxMemoryCacheSize)
 	if err != nil {
 		return nil, err
 	}
 	defer readSeekCloser.Close()
 
-	putObjectResult, err := rs.primaryStorage.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput, opts)
+	putObjectResult, err := rs.Next.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -165,9 +125,6 @@ func (rs *replicationStorage) PutObject(ctx context.Context, bucketName storage.
 		if err != nil {
 			return nil, err
 		}
-		// Do not forward conditional opts (If-Match / If-None-Match) to secondary
-		// storages. The precondition was already enforced on the primary; the
-		// secondary must replicate the write unconditionally.
 		_, err = secondaryStorage.PutObject(ctx, bucketName, key, contentType, readSeekCloser, checksumInput, nil)
 		if err != nil {
 			return nil, err
@@ -180,15 +137,13 @@ func (rs *replicationStorage) AppendObject(ctx context.Context, bucketName stora
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.AppendObject")
 	defer span.End()
 
-	// Use smart cache (memory up to maxMemoryCacheSize, then disk) so we can
-	// replay the body to each secondary storage.
 	readSeekCloser, err := ioutils.NewSmartCachedReadSeekCloser(reader, maxMemoryCacheSize)
 	if err != nil {
 		return nil, err
 	}
 	defer readSeekCloser.Close()
 
-	appendObjectResult, err := rs.primaryStorage.AppendObject(ctx, bucketName, key, readSeekCloser, checksumInput, opts)
+	appendObjectResult, err := rs.Next.AppendObject(ctx, bucketName, key, readSeekCloser, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -197,8 +152,6 @@ func (rs *replicationStorage) AppendObject(ctx context.Context, bucketName stora
 		if err != nil {
 			return nil, err
 		}
-		// Do not forward conditional opts (If-Match) to secondaries; the
-		// precondition was already enforced on the primary.
 		_, err = secondaryStorage.AppendObject(ctx, bucketName, key, readSeekCloser, checksumInput, nil)
 		if err != nil {
 			return nil, err
@@ -211,7 +164,7 @@ func (rs *replicationStorage) DeleteObject(ctx context.Context, bucketName stora
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObject")
 	defer span.End()
 
-	err := rs.primaryStorage.DeleteObject(ctx, bucketName, key, opts)
+	err := rs.Next.DeleteObject(ctx, bucketName, key, opts)
 	if err != nil {
 		return err
 	}
@@ -228,7 +181,7 @@ func (rs *replicationStorage) DeleteObjects(ctx context.Context, bucketName stor
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteObjects")
 	defer span.End()
 
-	result, err := rs.primaryStorage.DeleteObjects(ctx, bucketName, entries)
+	result, err := rs.Next.DeleteObjects(ctx, bucketName, entries)
 	if err != nil {
 		return nil, err
 	}
@@ -245,38 +198,37 @@ func (rs *replicationStorage) CreateMultipartUpload(ctx context.Context, bucketN
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.CreateMultipartUpload")
 	defer span.End()
 
-	initiateMultipartUploadResult, err := rs.primaryStorage.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
+	primaryResult, err := rs.Next.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
 	if err != nil {
 		return nil, err
 	}
-	var secondaryUploadIds []storage.UploadId = []storage.UploadId{}
+	secondaryUploadIDs := make([]storage.UploadId, 0, len(rs.secondaryStorages))
 	for _, secondaryStorage := range rs.secondaryStorages {
-		initiateMultipartUploadResult, err := secondaryStorage.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
+		secondaryResult, err := secondaryStorage.CreateMultipartUpload(ctx, bucketName, key, contentType, checksumType)
 		if err != nil {
 			return nil, err
 		}
-		secondaryUploadIds = append(secondaryUploadIds, initiateMultipartUploadResult.UploadId)
+		secondaryUploadIDs = append(secondaryUploadIDs, secondaryResult.UploadId)
 	}
 
 	rs.mapMutex.Lock()
-	rs.primaryUploadIdToSecondaryUploadIds[initiateMultipartUploadResult.UploadId] = secondaryUploadIds
+	rs.primaryUploadIdToSecondaryUploadIds[primaryResult.UploadId] = secondaryUploadIDs
 	rs.mapMutex.Unlock()
 
-	return initiateMultipartUploadResult, nil
+	return primaryResult, nil
 }
 
 func (rs *replicationStorage) UploadPart(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, partNumber int32, reader io.Reader, checksumInput *storage.ChecksumInput) (*storage.UploadPartResult, error) {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.UploadPart")
 	defer span.End()
 
-	// Use smart cache (memory up to maxMemoryCacheSize, then disk)
 	readSeekCloser, err := ioutils.NewSmartCachedReadSeekCloser(reader, maxMemoryCacheSize)
 	if err != nil {
 		return nil, err
 	}
 	defer readSeekCloser.Close()
 
-	uploadPartResult, err := rs.primaryStorage.UploadPart(ctx, bucketName, key, uploadId, partNumber, readSeekCloser, checksumInput)
+	uploadPartResult, err := rs.Next.UploadPart(ctx, bucketName, key, uploadId, partNumber, readSeekCloser, checksumInput)
 	if err != nil {
 		return nil, err
 	}
@@ -302,10 +254,11 @@ func (rs *replicationStorage) CompleteMultipartUpload(ctx context.Context, bucke
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.CompleteMultipartUpload")
 	defer span.End()
 
-	completeMultipartUploadResult, err := rs.primaryStorage.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
+	completeMultipartUploadResult, err := rs.Next.CompleteMultipartUpload(ctx, bucketName, key, uploadId, checksumInput, opts)
 	if err != nil {
 		return nil, err
 	}
+
 	rs.mapMutex.Lock()
 	secondaryUploadIds := rs.primaryUploadIdToSecondaryUploadIds[uploadId]
 	rs.mapMutex.Unlock()
@@ -327,10 +280,11 @@ func (rs *replicationStorage) AbortMultipartUpload(ctx context.Context, bucketNa
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.AbortMultipartUpload")
 	defer span.End()
 
-	err := rs.primaryStorage.AbortMultipartUpload(ctx, bucketName, key, uploadId)
+	err := rs.Next.AbortMultipartUpload(ctx, bucketName, key, uploadId)
 	if err != nil {
 		return err
 	}
+
 	rs.mapMutex.Lock()
 	secondaryUploadIds := rs.primaryUploadIdToSecondaryUploadIds[uploadId]
 	rs.mapMutex.Unlock()
@@ -348,32 +302,11 @@ func (rs *replicationStorage) AbortMultipartUpload(ctx context.Context, bucketNa
 	return nil
 }
 
-func (rs *replicationStorage) ListMultipartUploads(ctx context.Context, bucketName storage.BucketName, opts storage.ListMultipartUploadsOptions) (*storage.ListMultipartUploadsResult, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.ListMultipartUploads")
-	defer span.End()
-
-	return rs.primaryStorage.ListMultipartUploads(ctx, bucketName, opts)
-}
-
-func (rs *replicationStorage) ListParts(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey, uploadId storage.UploadId, opts storage.ListPartsOptions) (*storage.ListPartsResult, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.ListParts")
-	defer span.End()
-
-	return rs.primaryStorage.ListParts(ctx, bucketName, key, uploadId, opts)
-}
-
-func (rs *replicationStorage) GetBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName) (*storage.WebsiteConfiguration, error) {
-	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.GetBucketWebsiteConfiguration")
-	defer span.End()
-
-	return rs.primaryStorage.GetBucketWebsiteConfiguration(ctx, bucketName)
-}
-
 func (rs *replicationStorage) PutBucketWebsiteConfiguration(ctx context.Context, bucketName storage.BucketName, config *storage.WebsiteConfiguration) error {
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.PutBucketWebsiteConfiguration")
 	defer span.End()
 
-	err := rs.primaryStorage.PutBucketWebsiteConfiguration(ctx, bucketName, config)
+	err := rs.Next.PutBucketWebsiteConfiguration(ctx, bucketName, config)
 	if err != nil {
 		return err
 	}
@@ -390,7 +323,7 @@ func (rs *replicationStorage) DeleteBucketWebsiteConfiguration(ctx context.Conte
 	ctx, span := rs.tracer.Start(ctx, "ReplicationStorage.DeleteBucketWebsiteConfiguration")
 	defer span.End()
 
-	err := rs.primaryStorage.DeleteBucketWebsiteConfiguration(ctx, bucketName)
+	err := rs.Next.DeleteBucketWebsiteConfiguration(ctx, bucketName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Introduce a shared `DelegatingStorage` base in `internal/storage/middlewares/delegator` that forwards the full `storage.Storage` interface to an inner storage.
- Refactor cache, replication, conditional, prometheus, and audit storage middlewares to embed the delegator and keep only behavior-specific overrides.
- Add operation wrapper helpers in prometheus and audit middlewares to consolidate repeated pre/post logic (spans + metrics and start/complete audit logging).

## Validation
- `go test ./internal/storage/middlewares/prometheus ./internal/storage/middlewares/audit`
- `go test ./...`