### PR TITLE
refactor(outbox): unify runtime for storage and partstore

### DIFF
--- a/internal/storage/metadatapart/partstore/outbox/outbox.go
+++ b/internal/storage/metadatapart/partstore/outbox/outbox.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync/atomic"
-	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -16,80 +14,17 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/database"
 	partOutboxEntry "github.com/jdillenkofer/pithos/internal/storage/database/repository/partoutboxentry"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
-	"github.com/jdillenkofer/pithos/internal/task"
+	"github.com/jdillenkofer/pithos/internal/storage/outboxruntime"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type partOutboxMetrics struct {
-	pendingEntries     prometheus.Gauge
-	processedEntries   prometheus.Counter
-	processingDuration prometheus.Histogram
-	errorsCounter      prometheus.Counter
-}
-
-func newPartOutboxMetrics(registerer prometheus.Registerer) *partOutboxMetrics {
-	m := &partOutboxMetrics{
-		pendingEntries: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "pithos",
-			Subsystem: "part_outbox",
-			Name:      "pending_entries",
-			Help:      "Number of pending part outbox entries",
-		}),
-		processedEntries: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "pithos",
-			Subsystem: "part_outbox",
-			Name:      "processed_entries_total",
-			Help:      "Total number of processed part outbox entries",
-		}),
-		processingDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "pithos",
-			Subsystem: "part_outbox",
-			Name:      "processing_duration_seconds",
-			Help:      "Duration of part outbox processing in seconds",
-			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
-		}),
-		errorsCounter: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "pithos",
-			Subsystem: "part_outbox",
-			Name:      "errors_total",
-			Help:      "Total number of part outbox processing errors",
-		}),
-	}
-
-	if err := registerer.Register(m.pendingEntries); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register pendingEntries metric", "error", err)
-		}
-	}
-	if err := registerer.Register(m.processedEntries); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register processedEntries metric", "error", err)
-		}
-	}
-	if err := registerer.Register(m.processingDuration); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register processingDuration metric", "error", err)
-		}
-	}
-	if err := registerer.Register(m.errorsCounter); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register errorsCounter metric", "error", err)
-		}
-	}
-
-	return m
-}
-
 type outboxPartStore struct {
 	db                         database.Database
-	triggerChannel             chan struct{}
-	triggerChannelClosed       bool
-	outboxProcessingTaskHandle *task.TaskHandle
+	runtime                    *outboxruntime.Runtime[*partOutboxEntry.Entity]
 	innerPartStore             partstore.PartStore
 	partOutboxEntryRepository  partOutboxEntry.Repository
 	tracer                     trace.Tracer
-	metrics                    *partOutboxMetrics
 }
 
 // Compile-time check to ensure outboxPartStore implements partstore.PartStore
@@ -98,150 +33,65 @@ var _ partstore.PartStore = (*outboxPartStore)(nil)
 func New(db database.Database, innerPartStore partstore.PartStore, partOutboxEntryRepository partOutboxEntry.Repository, registerer prometheus.Registerer) (partstore.PartStore, error) {
 	obs := &outboxPartStore{
 		db:                        db,
-		triggerChannel:            make(chan struct{}, 16),
-		triggerChannelClosed:      false,
 		innerPartStore:            innerPartStore,
 		partOutboxEntryRepository: partOutboxEntryRepository,
 		tracer:                    otel.Tracer("internal/storage/metadatapart/partstore/outbox"),
-		metrics:                   newPartOutboxMetrics(registerer),
 	}
+	obs.runtime = outboxruntime.New(db, obs, outboxruntime.NewMetrics(registerer, "part_outbox", "Number of pending part outbox entries", "Total number of processed part outbox entries", "Duration of part outbox processing in seconds", "Total number of part outbox processing errors"))
 	return obs, nil
 }
 
-func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
-	ctx, span := obs.tracer.Start(ctx, "outboxPartStore.maybeProcessOutboxEntries")
-	defer span.End()
-
-	startTime := time.Now()
-	processedOutboxEntryCount := 0
-	defer func() {
-		obs.metrics.processingDuration.Observe(time.Since(startTime).Seconds())
-		if processedOutboxEntryCount > 0 {
-			obs.metrics.processedEntries.Add(float64(processedOutboxEntryCount))
-		}
-	}()
-
-	tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
-	if err != nil {
-		return
-	}
-
-	pendingCount, err := obs.partOutboxEntryRepository.Count(ctx, tx)
-	if err != nil {
-		tx.Rollback()
-		return
-	}
-	obs.metrics.pendingEntries.Set(float64(pendingCount))
-	tx.Commit()
-
-	for {
-		tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
-		if err != nil {
-			obs.metrics.errorsCounter.Inc()
-			return
-		}
-
-		entry, err := obs.partOutboxEntryRepository.FindFirstPartOutboxEntryWithForUpdateLock(ctx, tx)
-		if err != nil {
-			tx.Rollback()
-			obs.metrics.errorsCounter.Inc()
-			time.Sleep(5 * time.Second)
-			return
-		}
-		if entry == nil {
-			tx.Commit()
-			break
-		}
-
-		switch entry.Operation {
-		case partOutboxEntry.PutPartOperation:
-			chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, *entry.Id)
-			if err != nil {
-				tx.Rollback()
-				obs.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-			readers := make([]io.Reader, len(chunks))
-			for i, chunk := range chunks {
-				readers[i] = bytes.NewReader(chunk.Content)
-			}
-			err = obs.innerPartStore.PutPart(ctx, tx, entry.PartId, io.MultiReader(readers...))
-			if err != nil {
-				tx.Rollback()
-				obs.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		case partOutboxEntry.DeletePartOperation:
-			err = obs.innerPartStore.DeletePart(ctx, tx, entry.PartId)
-			if err != nil {
-				tx.Rollback()
-				obs.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		default:
-			slog.Warn(fmt.Sprint("Invalid operation", entry.Operation, "during outbox processing."))
-			tx.Rollback()
-			obs.metrics.errorsCounter.Inc()
-			time.Sleep(5 * time.Second)
-			return
-		}
-		err = obs.partOutboxEntryRepository.DeletePartOutboxEntryById(ctx, tx, *entry.Id)
-		if err != nil {
-			tx.Rollback()
-			return
-		}
-		processedOutboxEntryCount += 1
-
-		err = tx.Commit()
-		if err != nil {
-			return
-		}
-	}
-	if processedOutboxEntryCount > 0 {
-		slog.Info(fmt.Sprintf("Processed %d outbox entries", processedOutboxEntryCount))
-	}
-}
-
-func (obs *outboxPartStore) processOutboxLoop() {
-	ctx := context.Background()
-out:
-	for {
-		select {
-		case _, ok := <-obs.triggerChannel:
-			if !ok {
-				slog.Debug("Stopping OutboxPartStore processing")
-				break out
-			}
-		case <-time.After(1 * time.Second):
-		}
-		obs.maybeProcessOutboxEntries(ctx)
-	}
-}
-
 func (obs *outboxPartStore) Start(ctx context.Context) error {
-	obs.outboxProcessingTaskHandle = task.Start(func(_ *atomic.Bool) {
-		obs.processOutboxLoop()
-	})
+	obs.runtime.Start()
 	return obs.innerPartStore.Start(ctx)
 }
 
 func (obs *outboxPartStore) Stop(ctx context.Context) error {
-	if !obs.triggerChannelClosed {
-		close(obs.triggerChannel)
-		if obs.outboxProcessingTaskHandle != nil {
-			joinedWithTimeout := obs.outboxProcessingTaskHandle.JoinWithTimeout(30 * time.Second)
-			if joinedWithTimeout {
-				slog.Debug("OutboxPartStore.outboxProcessingTaskHandle joined with timeout of 30s")
-			} else {
-				slog.Debug("OutboxPartStore.outboxProcessingTaskHandle joined without timeout")
-			}
-		}
-		obs.triggerChannelClosed = true
-	}
+	obs.runtime.Stop()
 	return obs.innerPartStore.Stop(ctx)
+}
+
+func (obs *outboxPartStore) Name() string {
+	return "OutboxPartStore"
+}
+
+func (obs *outboxPartStore) CountPending(ctx context.Context, tx *sql.Tx) (int, error) {
+	return obs.partOutboxEntryRepository.Count(ctx, tx)
+}
+
+func (obs *outboxPartStore) FindFirstForUpdate(ctx context.Context, tx *sql.Tx) (*partOutboxEntry.Entity, error) {
+	return obs.partOutboxEntryRepository.FindFirstPartOutboxEntryWithForUpdateLock(ctx, tx)
+}
+
+func (obs *outboxPartStore) ProcessEntry(ctx context.Context, tx *sql.Tx, partEntry *partOutboxEntry.Entity) error {
+	if partEntry == nil {
+		return fmt.Errorf("invalid part outbox entry type")
+	}
+
+	switch partEntry.Operation {
+	case partOutboxEntry.PutPartOperation:
+		chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, *partEntry.Id)
+		if err != nil {
+			return err
+		}
+		readers := make([]io.Reader, len(chunks))
+		for i, chunk := range chunks {
+			readers[i] = bytes.NewReader(chunk.Content)
+		}
+		return obs.innerPartStore.PutPart(ctx, tx, partEntry.PartId, io.MultiReader(readers...))
+	case partOutboxEntry.DeletePartOperation:
+		return obs.innerPartStore.DeletePart(ctx, tx, partEntry.PartId)
+	default:
+		slog.Warn(fmt.Sprint("Invalid operation", partEntry.Operation, "during outbox processing."))
+		return fmt.Errorf("invalid operation: %s", partEntry.Operation)
+	}
+}
+
+func (obs *outboxPartStore) DeleteEntry(ctx context.Context, tx *sql.Tx, partEntry *partOutboxEntry.Entity) error {
+	if partEntry == nil {
+		return fmt.Errorf("invalid part outbox entry type")
+	}
+	return obs.partOutboxEntryRepository.DeletePartOutboxEntryById(ctx, tx, *partEntry.Id)
 }
 
 const chunkSize = 256 * 1000 * 1000 // 256MB
@@ -256,11 +106,7 @@ func (obs *outboxPartStore) storePartOutboxEntry(ctx context.Context, tx *sql.Tx
 		return nil, err
 	}
 
-	// Put struct{} in the channel unless it is full
-	select {
-	case obs.triggerChannel <- struct{}{}:
-	default:
-	}
+	obs.runtime.Trigger()
 
 	return entry.Id, nil
 }

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync/atomic"
 	"time"
 
 	"github.com/jdillenkofer/pithos/internal/checksumutils"
@@ -16,83 +15,20 @@ import (
 	"github.com/jdillenkofer/pithos/internal/storage/database"
 	storageOutboxEntry "github.com/jdillenkofer/pithos/internal/storage/database/repository/storageoutboxentry"
 	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/metadatastore"
-	"github.com/jdillenkofer/pithos/internal/task"
+	"github.com/jdillenkofer/pithos/internal/storage/outboxruntime"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
-type outboxMetrics struct {
-	pendingEntries     prometheus.Gauge
-	processedEntries   prometheus.Counter
-	processingDuration prometheus.Histogram
-	errorsCounter      prometheus.Counter
-}
-
-func newOutboxMetrics(registerer prometheus.Registerer) *outboxMetrics {
-	m := &outboxMetrics{
-		pendingEntries: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "pithos",
-			Subsystem: "outbox",
-			Name:      "pending_entries",
-			Help:      "Number of pending outbox entries",
-		}),
-		processedEntries: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "pithos",
-			Subsystem: "outbox",
-			Name:      "processed_entries_total",
-			Help:      "Total number of processed outbox entries",
-		}),
-		processingDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "pithos",
-			Subsystem: "outbox",
-			Name:      "processing_duration_seconds",
-			Help:      "Duration of outbox processing in seconds",
-			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
-		}),
-		errorsCounter: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "pithos",
-			Subsystem: "outbox",
-			Name:      "errors_total",
-			Help:      "Total number of outbox processing errors",
-		}),
-	}
-
-	if err := registerer.Register(m.pendingEntries); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register pendingEntries metric", "error", err)
-		}
-	}
-	if err := registerer.Register(m.processedEntries); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register processedEntries metric", "error", err)
-		}
-	}
-	if err := registerer.Register(m.processingDuration); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register processingDuration metric", "error", err)
-		}
-	}
-	if err := registerer.Register(m.errorsCounter); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			slog.Error("Failed to register errorsCounter metric", "error", err)
-		}
-	}
-
-	return m
-}
-
 type outboxStorage struct {
 	*lifecycle.ValidatedLifecycle
 	db                           database.Database
-	triggerChannel               chan struct{}
-	triggerChannelClosed         bool
-	outboxProcessingTaskHandle   *task.TaskHandle
+	runtime                      *outboxruntime.Runtime[*storageOutboxEntry.Entity]
 	innerStorage                 storage.Storage
 	storageOutboxEntryRepository storageOutboxEntry.Repository
 	tracer                       trace.Tracer
-	metrics                      *outboxMetrics
 }
 
 // Compile-time check to ensure outboxStorage implements storage.Storage
@@ -106,146 +42,19 @@ func NewStorage(db database.Database, innerStorage storage.Storage, storageOutbo
 	os := &outboxStorage{
 		ValidatedLifecycle:           lifecycle,
 		db:                           db,
-		triggerChannel:               make(chan struct{}, 16),
-		triggerChannelClosed:         false,
 		innerStorage:                 innerStorage,
 		storageOutboxEntryRepository: storageOutboxEntryRepository,
 		tracer:                       otel.Tracer("internal/storage/outbox"),
-		metrics:                      newOutboxMetrics(registerer),
 	}
+	os.runtime = outboxruntime.New(db, os, outboxruntime.NewMetrics(registerer, "outbox", "Number of pending outbox entries", "Total number of processed outbox entries", "Duration of outbox processing in seconds", "Total number of outbox processing errors"))
 	return os, nil
-}
-
-func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
-	startTime := time.Now()
-	processedOutboxEntryCount := 0
-	defer func() {
-		os.metrics.processingDuration.Observe(time.Since(startTime).Seconds())
-		if processedOutboxEntryCount > 0 {
-			os.metrics.processedEntries.Add(float64(processedOutboxEntryCount))
-		}
-	}()
-
-	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
-	if err != nil {
-		return
-	}
-	pendingCount, err := os.storageOutboxEntryRepository.Count(ctx, tx)
-	if err != nil {
-		tx.Rollback()
-		return
-	}
-	os.metrics.pendingEntries.Set(float64(pendingCount))
-	tx.Commit()
-
-	for {
-		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
-		if err != nil {
-			os.metrics.errorsCounter.Inc()
-			return
-		}
-		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryWithForUpdateLock(ctx, tx)
-		if err != nil {
-			tx.Rollback()
-			os.metrics.errorsCounter.Inc()
-			time.Sleep(5 * time.Second)
-			return
-		}
-		if entry == nil {
-			tx.Commit()
-			break
-		}
-
-		switch entry.Operation {
-		case storageOutboxEntry.CreateBucketStorageOperation:
-			err = os.innerStorage.CreateBucket(ctx, entry.Bucket)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		case storageOutboxEntry.DeleteBucketStorageOperation:
-			err = os.innerStorage.DeleteBucket(ctx, entry.Bucket)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		case storageOutboxEntry.PutObjectStorageOperation:
-			chunks, err := os.storageOutboxEntryRepository.FindStorageOutboxEntryChunksById(ctx, tx, *entry.Id)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-			readers := make([]io.Reader, len(chunks))
-			for i, chunk := range chunks {
-				readers[i] = bytes.NewReader(chunk.Content)
-			}
-			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(readers...), nil, nil)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		case storageOutboxEntry.DeleteObjectStorageOperation:
-			err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		default:
-			slog.Warn(fmt.Sprint("Invalid operation", entry.Operation, "during outbox processing."))
-			tx.Rollback()
-			time.Sleep(5 * time.Second)
-			return
-		}
-		err = os.storageOutboxEntryRepository.DeleteStorageOutboxEntryById(ctx, tx, *entry.Id)
-		if err != nil {
-			tx.Rollback()
-			return
-		}
-
-		err = tx.Commit()
-		if err != nil {
-			return
-		}
-		processedOutboxEntryCount += 1
-	}
-	if processedOutboxEntryCount > 0 {
-		slog.Info(fmt.Sprintf("Processed %d outbox entries", processedOutboxEntryCount))
-	}
-}
-
-func (os *outboxStorage) processOutboxLoop() {
-	ctx := context.Background()
-out:
-	for {
-		select {
-		case _, ok := <-os.triggerChannel:
-			if !ok {
-				slog.Debug("Stopping outboxStorage processing")
-				break out
-			}
-		case <-time.After(1 * time.Second):
-		}
-		os.maybeProcessOutboxEntries(ctx)
-	}
 }
 
 func (os *outboxStorage) Start(ctx context.Context) error {
 	if err := os.ValidatedLifecycle.Start(ctx); err != nil {
 		return err
 	}
-	os.outboxProcessingTaskHandle = task.Start(func(_ *atomic.Bool) {
-		os.processOutboxLoop()
-	})
+	os.runtime.Start()
 	return os.innerStorage.Start(ctx)
 }
 
@@ -253,19 +62,56 @@ func (os *outboxStorage) Stop(ctx context.Context) error {
 	if err := os.ValidatedLifecycle.Stop(ctx); err != nil {
 		return err
 	}
-	if !os.triggerChannelClosed {
-		close(os.triggerChannel)
-		if os.outboxProcessingTaskHandle != nil {
-			joinedWithTimeout := os.outboxProcessingTaskHandle.JoinWithTimeout(30 * time.Second)
-			if joinedWithTimeout {
-				slog.Debug("OutboxStorage.outboxProcessingTaskHandle joined with timeout of 30s")
-			} else {
-				slog.Debug("OutboxStorage.outboxProcessingTaskHandle joined without timeout")
-			}
-		}
-		os.triggerChannelClosed = true
-	}
+	os.runtime.Stop()
 	return os.innerStorage.Stop(ctx)
+}
+
+func (os *outboxStorage) Name() string {
+	return "OutboxStorage"
+}
+
+func (os *outboxStorage) CountPending(ctx context.Context, tx *sql.Tx) (int, error) {
+	return os.storageOutboxEntryRepository.Count(ctx, tx)
+}
+
+func (os *outboxStorage) FindFirstForUpdate(ctx context.Context, tx *sql.Tx) (*storageOutboxEntry.Entity, error) {
+	return os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryWithForUpdateLock(ctx, tx)
+}
+
+func (os *outboxStorage) ProcessEntry(ctx context.Context, tx *sql.Tx, storageEntry *storageOutboxEntry.Entity) error {
+	if storageEntry == nil {
+		return fmt.Errorf("invalid storage outbox entry type")
+	}
+
+	switch storageEntry.Operation {
+	case storageOutboxEntry.CreateBucketStorageOperation:
+		return os.innerStorage.CreateBucket(ctx, storageEntry.Bucket)
+	case storageOutboxEntry.DeleteBucketStorageOperation:
+		return os.innerStorage.DeleteBucket(ctx, storageEntry.Bucket)
+	case storageOutboxEntry.PutObjectStorageOperation:
+		chunks, err := os.storageOutboxEntryRepository.FindStorageOutboxEntryChunksById(ctx, tx, *storageEntry.Id)
+		if err != nil {
+			return err
+		}
+		readers := make([]io.Reader, len(chunks))
+		for i, chunk := range chunks {
+			readers[i] = bytes.NewReader(chunk.Content)
+		}
+		_, err = os.innerStorage.PutObject(ctx, storageEntry.Bucket, storage.MustNewObjectKey(storageEntry.Key), storageEntry.ContentType, io.MultiReader(readers...), nil, nil)
+		return err
+	case storageOutboxEntry.DeleteObjectStorageOperation:
+		return os.innerStorage.DeleteObject(ctx, storageEntry.Bucket, storage.MustNewObjectKey(storageEntry.Key), nil)
+	default:
+		slog.Warn(fmt.Sprint("Invalid operation", storageEntry.Operation, "during outbox processing."))
+		return fmt.Errorf("invalid operation: %s", storageEntry.Operation)
+	}
+}
+
+func (os *outboxStorage) DeleteEntry(ctx context.Context, tx *sql.Tx, storageEntry *storageOutboxEntry.Entity) error {
+	if storageEntry == nil {
+		return fmt.Errorf("invalid storage outbox entry type")
+	}
+	return os.storageOutboxEntryRepository.DeleteStorageOutboxEntryById(ctx, tx, *storageEntry.Id)
 }
 
 func (os *outboxStorage) storeStorageOutboxEntry(ctx context.Context, tx *sql.Tx, operation string, bucketName storage.BucketName, key string) (*ulid.ULID, error) {
@@ -280,10 +126,7 @@ func (os *outboxStorage) storeStorageOutboxEntry(ctx context.Context, tx *sql.Tx
 	}
 
 	// Put struct{} in the channel unless it is full
-	select {
-	case os.triggerChannel <- struct{}{}:
-	default:
-	}
+	os.runtime.Trigger()
 
 	return entry.Id, nil
 }

--- a/internal/storage/outboxruntime/runtime.go
+++ b/internal/storage/outboxruntime/runtime.go
@@ -1,0 +1,212 @@
+package outboxruntime
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/jdillenkofer/pithos/internal/storage/database"
+	"github.com/jdillenkofer/pithos/internal/task"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	PendingEntries     prometheus.Gauge
+	ProcessedEntries   prometheus.Counter
+	ProcessingDuration prometheus.Histogram
+	ErrorsCounter      prometheus.Counter
+}
+
+func NewMetrics(registerer prometheus.Registerer, subsystem string, pendingHelp string, processedHelp string, processingHelp string, errorsHelp string) *Metrics {
+	m := &Metrics{
+		PendingEntries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "pithos",
+			Subsystem: subsystem,
+			Name:      "pending_entries",
+			Help:      pendingHelp,
+		}),
+		ProcessedEntries: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "pithos",
+			Subsystem: subsystem,
+			Name:      "processed_entries_total",
+			Help:      processedHelp,
+		}),
+		ProcessingDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "pithos",
+			Subsystem: subsystem,
+			Name:      "processing_duration_seconds",
+			Help:      processingHelp,
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}),
+		ErrorsCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "pithos",
+			Subsystem: subsystem,
+			Name:      "errors_total",
+			Help:      errorsHelp,
+		}),
+	}
+
+	registerMetric(registerer, m.PendingEntries, "pendingEntries")
+	registerMetric(registerer, m.ProcessedEntries, "processedEntries")
+	registerMetric(registerer, m.ProcessingDuration, "processingDuration")
+	registerMetric(registerer, m.ErrorsCounter, "errorsCounter")
+
+	return m
+}
+
+func registerMetric(registerer prometheus.Registerer, collector prometheus.Collector, name string) {
+	if err := registerer.Register(collector); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			slog.Error(fmt.Sprintf("Failed to register %s metric", name), "error", err)
+		}
+	}
+}
+
+type Processor[T any] interface {
+	CountPending(ctx context.Context, tx *sql.Tx) (int, error)
+	FindFirstForUpdate(ctx context.Context, tx *sql.Tx) (T, error)
+	ProcessEntry(ctx context.Context, tx *sql.Tx, entry T) error
+	DeleteEntry(ctx context.Context, tx *sql.Tx, entry T) error
+	Name() string
+}
+
+type Runtime[T any] struct {
+	db                 database.Database
+	processor          Processor[T]
+	metrics            *Metrics
+	triggerChannel     chan struct{}
+	triggerClosed      bool
+	processingTask     *task.TaskHandle
+	pollInterval       time.Duration
+	errorBackoff       time.Duration
+	joinTimeout        time.Duration
+	processedLogFormat string
+}
+
+func New[T any](db database.Database, processor Processor[T], metrics *Metrics) *Runtime[T] {
+	return &Runtime[T]{
+		db:                 db,
+		processor:          processor,
+		metrics:            metrics,
+		triggerChannel:     make(chan struct{}, 16),
+		triggerClosed:      false,
+		pollInterval:       1 * time.Second,
+		errorBackoff:       5 * time.Second,
+		joinTimeout:        30 * time.Second,
+		processedLogFormat: "Processed %d outbox entries",
+	}
+}
+
+func (r *Runtime[T]) Trigger() {
+	select {
+	case r.triggerChannel <- struct{}{}:
+	default:
+	}
+}
+
+func (r *Runtime[T]) Start() {
+	r.processingTask = task.Start(func(_ *atomic.Bool) {
+		r.processLoop()
+	})
+}
+
+func (r *Runtime[T]) Stop() {
+	if r.triggerClosed {
+		return
+	}
+	close(r.triggerChannel)
+	if r.processingTask != nil {
+		joinedWithTimeout := r.processingTask.JoinWithTimeout(r.joinTimeout)
+		if joinedWithTimeout {
+			slog.Debug(fmt.Sprintf("%s processing task joined with timeout of %s", r.processor.Name(), r.joinTimeout))
+		} else {
+			slog.Debug(fmt.Sprintf("%s processing task joined without timeout", r.processor.Name()))
+		}
+	}
+	r.triggerClosed = true
+}
+
+func (r *Runtime[T]) processLoop() {
+	ctx := context.Background()
+out:
+	for {
+		select {
+		case _, ok := <-r.triggerChannel:
+			if !ok {
+				slog.Debug(fmt.Sprintf("Stopping %s processing", r.processor.Name()))
+				break out
+			}
+		case <-time.After(r.pollInterval):
+		}
+		r.maybeProcessEntries(ctx)
+	}
+}
+
+func (r *Runtime[T]) maybeProcessEntries(ctx context.Context) {
+	startTime := time.Now()
+	processedEntriesCount := 0
+	defer func() {
+		r.metrics.ProcessingDuration.Observe(time.Since(startTime).Seconds())
+		if processedEntriesCount > 0 {
+			r.metrics.ProcessedEntries.Add(float64(processedEntriesCount))
+		}
+	}()
+
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		return
+	}
+	pendingCount, err := r.processor.CountPending(ctx, tx)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	r.metrics.PendingEntries.Set(float64(pendingCount))
+	tx.Commit()
+
+	for {
+		tx, err := r.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		if err != nil {
+			r.metrics.ErrorsCounter.Inc()
+			return
+		}
+		entry, err := r.processor.FindFirstForUpdate(ctx, tx)
+		if err != nil {
+			tx.Rollback()
+			r.metrics.ErrorsCounter.Inc()
+			time.Sleep(r.errorBackoff)
+			return
+		}
+		if any(entry) == nil {
+			tx.Commit()
+			break
+		}
+
+		err = r.processor.ProcessEntry(ctx, tx, entry)
+		if err != nil {
+			tx.Rollback()
+			r.metrics.ErrorsCounter.Inc()
+			time.Sleep(r.errorBackoff)
+			return
+		}
+
+		err = r.processor.DeleteEntry(ctx, tx, entry)
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+
+		err = tx.Commit()
+		if err != nil {
+			return
+		}
+		processedEntriesCount += 1
+	}
+
+	if processedEntriesCount > 0 {
+		slog.Info(fmt.Sprintf(r.processedLogFormat, processedEntriesCount))
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce a shared outbox runtime in `internal/storage/outboxruntime` to centralize processing loop orchestration, trigger signaling, retries, and metrics registration.
- Refactor storage outbox and partstore outbox to implement small runtime adapter methods (`CountPending`, `FindFirstForUpdate`, `ProcessEntry`, `DeleteEntry`, `Name`) while preserving domain-specific enqueue/read behavior.
- Remove duplicated loop/task/metrics boilerplate from both outbox implementations without changing feature semantics.

## Validation
- `go test ./internal/storage/outbox ./internal/storage/metadatapart/partstore/outbox`
- `go test ./...`