### PR TITLE
feat(outbox): support multi-instance row scoping

### DIFF
--- a/cmd/pithos_test.go
+++ b/cmd/pithos_test.go
@@ -510,7 +510,7 @@ func setupReplicatedStorage(ctx context.Context, registry *prometheus.Registry, 
 		return nil, err
 	}
 
-	outboxStorage, err := outbox.NewStorage(db2, s3ClientStorage, storageOutboxEntryRepository, registry)
+	outboxStorage, err := outbox.NewStorage(db2, "default", s3ClientStorage, storageOutboxEntryRepository, registry)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -203,6 +203,66 @@ Pithos supports multiple storage backends that can be configured in the storage 
 
 > **Deployment note:** Place each `root` on a different physical disk or failure domain to get real resilience benefits.
 
+### Multiple Outbox Instances
+
+You can run multiple `OutboxStorage` and `OutboxPartStore` instances against the same database by setting a unique `outboxId` per instance. All outbox SQL operations are scoped to that ID, so each instance only reads and mutates its own rows.
+
+If `outboxId` is omitted, Pithos uses `"default"` for backward compatibility.
+
+```json
+{
+  "type": "MetadataPartStorage",
+  "db": {
+    "type": "RegisterDatabaseReference",
+    "refName": "db",
+    "db": {
+      "type": "SqliteDatabase",
+      "dbPath": "./data/pithos.db"
+    }
+  },
+  "metadataStore": {
+    "type": "SqlMetadataStore",
+    "db": {
+      "type": "DatabaseReference",
+      "refName": "db"
+    }
+  },
+  "partStore": {
+    "type": "OutboxPartStore",
+    "outboxId": "node-a-part-outbox",
+    "db": {
+      "type": "DatabaseReference",
+      "refName": "db"
+    },
+    "innerPartStore": {
+      "type": "SqlPartStore",
+      "db": {
+        "type": "DatabaseReference",
+        "refName": "db"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "type": "OutboxStorage",
+  "outboxId": "node-a-storage-outbox",
+  "db": {
+    "type": "DatabaseReference",
+    "refName": "db"
+  },
+  "innerStorage": {
+    "type": "S3ClientStorage",
+    "endpoint": "http://127.0.0.1:9000",
+    "region": "us-east-1",
+    "accessKey": "your-access-key",
+    "secretKey": "your-secret-key"
+  }
+}
+```
+
 ## Storage Migration
 
 Pithos supports storage migration through the `migrate-storage` subcommand:

--- a/internal/storage/config/config.go
+++ b/internal/storage/config/config.go
@@ -37,6 +37,7 @@ import (
 )
 
 const (
+	defaultOutboxId                  = "default"
 	cacheStorageType                 = "CacheStorage"
 	metadataPartStorageType          = "MetadataPartStorage"
 	conditionalStorageMiddlewareType = "ConditionalStorageMiddleware"
@@ -430,6 +431,7 @@ type OutboxStorageConfiguration struct {
 	RawDatabase              json.RawMessage                     `json:"db"`
 	InnerStorageInstantiator StorageInstantiator                 `json:"-"`
 	RawInnerStorage          json.RawMessage                     `json:"innerStorage"`
+	OutboxId                 internalConfig.StringProvider       `json:"outboxId,omitempty"`
 	internalConfig.DynamicJsonType
 }
 
@@ -471,6 +473,10 @@ func (o *OutboxStorageConfiguration) Instantiate(diProvider dependencyinjection.
 	if err != nil {
 		return nil, err
 	}
+	outboxId := o.OutboxId.Value()
+	if outboxId == "" {
+		outboxId = defaultOutboxId
+	}
 	storageOutboxEntryRepository, err := repositoryFactory.NewStorageOutboxEntryRepository(db)
 	if err != nil {
 		return nil, err
@@ -480,7 +486,7 @@ func (o *OutboxStorageConfiguration) Instantiate(diProvider dependencyinjection.
 	if err != nil {
 		return nil, err
 	}
-	return outbox.NewStorage(db, innerStorage, storageOutboxEntryRepository, prometheusRegisterer.(prometheus.Registerer))
+	return outbox.NewStorage(db, outboxId, innerStorage, storageOutboxEntryRepository, prometheusRegisterer.(prometheus.Registerer))
 }
 
 type ReplicationStorageConfiguration struct {

--- a/internal/storage/database/pgx/migrations/12_outbox_instance_id.down.sql
+++ b/internal/storage/database/pgx/migrations/12_outbox_instance_id.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS storage_outbox_entries_outbox_id_bucket_key_id_idx;
+DROP INDEX IF EXISTS storage_outbox_entries_outbox_id_bucket_id_idx;
+DROP INDEX IF EXISTS storage_outbox_entries_outbox_id_id_idx;
+DROP INDEX IF EXISTS part_outbox_entries_outbox_id_part_id_id_idx;
+DROP INDEX IF EXISTS part_outbox_entries_outbox_id_id_idx;
+
+ALTER TABLE storage_outbox_entries DROP COLUMN outbox_id;
+ALTER TABLE part_outbox_entries DROP COLUMN outbox_id;

--- a/internal/storage/database/pgx/migrations/12_outbox_instance_id.up.sql
+++ b/internal/storage/database/pgx/migrations/12_outbox_instance_id.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE part_outbox_entries ADD COLUMN outbox_id TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE storage_outbox_entries ADD COLUMN outbox_id TEXT NOT NULL DEFAULT 'default';
+
+CREATE INDEX part_outbox_entries_outbox_id_id_idx ON part_outbox_entries (outbox_id, id);
+CREATE INDEX part_outbox_entries_outbox_id_part_id_id_idx ON part_outbox_entries (outbox_id, part_id, id);
+CREATE INDEX storage_outbox_entries_outbox_id_id_idx ON storage_outbox_entries (outbox_id, id);
+CREATE INDEX storage_outbox_entries_outbox_id_bucket_id_idx ON storage_outbox_entries (outbox_id, bucket, id);
+CREATE INDEX storage_outbox_entries_outbox_id_bucket_key_id_idx ON storage_outbox_entries (outbox_id, bucket, key, id);

--- a/internal/storage/database/pgx/repository/partoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/partoutboxentry/pgx.go
@@ -14,24 +14,24 @@ type pgxRepository struct {
 }
 
 const (
-	countPartOutboxEntriesStmt                    = "SELECT COUNT(*) FROM part_outbox_entries"
-	findLastPartOutboxEntryByPartIdStmt           = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE part_id = $1 ORDER BY id DESC LIMIT 1"
-	findLastPartOutboxEntryGroupedByPartIdStmt    = "SELECT DISTINCT ON (part_id) id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY part_id, id DESC"
-	findFirstPartOutboxEntryStmt                  = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY id ASC LIMIT 1"
-	findPartOutboxEntryChunksByIdStmt             = "SELECT outbox_entry_id, chunk_index, content FROM part_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
-	insertPartOutboxEntryStmt                     = "INSERT INTO part_outbox_entries (id, operation, part_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5)"
-	updatePartOutboxEntryByIdStmt                 = "UPDATE part_outbox_entries SET operation = $1, part_id = $2, updated_at = $3 WHERE id = $4"
+	countPartOutboxEntriesStmt                    = "SELECT COUNT(*) FROM part_outbox_entries WHERE outbox_id = $1"
+	findLastPartOutboxEntryByPartIdStmt           = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE outbox_id = $1 AND part_id = $2 ORDER BY id DESC LIMIT 1"
+	findLastPartOutboxEntryGroupedByPartIdStmt    = "SELECT DISTINCT ON (part_id) id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE outbox_id = $1 ORDER BY part_id, id DESC"
+	findFirstPartOutboxEntryStmt                  = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE outbox_id = $1 ORDER BY id ASC LIMIT 1"
+	findPartOutboxEntryChunksByIdStmt             = "SELECT c.outbox_entry_id, c.chunk_index, c.content FROM part_outbox_contents c INNER JOIN part_outbox_entries e ON e.id = c.outbox_entry_id WHERE c.outbox_entry_id = $1 AND e.outbox_id = $2 ORDER BY c.chunk_index ASC"
+	insertPartOutboxEntryStmt                     = "INSERT INTO part_outbox_entries (id, outbox_id, operation, part_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6)"
+	updatePartOutboxEntryByIdStmt                 = "UPDATE part_outbox_entries SET operation = $1, part_id = $2, updated_at = $3 WHERE id = $4 AND outbox_id = $5"
 	upsertPartOutboxContentChunkStmt              = "INSERT INTO part_outbox_contents (outbox_entry_id, chunk_index, content) VALUES($1, $2, $3) ON CONFLICT (outbox_entry_id, chunk_index) DO UPDATE SET content = EXCLUDED.content"
-	deletePartOutboxEntryByIdStmt                 = "DELETE FROM part_outbox_entries WHERE id = $1"
+	deletePartOutboxEntryByIdStmt                 = "DELETE FROM part_outbox_entries WHERE id = $1 AND outbox_id = $2"
 )
 
 func NewRepository() (partoutboxentry.Repository, error) {
 	return &pgxRepository{}, nil
 }
 
-func (bor *pgxRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+func (bor *pgxRepository) Count(ctx context.Context, tx *sql.Tx, outboxId string) (int, error) {
 	var count int
-	err := tx.QueryRowContext(ctx, countPartOutboxEntriesStmt).Scan(&count)
+	err := tx.QueryRowContext(ctx, countPartOutboxEntriesStmt, outboxId).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -83,13 +83,13 @@ func convertRowsToPartOutboxEntryEntity(partOutboxRows *sql.Rows) (*partoutboxen
 	}, nil
 }
 
-func (bor *pgxRepository) FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, partId partstore.PartId) (*partoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastPartOutboxEntryByPartIdStmt, partId.String())
+func (bor *pgxRepository) FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, outboxId string, partId partstore.PartId) (*partoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastPartOutboxEntryByPartIdStmt, outboxId, partId.String())
 	return convertRowToPartOutboxEntryEntity(row)
 }
 
-func (bor *pgxRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx) ([]partoutboxentry.Entity, error) {
-	partOutboxEntryRows, err := tx.QueryContext(ctx, findLastPartOutboxEntryGroupedByPartIdStmt)
+func (bor *pgxRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx, outboxId string) ([]partoutboxentry.Entity, error) {
+	partOutboxEntryRows, err := tx.QueryContext(ctx, findLastPartOutboxEntryGroupedByPartIdStmt, outboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func (bor *pgxRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.Con
 	return partOutboxEntryEntities, nil
 }
 
-func (bor *pgxRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx) (*partoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstPartOutboxEntryStmt)
+func (bor *pgxRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*partoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstPartOutboxEntryStmt, outboxId)
 	partOutboxEntryEntity, err := convertRowToPartOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -114,8 +114,8 @@ func (bor *pgxRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *sql.
 	return partOutboxEntryEntity, nil
 }
 
-func (bor *pgxRepository) FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*partoutboxentry.ContentChunk, error) {
-	rows, err := tx.QueryContext(ctx, findPartOutboxEntryChunksByIdStmt, id.String())
+func (bor *pgxRepository) FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) ([]*partoutboxentry.ContentChunk, error) {
+	rows, err := tx.QueryContext(ctx, findPartOutboxEntryChunksByIdStmt, id.String(), outboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -139,18 +139,18 @@ func (bor *pgxRepository) FindPartOutboxEntryChunksById(ctx context.Context, tx 
 	return chunks, nil
 }
 
-func (bor *pgxRepository) SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, partOutboxEntry *partoutboxentry.Entity) error {
+func (bor *pgxRepository) SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string, partOutboxEntry *partoutboxentry.Entity) error {
 	if partOutboxEntry.Id == nil {
 		id := ulid.Make()
 		partOutboxEntry.Id = &id
 		partOutboxEntry.CreatedAt = time.Now().UTC()
 		partOutboxEntry.UpdatedAt = partOutboxEntry.CreatedAt
-		_, err := tx.ExecContext(ctx, insertPartOutboxEntryStmt, partOutboxEntry.Id.String(), partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.CreatedAt, partOutboxEntry.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertPartOutboxEntryStmt, partOutboxEntry.Id.String(), outboxId, partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.CreatedAt, partOutboxEntry.UpdatedAt)
 		return err
 	}
 
 	partOutboxEntry.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updatePartOutboxEntryByIdStmt, partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.UpdatedAt, partOutboxEntry.Id.String())
+	_, err := tx.ExecContext(ctx, updatePartOutboxEntryByIdStmt, partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.UpdatedAt, partOutboxEntry.Id.String(), outboxId)
 	return err
 }
 
@@ -159,7 +159,7 @@ func (bor *pgxRepository) SavePartOutboxContentChunk(ctx context.Context, tx *sq
 	return err
 }
 
-func (bor *pgxRepository) DeletePartOutboxEntryById(ctx context.Context, tx *sql.Tx, id ulid.ULID) error {
-	_, err := tx.ExecContext(ctx, deletePartOutboxEntryByIdStmt, id.String())
+func (bor *pgxRepository) DeletePartOutboxEntryById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) error {
+	_, err := tx.ExecContext(ctx, deletePartOutboxEntryByIdStmt, id.String(), outboxId)
 	return err
 }

--- a/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
+++ b/internal/storage/database/pgx/repository/storageoutboxentry/pgx.go
@@ -14,27 +14,27 @@ type pgxRepository struct {
 }
 
 const (
-	countStorageOutboxEntriesStmt                    = "SELECT COUNT(*) FROM storage_outbox_entries"
-	findFirstStorageOutboxEntryStmt                  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
-	findFirstStorageOutboxEntryForBucketStmt         = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryForBucketStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
-	findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id DESC LIMIT 1"
-	findStorageOutboxEntryChunksByIdStmt             = "SELECT outbox_entry_id, chunk_index, content FROM storage_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
-	insertStorageOutboxEntryStmt                     = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
-	updateStorageOutboxEntryByIdStmt                 = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6"
+	countStorageOutboxEntriesStmt                    = "SELECT COUNT(*) FROM storage_outbox_entries WHERE outbox_id = $1"
+	findFirstStorageOutboxEntryStmt                  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryStmt                   = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketStmt         = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 AND (key = '' OR key = $3) ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 AND (key = '' OR key = $3) ORDER BY id DESC LIMIT 1"
+	findStorageOutboxEntryChunksByIdStmt             = "SELECT c.outbox_entry_id, c.chunk_index, c.content FROM storage_outbox_contents c INNER JOIN storage_outbox_entries e ON e.id = c.outbox_entry_id WHERE c.outbox_entry_id = $1 AND e.outbox_id = $2 ORDER BY c.chunk_index ASC"
+	insertStorageOutboxEntryStmt                     = "INSERT INTO storage_outbox_entries (id, outbox_id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8)"
+	updateStorageOutboxEntryByIdStmt                 = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6 AND outbox_id = $7"
 	upsertStorageOutboxContentChunkStmt              = "INSERT INTO storage_outbox_contents (outbox_entry_id, chunk_index, content) VALUES($1, $2, $3) ON CONFLICT (outbox_entry_id, chunk_index) DO UPDATE SET content = EXCLUDED.content"
-	deleteStorageOutboxEntryByIdStmt                 = "DELETE FROM storage_outbox_entries WHERE id = $1"
+	deleteStorageOutboxEntryByIdStmt                 = "DELETE FROM storage_outbox_entries WHERE id = $1 AND outbox_id = $2"
 )
 
 func NewRepository() (storageoutboxentry.Repository, error) {
 	return &pgxRepository{}, nil
 }
 
-func (sor *pgxRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+func (sor *pgxRepository) Count(ctx context.Context, tx *sql.Tx, outboxId string) (int, error) {
 	var count int
-	err := tx.QueryRowContext(ctx, countStorageOutboxEntriesStmt).Scan(&count)
+	err := tx.QueryRowContext(ctx, countStorageOutboxEntriesStmt, outboxId).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -68,8 +68,8 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 	}, nil
 }
 
-func (sor *pgxRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryStmt)
+func (sor *pgxRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryStmt, outboxId)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -77,8 +77,8 @@ func (sor *pgxRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx *s
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *pgxRepository) FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryStmt)
+func (sor *pgxRepository) FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryStmt, outboxId)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -86,8 +86,8 @@ func (sor *pgxRepository) FindLastStorageOutboxEntry(ctx context.Context, tx *sq
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketStmt, bucketName.String())
+func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketStmt, outboxId, bucketName.String())
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -95,8 +95,8 @@ func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Conte
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *pgxRepository) FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketStmt, bucketName.String())
+func (sor *pgxRepository) FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketStmt, outboxId, bucketName.String())
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -104,8 +104,8 @@ func (sor *pgxRepository) FindLastStorageOutboxEntryForBucket(ctx context.Contex
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
+func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, outboxId, bucketName.String(), key)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -113,8 +113,8 @@ func (sor *pgxRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlo
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *pgxRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
+func (sor *pgxRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, outboxId, bucketName.String(), key)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -122,8 +122,8 @@ func (sor *pgxRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlob
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *pgxRepository) FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*storageoutboxentry.ContentChunk, error) {
-	rows, err := tx.QueryContext(ctx, findStorageOutboxEntryChunksByIdStmt, id.String())
+func (sor *pgxRepository) FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) ([]*storageoutboxentry.ContentChunk, error) {
+	rows, err := tx.QueryContext(ctx, findStorageOutboxEntryChunksByIdStmt, id.String(), outboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -147,18 +147,18 @@ func (sor *pgxRepository) FindStorageOutboxEntryChunksById(ctx context.Context, 
 	return chunks, nil
 }
 
-func (sor *pgxRepository) SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, storageOutboxEntry *storageoutboxentry.Entity) error {
+func (sor *pgxRepository) SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string, storageOutboxEntry *storageoutboxentry.Entity) error {
 	if storageOutboxEntry.Id == nil {
 		id := ulid.Make()
 		storageOutboxEntry.Id = &id
 		storageOutboxEntry.CreatedAt = time.Now().UTC()
 		storageOutboxEntry.UpdatedAt = storageOutboxEntry.CreatedAt
-		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), outboxId, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
 		return err
 	}
 
 	storageOutboxEntry.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String())
+	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String(), outboxId)
 	return err
 }
 
@@ -167,7 +167,7 @@ func (sor *pgxRepository) SaveStorageOutboxContentChunk(ctx context.Context, tx 
 	return err
 }
 
-func (sor *pgxRepository) DeleteStorageOutboxEntryById(ctx context.Context, tx *sql.Tx, id ulid.ULID) error {
-	_, err := tx.ExecContext(ctx, deleteStorageOutboxEntryByIdStmt, id.String())
+func (sor *pgxRepository) DeleteStorageOutboxEntryById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) error {
+	_, err := tx.ExecContext(ctx, deleteStorageOutboxEntryByIdStmt, id.String(), outboxId)
 	return err
 }

--- a/internal/storage/database/repository/partoutboxentry/interface.go
+++ b/internal/storage/database/repository/partoutboxentry/interface.go
@@ -10,14 +10,14 @@ import (
 )
 
 type Repository interface {
-	Count(ctx context.Context, tx *sql.Tx) (int, error)
-	FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, partId partstore.PartId) (*Entity, error)
-	FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx) ([]Entity, error)
-	FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
-	FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*ContentChunk, error)
-	SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, partOutboxEntry *Entity) error
+	Count(ctx context.Context, tx *sql.Tx, outboxId string) (int, error)
+	FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, outboxId string, partId partstore.PartId) (*Entity, error)
+	FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx, outboxId string) ([]Entity, error)
+	FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*Entity, error)
+	FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) ([]*ContentChunk, error)
+	SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string, partOutboxEntry *Entity) error
 	SavePartOutboxContentChunk(ctx context.Context, tx *sql.Tx, chunk *ContentChunk) error
-	DeletePartOutboxEntryById(ctx context.Context, tx *sql.Tx, id ulid.ULID) error
+	DeletePartOutboxEntryById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) error
 }
 
 type Entity struct {

--- a/internal/storage/database/repository/storageoutboxentry/interface.go
+++ b/internal/storage/database/repository/storageoutboxentry/interface.go
@@ -10,17 +10,17 @@ import (
 )
 
 type Repository interface {
-	Count(ctx context.Context, tx *sql.Tx) (int, error)
-	FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
-	FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*Entity, error)
-	FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*Entity, error)
-	FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*Entity, error)
-	FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*Entity, error)
-	FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*Entity, error)
-	FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*ContentChunk, error)
-	SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, storageOutboxEntry *Entity) error
+	Count(ctx context.Context, tx *sql.Tx, outboxId string) (int, error)
+	FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*Entity, error)
+	FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*Entity, error)
+	FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName) (*Entity, error)
+	FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName) (*Entity, error)
+	FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName, key string) (*Entity, error)
+	FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName, key string) (*Entity, error)
+	FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) ([]*ContentChunk, error)
+	SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string, storageOutboxEntry *Entity) error
 	SaveStorageOutboxContentChunk(ctx context.Context, tx *sql.Tx, chunk *ContentChunk) error
-	DeleteStorageOutboxEntryById(ctx context.Context, tx *sql.Tx, id ulid.ULID) error
+	DeleteStorageOutboxEntryById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) error
 }
 
 type Entity struct {

--- a/internal/storage/database/sqlite/migrations/19_outbox_instance_id.down.sql
+++ b/internal/storage/database/sqlite/migrations/19_outbox_instance_id.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS storage_outbox_entries_outbox_id_bucket_key_id_idx;
+DROP INDEX IF EXISTS storage_outbox_entries_outbox_id_bucket_id_idx;
+DROP INDEX IF EXISTS storage_outbox_entries_outbox_id_id_idx;
+DROP INDEX IF EXISTS part_outbox_entries_outbox_id_part_id_id_idx;
+DROP INDEX IF EXISTS part_outbox_entries_outbox_id_id_idx;
+
+ALTER TABLE storage_outbox_entries DROP COLUMN outbox_id;
+ALTER TABLE part_outbox_entries DROP COLUMN outbox_id;

--- a/internal/storage/database/sqlite/migrations/19_outbox_instance_id.up.sql
+++ b/internal/storage/database/sqlite/migrations/19_outbox_instance_id.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE part_outbox_entries ADD COLUMN outbox_id TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE storage_outbox_entries ADD COLUMN outbox_id TEXT NOT NULL DEFAULT 'default';
+
+CREATE INDEX part_outbox_entries_outbox_id_id_idx ON part_outbox_entries (outbox_id, id);
+CREATE INDEX part_outbox_entries_outbox_id_part_id_id_idx ON part_outbox_entries (outbox_id, part_id, id);
+CREATE INDEX storage_outbox_entries_outbox_id_id_idx ON storage_outbox_entries (outbox_id, id);
+CREATE INDEX storage_outbox_entries_outbox_id_bucket_id_idx ON storage_outbox_entries (outbox_id, bucket, id);
+CREATE INDEX storage_outbox_entries_outbox_id_bucket_key_id_idx ON storage_outbox_entries (outbox_id, bucket, key, id);

--- a/internal/storage/database/sqlite/repository/partoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/partoutboxentry/sqlite.go
@@ -14,24 +14,24 @@ type sqliteRepository struct {
 }
 
 const (
-	countPartOutboxEntriesStmt                 = "SELECT COUNT(*) FROM part_outbox_entries"
-	findLastPartOutboxEntryByPartIdStmt        = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE part_id = $1 ORDER BY id DESC LIMIT 1"
-	findLastPartOutboxEntryGroupedByPartIdStmt = "SELECT e.id, e.operation, e.part_id, e.created_at, e.updated_at FROM part_outbox_entries e INNER JOIN ( SELECT part_id, MAX(id) as max_id FROM part_outbox_entries GROUP BY part_id) m ON e.part_id = m.part_id AND e.id = m.max_id"
-	findFirstPartOutboxEntryStmt               = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries ORDER BY id ASC LIMIT 1"
-	findPartOutboxEntryChunksByIdStmt          = "SELECT outbox_entry_id, chunk_index, content FROM part_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
-	insertPartOutboxEntryStmt                  = "INSERT INTO part_outbox_entries (id, operation, part_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5)"
-	updatePartOutboxEntryByIdStmt              = "UPDATE part_outbox_entries SET operation = $1, part_id = $2, updated_at = $3 WHERE id = $4"
+	countPartOutboxEntriesStmt                 = "SELECT COUNT(*) FROM part_outbox_entries WHERE outbox_id = $1"
+	findLastPartOutboxEntryByPartIdStmt        = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE outbox_id = $1 AND part_id = $2 ORDER BY id DESC LIMIT 1"
+	findLastPartOutboxEntryGroupedByPartIdStmt = "SELECT e.id, e.operation, e.part_id, e.created_at, e.updated_at FROM part_outbox_entries e INNER JOIN ( SELECT part_id, MAX(id) as max_id FROM part_outbox_entries WHERE outbox_id = $1 GROUP BY part_id) m ON e.part_id = m.part_id AND e.id = m.max_id WHERE e.outbox_id = $1"
+	findFirstPartOutboxEntryStmt               = "SELECT id, operation, part_id, created_at, updated_at FROM part_outbox_entries WHERE outbox_id = $1 ORDER BY id ASC LIMIT 1"
+	findPartOutboxEntryChunksByIdStmt          = "SELECT c.outbox_entry_id, c.chunk_index, c.content FROM part_outbox_contents c INNER JOIN part_outbox_entries e ON e.id = c.outbox_entry_id WHERE c.outbox_entry_id = $1 AND e.outbox_id = $2 ORDER BY c.chunk_index ASC"
+	insertPartOutboxEntryStmt                  = "INSERT INTO part_outbox_entries (id, outbox_id, operation, part_id, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6)"
+	updatePartOutboxEntryByIdStmt              = "UPDATE part_outbox_entries SET operation = $1, part_id = $2, updated_at = $3 WHERE id = $4 AND outbox_id = $5"
 	upsertPartOutboxContentChunkStmt           = "INSERT OR REPLACE INTO part_outbox_contents (outbox_entry_id, chunk_index, content) VALUES($1, $2, $3)"
-	deletePartOutboxEntryByIdStmt              = "DELETE FROM part_outbox_entries WHERE id = $1"
+	deletePartOutboxEntryByIdStmt              = "DELETE FROM part_outbox_entries WHERE id = $1 AND outbox_id = $2"
 )
 
 func NewRepository() (partoutboxentry.Repository, error) {
 	return &sqliteRepository{}, nil
 }
 
-func (bor *sqliteRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+func (bor *sqliteRepository) Count(ctx context.Context, tx *sql.Tx, outboxId string) (int, error) {
 	var count int
-	err := tx.QueryRowContext(ctx, countPartOutboxEntriesStmt).Scan(&count)
+	err := tx.QueryRowContext(ctx, countPartOutboxEntriesStmt, outboxId).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -83,13 +83,13 @@ func convertRowsToPartOutboxEntryEntity(partOutboxRows *sql.Rows) (*partoutboxen
 	}, nil
 }
 
-func (bor *sqliteRepository) FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, partId partstore.PartId) (*partoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastPartOutboxEntryByPartIdStmt, partId.String())
+func (bor *sqliteRepository) FindLastPartOutboxEntryByPartId(ctx context.Context, tx *sql.Tx, outboxId string, partId partstore.PartId) (*partoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastPartOutboxEntryByPartIdStmt, outboxId, partId.String())
 	return convertRowToPartOutboxEntryEntity(row)
 }
 
-func (bor *sqliteRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx) ([]partoutboxentry.Entity, error) {
-	partOutboxEntryRows, err := tx.QueryContext(ctx, findLastPartOutboxEntryGroupedByPartIdStmt)
+func (bor *sqliteRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.Context, tx *sql.Tx, outboxId string) ([]partoutboxentry.Entity, error) {
+	partOutboxEntryRows, err := tx.QueryContext(ctx, findLastPartOutboxEntryGroupedByPartIdStmt, outboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func (bor *sqliteRepository) FindLastPartOutboxEntryGroupedByPartId(ctx context.
 	return partOutboxEntryEntities, nil
 }
 
-func (bor *sqliteRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx) (*partoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstPartOutboxEntryStmt)
+func (bor *sqliteRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*partoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstPartOutboxEntryStmt, outboxId)
 	partOutboxEntryEntity, err := convertRowToPartOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -114,8 +114,8 @@ func (bor *sqliteRepository) FindFirstPartOutboxEntry(ctx context.Context, tx *s
 	return partOutboxEntryEntity, nil
 }
 
-func (bor *sqliteRepository) FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*partoutboxentry.ContentChunk, error) {
-	rows, err := tx.QueryContext(ctx, findPartOutboxEntryChunksByIdStmt, id.String())
+func (bor *sqliteRepository) FindPartOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) ([]*partoutboxentry.ContentChunk, error) {
+	rows, err := tx.QueryContext(ctx, findPartOutboxEntryChunksByIdStmt, id.String(), outboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -139,18 +139,18 @@ func (bor *sqliteRepository) FindPartOutboxEntryChunksById(ctx context.Context, 
 	return chunks, nil
 }
 
-func (bor *sqliteRepository) SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, partOutboxEntry *partoutboxentry.Entity) error {
+func (bor *sqliteRepository) SavePartOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string, partOutboxEntry *partoutboxentry.Entity) error {
 	if partOutboxEntry.Id == nil {
 		id := ulid.Make()
 		partOutboxEntry.Id = &id
 		partOutboxEntry.CreatedAt = time.Now().UTC()
 		partOutboxEntry.UpdatedAt = partOutboxEntry.CreatedAt
-		_, err := tx.ExecContext(ctx, insertPartOutboxEntryStmt, partOutboxEntry.Id.String(), partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.CreatedAt, partOutboxEntry.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertPartOutboxEntryStmt, partOutboxEntry.Id.String(), outboxId, partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.CreatedAt, partOutboxEntry.UpdatedAt)
 		return err
 	}
 
 	partOutboxEntry.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updatePartOutboxEntryByIdStmt, partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.UpdatedAt, partOutboxEntry.Id.String())
+	_, err := tx.ExecContext(ctx, updatePartOutboxEntryByIdStmt, partOutboxEntry.Operation, partOutboxEntry.PartId.String(), partOutboxEntry.UpdatedAt, partOutboxEntry.Id.String(), outboxId)
 	return err
 }
 
@@ -159,7 +159,7 @@ func (bor *sqliteRepository) SavePartOutboxContentChunk(ctx context.Context, tx 
 	return err
 }
 
-func (bor *sqliteRepository) DeletePartOutboxEntryById(ctx context.Context, tx *sql.Tx, id ulid.ULID) error {
-	_, err := tx.ExecContext(ctx, deletePartOutboxEntryByIdStmt, id.String())
+func (bor *sqliteRepository) DeletePartOutboxEntryById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) error {
+	_, err := tx.ExecContext(ctx, deletePartOutboxEntryByIdStmt, id.String(), outboxId)
 	return err
 }

--- a/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
+++ b/internal/storage/database/sqlite/repository/storageoutboxentry/sqlite.go
@@ -14,27 +14,27 @@ type sqliteRepository struct {
 }
 
 const (
-	countStorageOutboxEntriesStmt            = "SELECT COUNT(*) FROM storage_outbox_entries"
-	findFirstStorageOutboxEntryStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryStmt           = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries ORDER BY id DESC LIMIT 1"
-	findFirstStorageOutboxEntryForBucketStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryForBucketStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 ORDER BY id DESC LIMIT 1"
-	findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id ASC LIMIT 1"
-	findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE bucket = $1 AND (key = '' OR key = $2) ORDER BY id DESC LIMIT 1"
-	findStorageOutboxEntryChunksByIdStmt     = "SELECT outbox_entry_id, chunk_index, content FROM storage_outbox_contents WHERE outbox_entry_id = $1 ORDER BY chunk_index ASC"
-	insertStorageOutboxEntryStmt             = "INSERT INTO storage_outbox_entries (id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7)"
-	updateStorageOutboxEntryByIdStmt         = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6"
+	countStorageOutboxEntriesStmt            = "SELECT COUNT(*) FROM storage_outbox_entries WHERE outbox_id = $1"
+	findFirstStorageOutboxEntryStmt          = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryStmt           = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 ORDER BY id DESC LIMIT 1"
+	findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 AND (key = '' OR key = $3) ORDER BY id ASC LIMIT 1"
+	findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt  = "SELECT id, operation, bucket, key, content_type, created_at, updated_at FROM storage_outbox_entries WHERE outbox_id = $1 AND bucket = $2 AND (key = '' OR key = $3) ORDER BY id DESC LIMIT 1"
+	findStorageOutboxEntryChunksByIdStmt     = "SELECT c.outbox_entry_id, c.chunk_index, c.content FROM storage_outbox_contents c INNER JOIN storage_outbox_entries e ON e.id = c.outbox_entry_id WHERE c.outbox_entry_id = $1 AND e.outbox_id = $2 ORDER BY c.chunk_index ASC"
+	insertStorageOutboxEntryStmt             = "INSERT INTO storage_outbox_entries (id, outbox_id, operation, bucket, key, content_type, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8)"
+	updateStorageOutboxEntryByIdStmt         = "UPDATE storage_outbox_entries SET operation = $1, bucket = $2, key = $3, content_type = $4, updated_at = $5 WHERE id = $6 AND outbox_id = $7"
 	upsertStorageOutboxContentChunkStmt      = "INSERT OR REPLACE INTO storage_outbox_contents (outbox_entry_id, chunk_index, content) VALUES($1, $2, $3)"
-	deleteStorageOutboxEntryByIdStmt         = "DELETE FROM storage_outbox_entries WHERE id = $1"
+	deleteStorageOutboxEntryByIdStmt         = "DELETE FROM storage_outbox_entries WHERE id = $1 AND outbox_id = $2"
 )
 
 func NewRepository() (storageoutboxentry.Repository, error) {
 	return &sqliteRepository{}, nil
 }
 
-func (sor *sqliteRepository) Count(ctx context.Context, tx *sql.Tx) (int, error) {
+func (sor *sqliteRepository) Count(ctx context.Context, tx *sql.Tx, outboxId string) (int, error) {
 	var count int
-	err := tx.QueryRowContext(ctx, countStorageOutboxEntriesStmt).Scan(&count)
+	err := tx.QueryRowContext(ctx, countStorageOutboxEntriesStmt, outboxId).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -68,8 +68,8 @@ func convertRowToStorageOutboxEntryEntity(storageOutboxRow *sql.Row) (*storageou
 	}, nil
 }
 
-func (sor *sqliteRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryStmt)
+func (sor *sqliteRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryStmt, outboxId)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -77,8 +77,8 @@ func (sor *sqliteRepository) FindFirstStorageOutboxEntry(ctx context.Context, tx
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryStmt)
+func (sor *sqliteRepository) FindLastStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryStmt, outboxId)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -86,8 +86,8 @@ func (sor *sqliteRepository) FindLastStorageOutboxEntry(ctx context.Context, tx 
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketStmt, bucketName.String())
+func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketStmt, outboxId, bucketName.String())
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -95,8 +95,8 @@ func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucket(ctx context.Co
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketStmt, bucketName.String())
+func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucket(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketStmt, outboxId, bucketName.String())
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -104,8 +104,8 @@ func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucket(ctx context.Con
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
+func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findFirstStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, outboxId, bucketName.String(), key)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -113,8 +113,8 @@ func (sor *sqliteRepository) FindFirstStorageOutboxEntryForBucketAndKeyIncluding
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
-	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, bucketName.String(), key)
+func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx context.Context, tx *sql.Tx, outboxId string, bucketName storage.BucketName, key string) (*storageoutboxentry.Entity, error) {
+	row := tx.QueryRowContext(ctx, findLastStorageOutboxEntryForBucketAndKeyIncludingGlobalStmt, outboxId, bucketName.String(), key)
 	storageOutboxEntryEntity, err := convertRowToStorageOutboxEntryEntity(row)
 	if err != nil {
 		return nil, err
@@ -122,8 +122,8 @@ func (sor *sqliteRepository) FindLastStorageOutboxEntryForBucketAndKeyIncludingG
 	return storageOutboxEntryEntity, nil
 }
 
-func (sor *sqliteRepository) FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, id ulid.ULID) ([]*storageoutboxentry.ContentChunk, error) {
-	rows, err := tx.QueryContext(ctx, findStorageOutboxEntryChunksByIdStmt, id.String())
+func (sor *sqliteRepository) FindStorageOutboxEntryChunksById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) ([]*storageoutboxentry.ContentChunk, error) {
+	rows, err := tx.QueryContext(ctx, findStorageOutboxEntryChunksByIdStmt, id.String(), outboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -147,18 +147,18 @@ func (sor *sqliteRepository) FindStorageOutboxEntryChunksById(ctx context.Contex
 	return chunks, nil
 }
 
-func (sor *sqliteRepository) SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, storageOutboxEntry *storageoutboxentry.Entity) error {
+func (sor *sqliteRepository) SaveStorageOutboxEntry(ctx context.Context, tx *sql.Tx, outboxId string, storageOutboxEntry *storageoutboxentry.Entity) error {
 	if storageOutboxEntry.Id == nil {
 		id := ulid.Make()
 		storageOutboxEntry.Id = &id
 		storageOutboxEntry.CreatedAt = time.Now().UTC()
 		storageOutboxEntry.UpdatedAt = storageOutboxEntry.CreatedAt
-		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
+		_, err := tx.ExecContext(ctx, insertStorageOutboxEntryStmt, storageOutboxEntry.Id.String(), outboxId, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.CreatedAt, storageOutboxEntry.UpdatedAt)
 		return err
 	}
 
 	storageOutboxEntry.UpdatedAt = time.Now().UTC()
-	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String())
+	_, err := tx.ExecContext(ctx, updateStorageOutboxEntryByIdStmt, storageOutboxEntry.Operation, storageOutboxEntry.Bucket.String(), storageOutboxEntry.Key, storageOutboxEntry.ContentType, storageOutboxEntry.UpdatedAt, storageOutboxEntry.Id.String(), outboxId)
 	return err
 }
 
@@ -167,7 +167,7 @@ func (sor *sqliteRepository) SaveStorageOutboxContentChunk(ctx context.Context, 
 	return err
 }
 
-func (sor *sqliteRepository) DeleteStorageOutboxEntryById(ctx context.Context, tx *sql.Tx, id ulid.ULID) error {
-	_, err := tx.ExecContext(ctx, deleteStorageOutboxEntryByIdStmt, id.String())
+func (sor *sqliteRepository) DeleteStorageOutboxEntryById(ctx context.Context, tx *sql.Tx, outboxId string, id ulid.ULID) error {
+	_, err := tx.ExecContext(ctx, deleteStorageOutboxEntryByIdStmt, id.String(), outboxId)
 	return err
 }

--- a/internal/storage/factory/factory.go
+++ b/internal/storage/factory/factory.go
@@ -105,7 +105,7 @@ func CreateStorage(storagePath string, db database.Database, useFilesystemPartSt
 			slog.Error(fmt.Sprintf("Could not create PartOutboxEntryRepository: %s", err))
 			os.Exit(1)
 		}
-		partStore, err = outboxPartStore.New(db, partStore, partOutboxEntryRepository, registerer)
+		partStore, err = outboxPartStore.New(db, "default", partStore, partOutboxEntryRepository, registerer)
 		if err != nil {
 			slog.Error(fmt.Sprint("Error during NewOutboxPartStore: ", err))
 			os.Exit(1)

--- a/internal/storage/metadatapart/partstore/config/config.go
+++ b/internal/storage/metadatapart/partstore/config/config.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	defaultOutboxId                        = "default"
 	filesystemPartStoreType               = "FilesystemPartStore"
 	compressionMiddlewareType             = "CompressionPartStoreMiddleware"
 	tinkEncryptionPartStoreMiddlewareType = "TinkEncryptionPartStoreMiddleware"
@@ -292,6 +293,7 @@ type OutboxPartStoreConfiguration struct {
 	RawDatabase                json.RawMessage                     `json:"db"`
 	InnerPartStoreInstantiator PartStoreInstantiator               `json:"-"`
 	RawInnerPartStore          json.RawMessage                     `json:"innerPartStore"`
+	OutboxId                   internalConfig.StringProvider       `json:"outboxId,omitempty"`
 	internalConfig.DynamicJsonType
 }
 
@@ -330,6 +332,10 @@ func (o *OutboxPartStoreConfiguration) Instantiate(diProvider dependencyinjectio
 	if err != nil {
 		return nil, err
 	}
+	outboxId := o.OutboxId.Value()
+	if outboxId == "" {
+		outboxId = defaultOutboxId
+	}
 	partOutboxEntryRepository, err := repositoryFactory.NewPartOutboxEntryRepository(db)
 	if err != nil {
 		return nil, err
@@ -343,7 +349,7 @@ func (o *OutboxPartStoreConfiguration) Instantiate(diProvider dependencyinjectio
 	if err != nil {
 		return nil, err
 	}
-	return outbox.New(db, innerPartStore, partOutboxEntryRepository, prometheusRegisterer.(prometheus.Registerer))
+	return outbox.New(db, outboxId, innerPartStore, partOutboxEntryRepository, prometheusRegisterer.(prometheus.Registerer))
 }
 
 type SftpPartStoreConfiguration struct {

--- a/internal/storage/metadatapart/partstore/outbox/outbox.go
+++ b/internal/storage/metadatapart/partstore/outbox/outbox.go
@@ -85,6 +85,7 @@ type outboxPartStore struct {
 	db                         database.Database
 	triggerChannel             chan struct{}
 	triggerChannelClosed       bool
+	outboxId                   string
 	outboxProcessingTaskHandle *task.TaskHandle
 	innerPartStore             partstore.PartStore
 	partOutboxEntryRepository  partOutboxEntry.Repository
@@ -95,11 +96,12 @@ type outboxPartStore struct {
 // Compile-time check to ensure outboxPartStore implements partstore.PartStore
 var _ partstore.PartStore = (*outboxPartStore)(nil)
 
-func New(db database.Database, innerPartStore partstore.PartStore, partOutboxEntryRepository partOutboxEntry.Repository, registerer prometheus.Registerer) (partstore.PartStore, error) {
+func New(db database.Database, outboxId string, innerPartStore partstore.PartStore, partOutboxEntryRepository partOutboxEntry.Repository, registerer prometheus.Registerer) (partstore.PartStore, error) {
 	obs := &outboxPartStore{
 		db:                        db,
 		triggerChannel:            make(chan struct{}, 16),
 		triggerChannelClosed:      false,
+		outboxId:                  outboxId,
 		innerPartStore:            innerPartStore,
 		partOutboxEntryRepository: partOutboxEntryRepository,
 		tracer:                    otel.Tracer("internal/storage/metadatapart/partstore/outbox"),
@@ -126,7 +128,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 		return
 	}
 
-	pendingCount, err := obs.partOutboxEntryRepository.Count(ctx, tx)
+	pendingCount, err := obs.partOutboxEntryRepository.Count(ctx, tx, obs.outboxId)
 	if err != nil {
 		tx.Rollback()
 		return
@@ -144,7 +146,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			return
 		}
 
-		entry, err = obs.partOutboxEntryRepository.FindFirstPartOutboxEntry(ctx, tx)
+		entry, err = obs.partOutboxEntryRepository.FindFirstPartOutboxEntry(ctx, tx, obs.outboxId)
 		if err != nil {
 			tx.Rollback()
 			obs.metrics.errorsCounter.Inc()
@@ -156,7 +158,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			break
 		}
 		if entry.Operation == partOutboxEntry.PutPartOperation {
-			chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, *entry.Id)
+			chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, obs.outboxId, *entry.Id)
 			if err != nil {
 				tx.Rollback()
 				obs.metrics.errorsCounter.Inc()
@@ -205,7 +207,7 @@ func (obs *outboxPartStore) maybeProcessOutboxEntries(ctx context.Context) {
 			time.Sleep(5 * time.Second)
 			return
 		}
-		err = obs.partOutboxEntryRepository.DeletePartOutboxEntryById(ctx, tx, *entry.Id)
+		err = obs.partOutboxEntryRepository.DeletePartOutboxEntryById(ctx, tx, obs.outboxId, *entry.Id)
 		if err != nil {
 			tx.Rollback()
 			obs.metrics.errorsCounter.Inc()
@@ -270,7 +272,7 @@ func (obs *outboxPartStore) storePartOutboxEntry(ctx context.Context, tx *sql.Tx
 		Operation: operation,
 		PartId:    partId,
 	}
-	err := obs.partOutboxEntryRepository.SavePartOutboxEntry(ctx, tx, &entry)
+	err := obs.partOutboxEntryRepository.SavePartOutboxEntry(ctx, tx, obs.outboxId, &entry)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +329,7 @@ func (obs *outboxPartStore) GetPart(ctx context.Context, tx *sql.Tx, partId part
 	ctx, span := obs.tracer.Start(ctx, "outboxPartStore.GetPart")
 	defer span.End()
 
-	lastEntry, err := obs.partOutboxEntryRepository.FindLastPartOutboxEntryByPartId(ctx, tx, partId)
+	lastEntry, err := obs.partOutboxEntryRepository.FindLastPartOutboxEntryByPartId(ctx, tx, obs.outboxId, partId)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +338,7 @@ func (obs *outboxPartStore) GetPart(ctx context.Context, tx *sql.Tx, partId part
 			return nil, partstore.ErrPartNotFound
 		}
 
-		chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, *lastEntry.Id)
+		chunks, err := obs.partOutboxEntryRepository.FindPartOutboxEntryChunksById(ctx, tx, obs.outboxId, *lastEntry.Id)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +358,7 @@ func (obs *outboxPartStore) GetPartIds(ctx context.Context, tx *sql.Tx) ([]parts
 	defer span.End()
 
 	// We get the lastOutboxEntry for each partId
-	lastOutboxEntryGroupedByPartId, err := obs.partOutboxEntryRepository.FindLastPartOutboxEntryGroupedByPartId(ctx, tx)
+	lastOutboxEntryGroupedByPartId, err := obs.partOutboxEntryRepository.FindLastPartOutboxEntryGroupedByPartId(ctx, tx, obs.outboxId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/metadatapart/partstore/outbox/outbox_test.go
+++ b/internal/storage/metadatapart/partstore/outbox/outbox_test.go
@@ -52,7 +52,7 @@ func TestOutboxPartStore(t *testing.T) {
 		os.Exit(1)
 	}
 	reg := prometheus.NewRegistry()
-	outboxPartStore, err := New(db, filesystemPartStore, partOutboxEntryRepository, reg)
+	outboxPartStore, err := New(db, "default", filesystemPartStore, partOutboxEntryRepository, reg)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Could not create OutboxPartStore: %s", err))
 		os.Exit(1)

--- a/internal/storage/outbox/outbox.go
+++ b/internal/storage/outbox/outbox.go
@@ -88,6 +88,7 @@ type outboxStorage struct {
 	db                           database.Database
 	triggerChannel               chan struct{}
 	triggerChannelClosed         bool
+	outboxId                     string
 	outboxProcessingTaskHandle   *task.TaskHandle
 	innerStorage                 storage.Storage
 	storageOutboxEntryRepository storageOutboxEntry.Repository
@@ -98,7 +99,7 @@ type outboxStorage struct {
 // Compile-time check to ensure outboxStorage implements storage.Storage
 var _ storage.Storage = (*outboxStorage)(nil)
 
-func NewStorage(db database.Database, innerStorage storage.Storage, storageOutboxEntryRepository storageOutboxEntry.Repository, registerer prometheus.Registerer) (storage.Storage, error) {
+func NewStorage(db database.Database, outboxId string, innerStorage storage.Storage, storageOutboxEntryRepository storageOutboxEntry.Repository, registerer prometheus.Registerer) (storage.Storage, error) {
 	lifecycle, err := lifecycle.NewValidatedLifecycle("OutboxStorage")
 	if err != nil {
 		return nil, err
@@ -108,6 +109,7 @@ func NewStorage(db database.Database, innerStorage storage.Storage, storageOutbo
 		db:                           db,
 		triggerChannel:               make(chan struct{}, 16),
 		triggerChannelClosed:         false,
+		outboxId:                     outboxId,
 		innerStorage:                 innerStorage,
 		storageOutboxEntryRepository: storageOutboxEntryRepository,
 		tracer:                       otel.Tracer("internal/storage/outbox"),
@@ -130,7 +132,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 	if err != nil {
 		return
 	}
-	pendingCount, err := os.storageOutboxEntryRepository.Count(ctx, tx)
+	pendingCount, err := os.storageOutboxEntryRepository.Count(ctx, tx, os.outboxId)
 	if err != nil {
 		tx.Rollback()
 		return
@@ -147,7 +149,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			os.metrics.errorsCounter.Inc()
 			return
 		}
-		entry, err = os.storageOutboxEntryRepository.FindFirstStorageOutboxEntry(ctx, tx)
+		entry, err = os.storageOutboxEntryRepository.FindFirstStorageOutboxEntry(ctx, tx, os.outboxId)
 		if err != nil {
 			tx.Rollback()
 			os.metrics.errorsCounter.Inc()
@@ -159,7 +161,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			break
 		}
 		if entry.Operation == storageOutboxEntry.PutObjectStorageOperation {
-			chunks, err := os.storageOutboxEntryRepository.FindStorageOutboxEntryChunksById(ctx, tx, *entry.Id)
+			chunks, err := os.storageOutboxEntryRepository.FindStorageOutboxEntryChunksById(ctx, tx, os.outboxId, *entry.Id)
 			if err != nil {
 				tx.Rollback()
 				os.metrics.errorsCounter.Inc()
@@ -217,7 +219,7 @@ func (os *outboxStorage) maybeProcessOutboxEntries(ctx context.Context) {
 			os.metrics.errorsCounter.Inc()
 			return
 		}
-		err = os.storageOutboxEntryRepository.DeleteStorageOutboxEntryById(ctx, tx, *entry.Id)
+		err = os.storageOutboxEntryRepository.DeleteStorageOutboxEntryById(ctx, tx, os.outboxId, *entry.Id)
 		if err != nil {
 			tx.Rollback()
 			os.metrics.errorsCounter.Inc()
@@ -287,7 +289,7 @@ func (os *outboxStorage) storeStorageOutboxEntry(ctx context.Context, tx *sql.Tx
 		Bucket:    bucketName,
 		Key:       key,
 	}
-	err := os.storageOutboxEntryRepository.SaveStorageOutboxEntry(ctx, tx, &entry)
+	err := os.storageOutboxEntryRepository.SaveStorageOutboxEntry(ctx, tx, os.outboxId, &entry)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +348,7 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucket(ctx context.Context, bu
 	if err != nil {
 		return err
 	}
-	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntryForBucket(ctx, tx, bucketName)
+	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntryForBucket(ctx, tx, os.outboxId, bucketName)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -366,7 +368,7 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucket(ctx context.Context, bu
 		if err != nil {
 			return err
 		}
-		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryForBucket(ctx, tx, bucketName)
+		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryForBucket(ctx, tx, os.outboxId, bucketName)
 		if err != nil {
 			tx.Rollback()
 			return err
@@ -390,7 +392,7 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ct
 	if err != nil {
 		return err
 	}
-	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx, tx, bucketName, key.String())
+	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx, tx, os.outboxId, bucketName, key.String())
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -410,7 +412,7 @@ func (os *outboxStorage) waitForAllOutboxEntriesOfBucketAndKeyIncludingGlobal(ct
 		if err != nil {
 			return err
 		}
-		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx, tx, bucketName, key.String())
+		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntryForBucketAndKeyIncludingGlobal(ctx, tx, os.outboxId, bucketName, key.String())
 		if err != nil {
 			tx.Rollback()
 			return err
@@ -434,7 +436,7 @@ func (os *outboxStorage) waitForAllOutboxEntries(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntry(ctx, tx)
+	lastStorageOutboxEntry, err := os.storageOutboxEntryRepository.FindLastStorageOutboxEntry(ctx, tx, os.outboxId)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -454,7 +456,7 @@ func (os *outboxStorage) waitForAllOutboxEntries(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntry(ctx, tx)
+		entry, err := os.storageOutboxEntryRepository.FindFirstStorageOutboxEntry(ctx, tx, os.outboxId)
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/internal/storage/outbox/outbox_test.go
+++ b/internal/storage/outbox/outbox_test.go
@@ -113,7 +113,7 @@ func TestMetadataPartStorageWithOutbox(t *testing.T) {
 
 	}
 	reg := prometheus.NewRegistry()
-	outboxStorage, err := NewStorage(db2, metadataPartStorage, storageOutboxEntryRepository, reg)
+	outboxStorage, err := NewStorage(db2, "default", metadataPartStorage, storageOutboxEntryRepository, reg)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Could not create OutboxStorage: %s", err))
 		os.Exit(1)


### PR DESCRIPTION
## What
- add outbox_id scoping column to storage and part outbox entry tables (pgx + sqlite migrations)
- support configuring outboxId on OutboxStorage and OutboxPartStore (default: default)
- move outbox scoping from repository constructor state to repository method arguments (ctx, tx, outboxId, ...)
- keep chunk isolation via join to outbox entries filtered by outbox_id
- update docs with multi-outbox configuration examples

## Why
This allows multiple outbox instances to share one database safely while ensuring each instance only operates on its own rows.

## Validation
- go build ./...
- go test ./...