### PR TITLE
fix(outbox): reduce lock contention and scope key waits

### DIFF
--- a/internal/storage/database/pgx/repository/partoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/partoutboxentry/pgx.go
@@ -18,7 +18,6 @@ const (
 	findLastPartOutboxEntryByPartIdStmt           = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE part_id = $1 ORDER BY id DESC LIMIT 1"
 	findLastPartOutboxEntryGroupedByPartIdStmt    = "SELECT DISTINCT ON (part_id) id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY part_id, id DESC"
 	findFirstPartOutboxEntryStmt                  = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY id ASC LIMIT 1"
-	findFirstPartOutboxEntryWithForUpdateLockStmt = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY id ASC LIMIT 1 FOR UPDATE"
 	findPartOutboxEntryChunksByIdStmt             = "SELECT outbox_entry_id, chunk_index, content FROM part_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
 	insertPartOutboxEntryStmt                     = "INSERT INTO part_outbox_entries (id, operation, part_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5)"
 	updatePartOutboxEntryByIdStmt                 = "UPDATE part_outbox_entries SET operation = $1, part_id = $2, updated_at = $3 WHERE id = $4"
@@ -108,15 +107,6 @@ func (bor *pgxRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.Con
 
 func (bor *pgxRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx) (*partoutboxentry.Entity, error) {
 	row := tx.QueryRowContext(ctx, findFirstPartOutboxEntryStmt)
-	partOutboxEntryEntity, err := convertRowToPartOutboxEntryEntity(row)
-	if err != nil {
-		return nil, err
-	}
-	return partOutboxEntryEntity, nil
-}
-
-func (bor *pgxRepository) FindFirstPartOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*partoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstPartOutboxEntryWithForUpdateLockStmt)
 	partOutboxEntryEntity, err := convertRowToPartOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err

--- a/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
@@ -15,7 +15,6 @@ type pgxRepository struct {
 
 const (
 	countStorageOutboxEntriesStmt                    = "SELECT COUNT(*) FROM storage_outbox_entries"
-	findFirstStorageOutboxEntryWithForUpdateLockStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1 FOR UPDATE"
 	findFirstStorageOutboxEntryStmt                  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
 	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
 	findFirstStorageOutboxEntryForBucketStmt         = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
@@ -69,15 +68,6 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 
 func (sor *pgxRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
 	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryStmt)
-	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
-	if err != nil {
-		return nil, err
-	}
-	return storageOutboxEntryEntity, nil
-}
-
-func (sor *pgxRepository) FindFirstStorageOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryWithForUpdateLockStmt)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err

--- a/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
@@ -19,6 +19,8 @@ const (
 	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
 	findFirstStorageOutboxEntryForBucketStmt         = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
 	findLastStorageOutboxEntryForBucketStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id DESC LIMIT 1"
 	findStorageOutboxEntryChunksByIdStmt             = "SELECT outbox_entry_id, chunk_index, content FROM storage_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
 	insertStorageOutboxEntryStmt                     = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
 	updateStorageOutboxEntryByIdStmt                 = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6"
@@ -95,6 +97,24 @@ func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Conte
 
 func (sor *pgxRepository) FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
 	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketStmt, bucketName.String())
+	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
+	if err != nil {
+		return nil, err
+	}
+	return storageOutboxEntryEntity, nil
+}
+
+func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
+	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
+	if err != nil {
+		return nil, err
+	}
+	return storageOutboxEntryEntity, nil
+}
+
+func (sor *pgxRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err

--- a/internal/storage/database/repository/partoutboxentry/interface.go
+++ b/internal/storage/database/repository/partoutboxentry/interface.go
@@ -13,7 +13,6 @@ type Repository interface {
 	Count(ctx context.Context, tx *sql.Tx) (int, error)
 	FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, partId partstore.PartId) (*Entity, error)
 	FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx) ([]Entity, error)
-	FindFirstPartOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*ContentChunk, error)
 	SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, partOutboxEntry *Entity) error

--- a/internal/storage/database/repository/storageoutboxentry/interface.go
+++ b/internal/storage/database/repository/storageoutboxentry/interface.go
@@ -15,6 +15,8 @@ type Repository interface {
 	FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*Entity, error)
 	FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*Entity, error)
+	FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*Entity, error)
+	FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*Entity, error)
 	FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*ContentChunk, error)
 	SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, storageOutboxEntry *Entity) error
 	SaveStorageOutboxContentChunk(ctx context.Context, tx *sql.Tx, chunk *ContentChunk) error

--- a/internal/storage/database/repository/storageoutboxentry/interface.go
+++ b/internal/storage/database/repository/storageoutboxentry/interface.go
@@ -12,7 +12,6 @@ import (
 type Repository interface {
 	Count(ctx context.Context, tx *sql.Tx) (int, error)
 	FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
-	FindFirstStorageOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
 	FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*Entity, error)
 	FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*Entity, error)

--- a/internal/storage/database/sqlite/repository/partoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/partoutboxentry/sqlite.go
@@ -114,10 +114,6 @@ func (bor *sqliteRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *s
 	return partOutboxEntryEntity, nil
 }
 
-func (bor *sqliteRepository) FindFirstPartOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*partoutboxentry.Entity, error) {
-	return bor.FindFirstPartOutboxEntry(ctx, tx)
-}
-
 func (bor *sqliteRepository) FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*partoutboxentry.ContentChunk, error) {
 	rows, err := tx.QueryContext(ctx, findPartOutboxEntryChunksByIdStmt, id.String())
 	if err != nil {

--- a/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
@@ -75,10 +75,6 @@ func (sor *sqliteRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindFirstStorageOutboxEntryWithForUpdateLock(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
-	return sor.FindFirstStorageOutboxEntry(ctx, tx)
-}
-
 func (sor *sqliteRepository) FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
 	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryStmt)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)

--- a/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
@@ -19,6 +19,8 @@ const (
 	findLastStorageOutboxEntryStmt           = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
 	findFirstStorageOutboxEntryForBucketStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
 	findLastStorageOutboxEntryForBucketStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id DESC LIMIT 1"
 	findStorageOutboxEntryChunksByIdStmt     = "SELECT outbox_entry_id, chunk_index, content FROM storage_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
 	insertStorageOutboxEntryStmt             = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
 	updateStorageOutboxEntryByIdStmt         = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6"
@@ -95,6 +97,24 @@ func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Co
 
 func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
 	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketStmt, bucketName.String())
+	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
+	if err != nil {
+		return nil, err
+	}
+	return storageOutboxEntryEntity, nil
+}
+
+func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
+	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
+	if err != nil {
+		return nil, err
+	}
+	return storageOutboxEntryEntity, nil
+}
+
+func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err

--- a/internal/storage/metadatapart/partstore/outbox/outbox.go
+++ b/internal/storage/metadatapart/partstore/outbox/outbox.go
@@ -121,7 +121,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 		}
 	}()
 
-	tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return
 	}
@@ -135,13 +135,16 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 	tx.Commit()
 
 	for {
-		tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		var entry *partOutboxEntry.Entity
+		var putPartReader io.Reader
+
+		tx, err := obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 		if err != nil {
 			obs.metrics.errorsCounter.Inc()
 			return
 		}
 
-		entry, err := obs.partOutboxEntryRepository.FindFirstPartOutboxEntryWithForUpdateLock(ctx, tx)
+		entry, err = obs.partOutboxEntryRepository.FindFirstPartOutboxEntry(ctx, tx)
 		if err != nil {
 			tx.Rollback()
 			obs.metrics.errorsCounter.Inc()
@@ -152,9 +155,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			tx.Commit()
 			break
 		}
-
-		switch entry.Operation {
-		case partOutboxEntry.PutPartOperation:
+		if entry.Operation == partOutboxEntry.PutPartOperation {
 			chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, *entry.Id)
 			if err != nil {
 				tx.Rollback()
@@ -166,7 +167,23 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			for i, chunk := range chunks {
 				readers[i] = bytes.NewReader(chunk.Content)
 			}
-			err = obs.innerPartStore.PutPart(ctx, tx, entry.PartId, io.MultiReader(readers...))
+			putPartReader = io.MultiReader(readers...)
+		}
+		err = tx.Commit()
+		if err != nil {
+			obs.metrics.errorsCounter.Inc()
+			return
+		}
+
+		tx, err = obs.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		if err != nil {
+			obs.metrics.errorsCounter.Inc()
+			return
+		}
+
+		switch entry.Operation {
+		case partOutboxEntry.PutPartOperation:
+			err = obs.innerPartStore.PutPart(ctx, tx, entry.PartId, putPartReader)
 			if err != nil {
 				tx.Rollback()
 				obs.metrics.errorsCounter.Inc()
@@ -191,6 +208,8 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 		err = obs.partOutboxEntryRepository.DeletePartOutboxEntryById(ctx, tx, *entry.Id)
 		if err != nil {
 			tx.Rollback()
+			obs.metrics.errorsCounter.Inc()
+			time.Sleep(5 * time.Second)
 			return
 		}
 		processedOutboxEntryCount += 1

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -126,7 +126,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 		}
 	}()
 
-	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return
 	}
@@ -139,12 +139,15 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 	tx.Commit()
 
 	for {
-		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		var entry *storageOutboxEntry.Entity
+		var putObjectReaders []io.Reader
+
+		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 		if err != nil {
 			os.metrics.errorsCounter.Inc()
 			return
 		}
-		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryWithForUpdateLock(ctx, tx)
+		entry, err = os.storageOutboxEntryRepository.FindFirstStorageOutboxEntry(ctx, tx)
 		if err != nil {
 			tx.Rollback()
 			os.metrics.errorsCounter.Inc()
@@ -155,25 +158,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			tx.Commit()
 			break
 		}
-
-		switch entry.Operation {
-		case storageOutboxEntry.CreateBucketStorageOperation:
-			err = os.innerStorage.CreateBucket(ctx, entry.Bucket)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		case storageOutboxEntry.DeleteBucketStorageOperation:
-			err = os.innerStorage.DeleteBucket(ctx, entry.Bucket)
-			if err != nil {
-				tx.Rollback()
-				os.metrics.errorsCounter.Inc()
-				time.Sleep(5 * time.Second)
-				return
-			}
-		case storageOutboxEntry.PutObjectStorageOperation:
+		if entry.Operation == storageOutboxEntry.PutObjectStorageOperation {
 			chunks, err := os.storageOutboxEntryRepository.FindStorageOutboxEntryChunksById(ctx, tx, *entry.Id)
 			if err != nil {
 				tx.Rollback()
@@ -181,13 +166,35 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 				time.Sleep(5 * time.Second)
 				return
 			}
-			readers := make([]io.Reader, len(chunks))
+			putObjectReaders = make([]io.Reader, len(chunks))
 			for i, chunk := range chunks {
-				readers[i] = bytes.NewReader(chunk.Content)
+				putObjectReaders[i] = bytes.NewReader(chunk.Content)
 			}
-			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(readers...), nil, nil)
+		}
+		err = tx.Commit()
+		if err != nil {
+			os.metrics.errorsCounter.Inc()
+			return
+		}
+
+		switch entry.Operation {
+		case storageOutboxEntry.CreateBucketStorageOperation:
+			err = os.innerStorage.CreateBucket(ctx, entry.Bucket)
 			if err != nil {
-				tx.Rollback()
+				os.metrics.errorsCounter.Inc()
+				time.Sleep(5 * time.Second)
+				return
+			}
+		case storageOutboxEntry.DeleteBucketStorageOperation:
+			err = os.innerStorage.DeleteBucket(ctx, entry.Bucket)
+			if err != nil {
+				os.metrics.errorsCounter.Inc()
+				time.Sleep(5 * time.Second)
+				return
+			}
+		case storageOutboxEntry.PutObjectStorageOperation:
+			_, err = os.innerStorage.PutObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), entry.ContentType, io.MultiReader(putObjectReaders...), nil, nil)
+			if err != nil {
 				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
@@ -195,20 +202,26 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 		case storageOutboxEntry.DeleteObjectStorageOperation:
 			err = os.innerStorage.DeleteObject(ctx, entry.Bucket, storage.MustNewObjectKey(entry.Key), nil)
 			if err != nil {
-				tx.Rollback()
 				os.metrics.errorsCounter.Inc()
 				time.Sleep(5 * time.Second)
 				return
 			}
 		default:
 			slog.Warn(fmt.Sprint("Invalid operation", entry.Operation, "during outbox processing."))
-			tx.Rollback()
 			time.Sleep(5 * time.Second)
+			return
+		}
+
+		tx, err = os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		if err != nil {
+			os.metrics.errorsCounter.Inc()
 			return
 		}
 		err = os.storageOutboxEntryRepository.DeleteStorageOutboxEntryById(ctx, tx, *entry.Id)
 		if err != nil {
 			tx.Rollback()
+			os.metrics.errorsCounter.Inc()
+			time.Sleep(5 * time.Second)
 			return
 		}
 
@@ -329,7 +342,7 @@ func (os *outboxStorage) DeleteBucket(ctx context.Context, bucketName storage.Bu
 }
 
 func (os *outboxStorage) waitForAllOutboxEntriesOfBucket(ctx context.Context, bucketName storage.BucketName) error {
-	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -349,7 +362,7 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucket(ctx context.Context, bu
 	lastId := lastStorageOutboxEntry.Id
 
 	for {
-		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 		if err != nil {
 			return err
 		}
@@ -373,7 +386,7 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucket(ctx context.Context, bu
 }
 
 func (os *outboxStorage) waitForAllOutboxEntries(ctx context.Context) error {
-	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -393,7 +406,7 @@ func (os *outboxStorage) waitForAllOutboxEntries(ctx context.Context) error {
 	lastId := lastStorageOutboxEntry.Id
 
 	for {
-		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 		if err != nil {
 			return err
 		}

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -385,6 +385,50 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucket(ctx context.Context, bu
 	}
 }
 
+func (os *outboxStorage) waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx context.Context, bucketName storage.BucketName, key storage.ObjectKey) error {
+	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return err
+	}
+	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx, tx, bucketName, key.String())
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+	if lastStorageOutboxEntry == nil {
+		return nil
+	}
+
+	lastId := lastStorageOutboxEntry.Id
+
+	for {
+		tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+		if err != nil {
+			return err
+		}
+		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx, tx, bucketName, key.String())
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+		err = tx.Commit()
+		if err != nil {
+			return err
+		}
+		if entry == nil {
+			return nil
+		}
+		if (*entry.Id).Compare(*lastId) > 0 {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
 func (os *outboxStorage) waitForAllOutboxEntries(ctx context.Context) error {
 	tx, err := os.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
@@ -469,7 +513,7 @@ func (os *outboxStorage) HeadObject(ctx context.Context, bucketName storage.Buck
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.HeadObject")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +525,7 @@ func (os *outboxStorage) GetObject(ctx context.Context, bucketName storage.Bucke
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.GetObject")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -496,7 +540,7 @@ func (os *outboxStorage) PutObject(ctx context.Context, bucketName storage.Bucke
 	defer span.End()
 
 	if opts != nil && (opts.IfNoneMatchStar || opts.IfMatchETag != nil) {
-		err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+		err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 		if err != nil {
 			return nil, err
 		}
@@ -571,8 +615,8 @@ func (os *outboxStorage) AppendObject(ctx context.Context, bucketName storage.Bu
 	defer span.End()
 
 	// Append is always conditional (requires the object to be consistent), so
-	// flush all pending outbox entries for the bucket before delegating.
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	// Append is key scoped but must respect global bucket operations.
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}
@@ -635,7 +679,7 @@ func (os *outboxStorage) CreateMultipartUpload(ctx context.Context, bucketName s
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.CreateMultipartUpload")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +690,7 @@ func (os *outboxStorage) UploadPart(ctx context.Context, bucketName storage.Buck
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.UploadPart")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +702,7 @@ func (os *outboxStorage) CompleteMultipartUpload(ctx context.Context, bucketName
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.CompleteMultipartUpload")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +714,7 @@ func (os *outboxStorage) AbortMultipartUpload(ctx context.Context, bucketName st
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.AbortMultipartUpload")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return err
 	}
@@ -694,7 +738,7 @@ func (os *outboxStorage) ListParts(ctx context.Context, bucketName storage.Bucke
 	ctx, span := os.tracer.Start(ctx, "OutboxStorage.ListParts")
 	defer span.End()
 
-	err := os.waitForAllOutboxEntriesOfBucket(ctx, bucketName)
+	err := os.waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ctx, bucketName, key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What changed
- changed outbox processing to avoid holding long write transactions during external storage operations
  - read next entry/chunks in a read-only transaction
  - execute side-effect outside transaction
  - use a short write transaction only to finalize (delete processed entry)
- switched outbox checking/polling paths to read-only transactions
- removed unused lock-specific repository methods (`*WithForUpdateLock`)
- scoped key-specific consistency waits to:
  - the same key, plus
  - bucket-global outbox entries (`key = ""`)
  so independent keys in the same bucket do not block each other

## Why
- reduce read blocking caused by long write transactions
- preserve correctness for key operations that still depend on bucket-global mutations (e.g. bucket create/delete)
- reduce unnecessary cross-key waiting in replicated/transactional outbox paths

## Notes
- follow-up design for strict ordered multi-instance claim/lease processing is tracked in #731

## Validation
- `go test ./internal/storage/outbox`
- `go test ./internal/storage/database/...`