### PR TITLE
fix(erasurecoding): prevent windows file-in-use test races

### DIFF
--- a/internal/storage/metadatapart/partstore/middlewares/erasurecoding/erasurecoding.go
+++ b/internal/storage/metadatapart/partstore/middlewares/erasurecoding/erasurecoding.go
@@ -29,6 +29,7 @@ const DefaultHealScanInterval = 7 * 24 * time.Hour
 type erasureCodingPartStore struct {
 	*lifecycle.ValidatedLifecycle
 	partStores    []partstore.PartStore
+	partLocker    partLocker
 	dataShards    int
 	parityShards  int
 	totalShards   int
@@ -75,6 +76,7 @@ func NewWithPartStores(dataShards int, parityShards int, stripeShardSize int, pa
 	store := &erasureCodingPartStore{
 		ValidatedLifecycle: v,
 		partStores:         partStores,
+		partLocker:         newPartLocker(),
 		dataShards:         dataShards,
 		parityShards:       parityShards,
 		totalShards:        totalShards,
@@ -217,6 +219,9 @@ func parseFrameHeader(b []byte) (uint64, int, int, []byte, error) {
 }
 
 func (e *erasureCodingPartStore) PutPart(ctx context.Context, tx *sql.Tx, partId partstore.PartId, reader io.Reader) error {
+	unlock := e.partLocker.Lock(partId)
+	defer unlock()
+
 	enc, err := reedsolomon.New(e.dataShards, e.parityShards)
 	if err != nil {
 		return err
@@ -301,6 +306,15 @@ func (e *erasureCodingPartStore) PutPart(ctx context.Context, tx *sql.Tx, partId
 }
 
 func (e *erasureCodingPartStore) GetPart(ctx context.Context, tx *sql.Tx, partId partstore.PartId) (io.ReadCloser, error) {
+	unlock := e.partLocker.Lock(partId)
+	unlockOnError := true
+	defer func() {
+		if unlockOnError {
+			// Prevent leaked locks when setup fails.
+			unlock()
+		}
+	}()
+
 	readers := make([]io.ReadCloser, e.totalShards)
 	healShards := make([]bool, e.totalShards)
 	for i := 0; i < e.totalShards; i++ {
@@ -490,19 +504,26 @@ func (e *erasureCodingPartStore) GetPart(ctx context.Context, tx *sql.Tx, partId
 		}
 	}()
 
-	return &readCloserWithWait{ReadCloser: pr, done: done}, nil
+	// Keep lock for stream lifetime so Windows cannot delete the shard mid-read.
+	unlockOnError = false
+	return &readCloserWithWait{ReadCloser: pr, done: done, unlock: unlock}, nil
 }
 
 type readCloserWithWait struct {
 	io.ReadCloser
 	done chan struct{}
 	once sync.Once
+	unlock func()
 }
 
 func (r *readCloserWithWait) Close() error {
 	err := r.ReadCloser.Close()
 	r.once.Do(func() {
 		<-r.done
+		if r.unlock != nil {
+			// Unlock only after read loop exits to avoid Windows file-in-use delete races.
+			r.unlock()
+		}
 	})
 	return err
 }
@@ -528,6 +549,9 @@ func (e *erasureCodingPartStore) GetPartIds(ctx context.Context, tx *sql.Tx) ([]
 }
 
 func (e *erasureCodingPartStore) DeletePart(ctx context.Context, tx *sql.Tx, partId partstore.PartId) error {
+	unlock := e.partLocker.Lock(partId)
+	defer unlock()
+
 	for i := 0; i < e.totalShards; i++ {
 		if err := e.partStores[i].DeletePart(ctx, tx, partId); err != nil {
 			return err

--- a/internal/storage/metadatapart/partstore/middlewares/erasurecoding/erasurecoding_test.go
+++ b/internal/storage/metadatapart/partstore/middlewares/erasurecoding/erasurecoding_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -36,9 +39,33 @@ func createTestStore(t *testing.T, shardCount int) (partstore.PartStore, []parts
 		assert.Nil(t, err)
 		stores = append(stores, s)
 	}
-	ec, err := NewWithPartStores(2, 1, 64*1024, stores)
+	// Disable background healing here because these tests delete shard files directly,
+	// bypassing middleware locks and otherwise introducing timing-dependent races.
+	ec, err := NewWithPartStores(2, 1, 64*1024, stores, WithHealScanInterval(0))
 	assert.Nil(t, err)
 	return ec, stores, db
+}
+
+func deleteShardPartWithRetry(t *testing.T, ctx context.Context, db database.Database, shardStore partstore.PartStore, partId partstore.PartId) {
+	t.Helper()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		tx, _ := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+		err := shardStore.DeletePart(ctx, tx, partId)
+		if err == nil {
+			assert.Nil(t, tx.Commit())
+			return
+		}
+		_ = tx.Rollback()
+
+		if runtime.GOOS == "windows" && errors.Is(err, syscall.Errno(32)) && time.Now().Before(deadline) {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		assert.Nil(t, err)
+		return
+	}
 }
 
 func TestErasureCodingPartStoreRoundtrip(t *testing.T) {
@@ -90,10 +117,9 @@ func TestErasureCodingPartStoreCanReconstructMissingShard(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, tx.Commit())
 
-	tx, _ = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
-	err = shardStores[0].DeletePart(ctx, tx, *partId)
-	assert.Nil(t, err)
-	assert.Nil(t, tx.Commit())
+	// Background healing reads shards concurrently; on Windows this can briefly
+	// block direct file deletion, so retry to keep this test deterministic.
+	deleteShardPartWithRetry(t, ctx, db, shardStores[0], *partId)
 
 	tx, _ = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	rc, err := store.GetPart(ctx, tx, *partId)
@@ -112,10 +138,8 @@ func TestErasureCodingPartStoreCanReconstructMissingShard(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, tx.Commit())
 
-	tx, _ = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
-	err = shardStores[1].DeletePart(ctx, tx, *partId)
-	assert.Nil(t, err)
-	assert.Nil(t, tx.Commit())
+	// Same rationale as above: direct shard deletion races active heal reads.
+	deleteShardPartWithRetry(t, ctx, db, shardStores[1], *partId)
 
 	tx, _ = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	rc, err = store.GetPart(ctx, tx, *partId)

--- a/internal/storage/metadatapart/partstore/middlewares/erasurecoding/partlocker_nonwindows.go
+++ b/internal/storage/metadatapart/partstore/middlewares/erasurecoding/partlocker_nonwindows.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package erasurecoding
+
+import "github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
+
+type partLocker interface {
+	Lock(partstore.PartId) func()
+}
+
+type noopPartLocker struct{}
+
+func newPartLocker() partLocker {
+	return &noopPartLocker{}
+}
+
+func (l *noopPartLocker) Lock(partstore.PartId) func() {
+	return func() {}
+}

--- a/internal/storage/metadatapart/partstore/middlewares/erasurecoding/partlocker_windows.go
+++ b/internal/storage/metadatapart/partstore/middlewares/erasurecoding/partlocker_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package erasurecoding
+
+import (
+	"sync"
+
+	"github.com/jdillenkofer/pithos/internal/storage/metadatapart/partstore"
+)
+
+type partLocker interface {
+	Lock(partstore.PartId) func()
+}
+
+type windowsPartLocker struct {
+	mu    sync.Mutex
+	locks map[string]*partLockEntry
+}
+
+type partLockEntry struct {
+	refs int
+	mu   sync.Mutex
+}
+
+func newPartLocker() partLocker {
+	return &windowsPartLocker{locks: make(map[string]*partLockEntry)}
+}
+
+func (l *windowsPartLocker) Lock(partId partstore.PartId) func() {
+	key := partId.String()
+
+	l.mu.Lock()
+	entry, ok := l.locks[key]
+	if !ok {
+		entry = &partLockEntry{}
+		l.locks[key] = entry
+	}
+	entry.refs++
+	l.mu.Unlock()
+
+	entry.mu.Lock()
+
+	return func() {
+		entry.mu.Unlock()
+
+		l.mu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(l.locks, key)
+		}
+		l.mu.Unlock()
+	}
+}


### PR DESCRIPTION
## What changed
- add Windows-only per-part locking in erasurecoding middleware (PutPart, GetPart, DeletePart)
- keep lock for the full GetPart stream lifetime and release on Close
- add no-op locker implementation for non-Windows builds
- disable background heal scan in the default erasurecoding test store helper to avoid non-deterministic races when tests delete shard files directly
- add brief inline comments explaining why lock lifetime and test behavior are needed

## Why
Windows returns sharing violations when deleting files that are still open. Concurrent read/heal and delete operations on the same part caused flaky CI behavior.

## Validation
- go test ./internal/storage/metadatapart/partstore/middlewares/erasurecoding -count=30
- GOOS=windows GOARCH=amd64 go test ./internal/storage/metadatapart/partstore/middlewares/erasurecoding -c